### PR TITLE
feat(admin): add user and guild detail views (Phase 3)

### DIFF
--- a/client/src/lib/tauri.ts
+++ b/client/src/lib/tauri.ts
@@ -35,12 +35,14 @@ import type {
   AuditLogEntry,
   PaginatedResponse,
   ElevateResponse,
+  UserDetailsResponse,
+  GuildDetailsResponse,
   CallEndReason,
   CallStateResponse,
 } from "./types";
 
 // Re-export types for convenience
-export type { User, Channel, Message, AppSettings, Guild, GuildMember, GuildInvite, InviteResponse, InviteExpiry, Friend, Friendship, DMChannel, DMListItem, Page, PageListItem, GuildRole, ChannelOverride, CreateRoleRequest, UpdateRoleRequest, SetChannelOverrideRequest, AssignRoleResponse, RemoveRoleResponse, DeleteRoleResponse, AdminStats, AdminStatus, UserSummary, GuildSummary, AuditLogEntry, PaginatedResponse, ElevateResponse, CallEndReason, CallStateResponse };
+export type { User, Channel, Message, AppSettings, Guild, GuildMember, GuildInvite, InviteResponse, InviteExpiry, Friend, Friendship, DMChannel, DMListItem, Page, PageListItem, GuildRole, ChannelOverride, CreateRoleRequest, UpdateRoleRequest, SetChannelOverrideRequest, AssignRoleResponse, RemoveRoleResponse, DeleteRoleResponse, AdminStats, AdminStatus, UserSummary, GuildSummary, AuditLogEntry, PaginatedResponse, ElevateResponse, UserDetailsResponse, GuildDetailsResponse, CallEndReason, CallStateResponse };
 
 // Detect if running in Tauri
 const isTauri = typeof window !== "undefined" && "__TAURI__" in window;
@@ -1643,6 +1645,44 @@ export async function adminListGuilds(
   return httpRequest<PaginatedResponse<GuildSummary>>(
     "GET",
     `/api/admin/guilds${query ? `?${query}` : ""}`
+  );
+}
+
+/**
+ * Get detailed user information (admin only).
+ */
+export async function adminGetUserDetails(
+  userId: string
+): Promise<UserDetailsResponse> {
+  if (isTauri) {
+    const { invoke } = await import("@tauri-apps/api/core");
+    return invoke<UserDetailsResponse>("admin_get_user_details", {
+      user_id: userId,
+    });
+  }
+
+  return httpRequest<UserDetailsResponse>(
+    "GET",
+    `/api/admin/users/${userId}/details`
+  );
+}
+
+/**
+ * Get detailed guild information (admin only).
+ */
+export async function adminGetGuildDetails(
+  guildId: string
+): Promise<GuildDetailsResponse> {
+  if (isTauri) {
+    const { invoke } = await import("@tauri-apps/api/core");
+    return invoke<GuildDetailsResponse>("admin_get_guild_details", {
+      guild_id: guildId,
+    });
+  }
+
+  return httpRequest<GuildDetailsResponse>(
+    "GET",
+    `/api/admin/guilds/${guildId}/details`
   );
 }
 

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -514,6 +514,57 @@ export interface ElevateResponse {
   session_id: string;
 }
 
+// User Detail Types
+
+export interface UserGuildMembership {
+  guild_id: string;
+  guild_name: string;
+  guild_icon_url: string | null;
+  joined_at: string;
+  is_owner: boolean;
+}
+
+export interface UserDetailsResponse {
+  id: string;
+  username: string;
+  display_name: string;
+  email: string | null;
+  avatar_url: string | null;
+  created_at: string;
+  is_banned: boolean;
+  last_login: string | null;
+  guild_count: number;
+  guilds: UserGuildMembership[];
+}
+
+// Guild Detail Types
+
+export interface GuildMemberInfo {
+  user_id: string;
+  username: string;
+  display_name: string;
+  avatar_url: string | null;
+  joined_at: string;
+}
+
+export interface GuildOwnerInfo {
+  user_id: string;
+  username: string;
+  display_name: string;
+  avatar_url: string | null;
+}
+
+export interface GuildDetailsResponse {
+  id: string;
+  name: string;
+  icon_url: string | null;
+  member_count: number;
+  created_at: string;
+  suspended_at: string | null;
+  owner: GuildOwnerInfo;
+  top_members: GuildMemberInfo[];
+}
+
 // Call State Types
 
 export type CallEndReason = "cancelled" | "all_declined" | "no_answer" | "last_left";

--- a/server/src/admin/mod.rs
+++ b/server/src/admin/mod.rs
@@ -45,7 +45,9 @@ pub fn router(state: AppState) -> Router<AppState> {
         .route("/health", get(|| async { "admin ok" }))
         .route("/stats", get(handlers::get_admin_stats))
         .route("/users", get(handlers::list_users))
+        .route("/users/:id/details", get(handlers::get_user_details))
         .route("/guilds", get(handlers::list_guilds))
+        .route("/guilds/:id/details", get(handlers::get_guild_details))
         .route("/audit-log", get(handlers::get_audit_log))
         .route(
             "/elevate",


### PR DESCRIPTION
## Summary
- Add backend handlers for user and guild detail endpoints (`GET /api/admin/users/:id/details` and `GET /api/admin/guilds/:id/details`)
- User details include last login timestamp and guild memberships with owner status
- Guild details include owner info with avatar and top 5 members preview
- Frontend auto-loads details when selecting a user or guild in the admin panel
- UsersPanel shows last login and guild memberships with crown icons for owned guilds
- GuildsPanel shows owner info section and stacked avatar member preview

## Test plan
- [ ] Select a user in UsersPanel, verify last login and guild list appear
- [ ] Verify guild memberships show crown icon for owned guilds
- [ ] Select a guild in GuildsPanel, verify owner info loads correctly
- [ ] Verify stacked avatars show for members preview
- [ ] Test with users/guilds that have no memberships/members
- [ ] Verify loading states show while details are being fetched

## Note
This PR is based on Phase 2 branch (`feature/admin-panel-phase2-search-filters`). It should be merged after Phase 2 is merged to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)