### PR TITLE
Add S3-compatible file upload service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 
 # Web Framework
-axum = { version = "0.7", features = ["ws"] }
+axum = { version = "0.7", features = ["ws", "multipart"] }
 tower = "0.4"
 tower-http = { version = "0.5", features = ["cors", "trace", "compression-gzip"] }
 
@@ -86,6 +86,9 @@ pulldown-cmark = "0.10"
 
 # Validation
 validator = { version = "0.16", features = ["derive"] }
+
+# MIME type detection
+mime_guess = "2"
 
 # Internal Crates
 vc-common = { path = "shared/vc-common" }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -71,6 +71,9 @@ pulldown-cmark.workspace = true
 # Validation
 validator.workspace = true
 
+# MIME detection
+mime_guess.workspace = true
+
 # Config
 dotenvy = "0.15"
 

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -11,7 +11,7 @@ use tower_http::{
     trace::TraceLayer,
 };
 
-use crate::{auth, chat, config::Config, voice, ws};
+use crate::{auth, chat, chat::S3Client, config::Config, voice, ws};
 
 /// Shared application state.
 #[derive(Clone)]
@@ -22,16 +22,29 @@ pub struct AppState {
     pub redis: fred::clients::RedisClient,
     /// Server configuration
     pub config: Arc<Config>,
+    /// S3 client for file storage (optional)
+    pub s3: Option<S3Client>,
 }
 
 impl AppState {
     /// Create new application state.
-    pub fn new(db: PgPool, redis: fred::clients::RedisClient, config: Config) -> Self {
+    pub fn new(
+        db: PgPool,
+        redis: fred::clients::RedisClient,
+        config: Config,
+        s3: Option<S3Client>,
+    ) -> Self {
         Self {
             db,
             redis,
             config: Arc::new(config),
+            s3,
         }
+    }
+
+    /// Check if S3 storage is configured and available.
+    pub fn has_s3(&self) -> bool {
+        self.s3.is_some()
     }
 }
 

--- a/server/src/chat/mod.rs
+++ b/server/src/chat/mod.rs
@@ -4,6 +4,7 @@
 
 mod channels;
 mod messages;
+pub mod s3;
 mod uploads;
 
 use axum::{
@@ -12,6 +13,8 @@ use axum::{
 };
 
 use crate::api::AppState;
+
+pub use s3::S3Client;
 
 /// Create channels router.
 pub fn channels_router() -> Router<AppState> {
@@ -34,4 +37,6 @@ pub fn messages_router() -> Router<AppState> {
         .route("/{id}", patch(messages::update))
         .route("/{id}", delete(messages::delete))
         .route("/upload", post(uploads::upload_file))
+        .route("/attachments/{id}", get(uploads::get_attachment))
+        .route("/attachments/{id}/download", get(uploads::download))
 }

--- a/server/src/chat/s3.rs
+++ b/server/src/chat/s3.rs
@@ -1,0 +1,172 @@
+//! S3 Storage Client
+//!
+//! Handles S3-compatible storage for file uploads.
+//! Supports any S3-compatible backend: AWS S3, MinIO, Backblaze B2, Cloudflare R2.
+
+use aws_config::Region;
+use aws_sdk_s3::{
+    config::{Credentials, SharedCredentialsProvider},
+    presigning::PresigningConfig,
+    primitives::ByteStream,
+    Client,
+};
+use std::time::Duration;
+use thiserror::Error;
+use tracing::info;
+
+use crate::config::Config;
+
+/// S3 client wrapper with configuration.
+#[derive(Clone)]
+pub struct S3Client {
+    client: Client,
+    bucket: String,
+    presign_expiry: Duration,
+}
+
+/// S3-related errors.
+#[derive(Debug, Error)]
+pub enum S3Error {
+    /// Failed to upload file.
+    #[error("Failed to upload file: {0}")]
+    Upload(String),
+
+    /// Failed to download file.
+    #[error("Failed to download file: {0}")]
+    Download(String),
+
+    /// Failed to generate presigned URL.
+    #[error("Failed to generate presigned URL: {0}")]
+    Presign(String),
+
+    /// Failed to delete file.
+    #[error("Failed to delete file: {0}")]
+    Delete(String),
+
+    /// S3 configuration error.
+    #[error("S3 configuration error: {0}")]
+    Config(String),
+}
+
+impl S3Client {
+    /// Create a new S3 client from configuration.
+    ///
+    /// Supports custom endpoints for S3-compatible backends (MinIO, R2, B2).
+    /// Uses path-style addressing when a custom endpoint is configured.
+    pub async fn new(config: &Config) -> Result<Self, S3Error> {
+        let region = Region::new(
+            std::env::var("AWS_REGION").unwrap_or_else(|_| "us-east-1".to_string()),
+        );
+
+        let mut s3_config_builder = aws_sdk_s3::Config::builder().region(region);
+
+        // Configure credentials from environment
+        if let (Ok(access_key), Ok(secret_key)) = (
+            std::env::var("AWS_ACCESS_KEY_ID"),
+            std::env::var("AWS_SECRET_ACCESS_KEY"),
+        ) {
+            let credentials = Credentials::new(
+                access_key,
+                secret_key,
+                None, // session token
+                None, // expiry
+                "environment",
+            );
+            s3_config_builder =
+                s3_config_builder.credentials_provider(SharedCredentialsProvider::new(credentials));
+        }
+
+        // Configure custom endpoint for S3-compatible backends
+        if let Some(endpoint) = &config.s3_endpoint {
+            s3_config_builder = s3_config_builder
+                .endpoint_url(endpoint)
+                .force_path_style(true); // Required for MinIO and most S3-compatible backends
+        }
+
+        let s3_config = s3_config_builder.build();
+        let client = Client::from_conf(s3_config);
+
+        info!(
+            bucket = %config.s3_bucket,
+            endpoint = ?config.s3_endpoint,
+            "S3 client initialized"
+        );
+
+        Ok(Self {
+            client,
+            bucket: config.s3_bucket.clone(),
+            presign_expiry: Duration::from_secs(config.s3_presign_expiry as u64),
+        })
+    }
+
+    /// Upload a file to S3.
+    ///
+    /// # Arguments
+    /// * `key` - The S3 object key (path)
+    /// * `data` - File contents as bytes
+    /// * `content_type` - MIME type of the file
+    pub async fn upload(&self, key: &str, data: Vec<u8>, content_type: &str) -> Result<(), S3Error> {
+        self.client
+            .put_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .body(ByteStream::from(data))
+            .content_type(content_type)
+            .send()
+            .await
+            .map_err(|e| S3Error::Upload(e.to_string()))?;
+
+        Ok(())
+    }
+
+    /// Generate a presigned URL for downloading a file.
+    ///
+    /// The URL is valid for the configured expiry duration.
+    pub async fn presign_get(&self, key: &str) -> Result<String, S3Error> {
+        let presign_config = PresigningConfig::builder()
+            .expires_in(self.presign_expiry)
+            .build()
+            .map_err(|e| S3Error::Presign(e.to_string()))?;
+
+        let presigned = self
+            .client
+            .get_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .presigned(presign_config)
+            .await
+            .map_err(|e| S3Error::Presign(e.to_string()))?;
+
+        Ok(presigned.uri().to_string())
+    }
+
+    /// Delete a file from S3.
+    pub async fn delete(&self, key: &str) -> Result<(), S3Error> {
+        self.client
+            .delete_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .send()
+            .await
+            .map_err(|e| S3Error::Delete(e.to_string()))?;
+
+        Ok(())
+    }
+
+    /// Check if the bucket is accessible (health check).
+    pub async fn health_check(&self) -> Result<(), S3Error> {
+        self.client
+            .head_bucket()
+            .bucket(&self.bucket)
+            .send()
+            .await
+            .map_err(|e| S3Error::Config(format!("Bucket not accessible: {}", e)))?;
+
+        Ok(())
+    }
+
+    /// Get the bucket name.
+    pub fn bucket(&self) -> &str {
+        &self.bucket
+    }
+}

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -32,6 +32,12 @@ pub struct Config {
     /// S3 bucket name
     pub s3_bucket: String,
 
+    /// S3 presigned URL expiry in seconds (default: 3600 = 1 hour)
+    pub s3_presign_expiry: i64,
+
+    /// Allowed MIME types for file uploads (comma-separated)
+    pub allowed_mime_types: Option<Vec<String>>,
+
     /// OIDC issuer URL (optional)
     pub oidc_issuer_url: Option<String>,
 
@@ -75,6 +81,16 @@ impl Config {
                 .unwrap_or(604800),
             s3_endpoint: env::var("S3_ENDPOINT").ok(),
             s3_bucket: env::var("S3_BUCKET").unwrap_or_else(|_| "voicechat".into()),
+            s3_presign_expiry: env::var("S3_PRESIGN_EXPIRY")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(3600), // 1 hour
+            allowed_mime_types: env::var("ALLOWED_MIME_TYPES").ok().map(|s| {
+                s.split(',')
+                    .map(|t| t.trim().to_string())
+                    .filter(|t| !t.is_empty())
+                    .collect()
+            }),
             oidc_issuer_url: env::var("OIDC_ISSUER_URL").ok(),
             oidc_client_id: env::var("OIDC_CLIENT_ID").ok(),
             oidc_client_secret: env::var("OIDC_CLIENT_SECRET").ok(),


### PR DESCRIPTION
Implement file upload functionality supporting any S3-compatible backend (AWS S3, MinIO, Backblaze B2, Cloudflare R2). Files attach to messages and are served via presigned URLs.

- Add S3Client wrapper with custom endpoint support for self-hosted backends
- Implement upload, download, and metadata endpoints
- Add FileAttachment database queries
- Support configurable presigned URL expiry and MIME type whitelist
- Graceful degradation when S3 is not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)