### PR TITLE
feat(client): complete DM voice call client integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- DM voice calls client integration
+  - Voice connection wiring: WebRTC starts after accepting/starting calls
+  - Tauri commands for call lifecycle (start, join, decline, leave)
+  - Ring sound notification with looping playback for incoming calls
+  - Call indicator in DM sidebar with pulsing animation for incoming calls
 - Clipboard protection system for secure copy/paste operations
   - ClipboardGuard service with SHA-256 hash-based tamper detection
   - Auto-clear timers based on sensitivity (Critical: 60s, Sensitive: 120s)

--- a/client/src-tauri/src/commands/calls.rs
+++ b/client/src-tauri/src/commands/calls.rs
@@ -1,0 +1,311 @@
+//! DM Call Commands
+//!
+//! Tauri commands for DM voice call signaling: start, join, decline, leave.
+//! These commands handle the call lifecycle via HTTP, while voice.rs handles
+//! the actual WebRTC connection.
+
+use serde::{Deserialize, Serialize};
+use tauri::{command, State};
+use tracing::{debug, error, info};
+
+use crate::AppState;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/// Call capabilities (for future video/screen share support).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CallCapabilities {
+    pub audio: bool,
+    pub video: bool,
+    pub screenshare: bool,
+}
+
+/// Call state response from server.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CallStateResponse {
+    pub channel_id: String,
+    #[serde(flatten)]
+    pub state: CallStateInfo,
+    pub capabilities: Option<Vec<String>>,
+}
+
+/// Call state information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum CallStateInfo {
+    Ringing {
+        started_by: String,
+        started_at: String,
+        declined_by: Vec<String>,
+        target_users: Vec<String>,
+    },
+    Active {
+        started_at: String,
+        participants: Vec<String>,
+    },
+    Ended {
+        reason: String,
+        duration_secs: Option<u32>,
+        ended_at: String,
+    },
+}
+
+// ============================================================================
+// Call Commands
+// ============================================================================
+
+/// Start a voice call in a DM channel.
+///
+/// The initiator starts the call and joins immediately.
+/// Other participants receive an incoming call notification.
+#[command]
+pub async fn start_dm_call(
+    channel_id: String,
+    state: State<'_, AppState>,
+) -> Result<CallStateResponse, String> {
+    let (server_url, token) = {
+        let auth = state.auth.read().await;
+        (auth.server_url.clone(), auth.access_token.clone())
+    };
+
+    let server_url = server_url.ok_or("Not authenticated")?;
+    let token = token.ok_or("Not authenticated")?;
+
+    info!("Starting call in DM: {}", channel_id);
+
+    let response = state
+        .http
+        .post(format!("{server_url}/api/dm/{channel_id}/call/start"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .map_err(|e| {
+            error!("Failed to start call: {}", e);
+            format!("Connection failed: {e}")
+        })?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        error!("Failed to start call: {} - {}", status, body);
+        return Err(format!("Failed to start call: {status}"));
+    }
+
+    let call_state: CallStateResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Invalid response: {e}"))?;
+
+    debug!("Call started: {:?}", call_state);
+    Ok(call_state)
+}
+
+/// Join an active call in a DM channel.
+///
+/// Called when accepting an incoming call.
+#[command]
+pub async fn join_dm_call(
+    channel_id: String,
+    state: State<'_, AppState>,
+) -> Result<CallStateResponse, String> {
+    let (server_url, token) = {
+        let auth = state.auth.read().await;
+        (auth.server_url.clone(), auth.access_token.clone())
+    };
+
+    let server_url = server_url.ok_or("Not authenticated")?;
+    let token = token.ok_or("Not authenticated")?;
+
+    info!("Joining call in DM: {}", channel_id);
+
+    let response = state
+        .http
+        .post(format!("{server_url}/api/dm/{channel_id}/call/join"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .map_err(|e| {
+            error!("Failed to join call: {}", e);
+            format!("Connection failed: {e}")
+        })?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        error!("Failed to join call: {} - {}", status, body);
+        return Err(format!("Failed to join call: {status}"));
+    }
+
+    let call_state: CallStateResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Invalid response: {e}"))?;
+
+    debug!("Joined call: {:?}", call_state);
+    Ok(call_state)
+}
+
+/// Decline an incoming call in a DM channel.
+///
+/// The user won't join the call and others will be notified.
+#[command]
+pub async fn decline_dm_call(
+    channel_id: String,
+    state: State<'_, AppState>,
+) -> Result<CallStateResponse, String> {
+    let (server_url, token) = {
+        let auth = state.auth.read().await;
+        (auth.server_url.clone(), auth.access_token.clone())
+    };
+
+    let server_url = server_url.ok_or("Not authenticated")?;
+    let token = token.ok_or("Not authenticated")?;
+
+    info!("Declining call in DM: {}", channel_id);
+
+    let response = state
+        .http
+        .post(format!("{server_url}/api/dm/{channel_id}/call/decline"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .map_err(|e| {
+            error!("Failed to decline call: {}", e);
+            format!("Connection failed: {e}")
+        })?;
+
+    // 404 means call already ended, which is fine
+    if response.status().as_u16() == 404 {
+        return Ok(CallStateResponse {
+            channel_id,
+            state: CallStateInfo::Ended {
+                reason: "no_answer".to_string(),
+                duration_secs: None,
+                ended_at: chrono::Utc::now().to_rfc3339(),
+            },
+            capabilities: None,
+        });
+    }
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        error!("Failed to decline call: {} - {}", status, body);
+        return Err(format!("Failed to decline call: {status}"));
+    }
+
+    let call_state: CallStateResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Invalid response: {e}"))?;
+
+    debug!("Declined call: {:?}", call_state);
+    Ok(call_state)
+}
+
+/// Leave an active call in a DM channel.
+///
+/// If this is the last participant, the call ends.
+#[command]
+pub async fn leave_dm_call(
+    channel_id: String,
+    state: State<'_, AppState>,
+) -> Result<CallStateResponse, String> {
+    let (server_url, token) = {
+        let auth = state.auth.read().await;
+        (auth.server_url.clone(), auth.access_token.clone())
+    };
+
+    let server_url = server_url.ok_or("Not authenticated")?;
+    let token = token.ok_or("Not authenticated")?;
+
+    info!("Leaving call in DM: {}", channel_id);
+
+    let response = state
+        .http
+        .post(format!("{server_url}/api/dm/{channel_id}/call/leave"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .map_err(|e| {
+            error!("Failed to leave call: {}", e);
+            format!("Connection failed: {e}")
+        })?;
+
+    // 404 means call already ended, which is fine
+    if response.status().as_u16() == 404 {
+        return Ok(CallStateResponse {
+            channel_id,
+            state: CallStateInfo::Ended {
+                reason: "last_left".to_string(),
+                duration_secs: None,
+                ended_at: chrono::Utc::now().to_rfc3339(),
+            },
+            capabilities: None,
+        });
+    }
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        error!("Failed to leave call: {} - {}", status, body);
+        return Err(format!("Failed to leave call: {status}"));
+    }
+
+    let call_state: CallStateResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Invalid response: {e}"))?;
+
+    debug!("Left call: {:?}", call_state);
+    Ok(call_state)
+}
+
+/// Get current call state for a DM channel.
+#[command]
+pub async fn get_dm_call(
+    channel_id: String,
+    state: State<'_, AppState>,
+) -> Result<Option<CallStateResponse>, String> {
+    let (server_url, token) = {
+        let auth = state.auth.read().await;
+        (auth.server_url.clone(), auth.access_token.clone())
+    };
+
+    let server_url = server_url.ok_or("Not authenticated")?;
+    let token = token.ok_or("Not authenticated")?;
+
+    debug!("Getting call state for DM: {}", channel_id);
+
+    let response = state
+        .http
+        .get(format!("{server_url}/api/dm/{channel_id}/call"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .map_err(|e| {
+            error!("Failed to get call state: {}", e);
+            format!("Connection failed: {e}")
+        })?;
+
+    // 404 means no active call
+    if response.status().as_u16() == 404 {
+        return Ok(None);
+    }
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        error!("Failed to get call state: {} - {}", status, body);
+        return Err(format!("Failed to get call state: {status}"));
+    }
+
+    let call_state: CallStateResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Invalid response: {e}"))?;
+
+    Ok(Some(call_state))
+}

--- a/client/src-tauri/src/commands/mod.rs
+++ b/client/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod admin;
 pub mod auth;
+pub mod calls;
 pub mod chat;
 pub mod clipboard;
 pub mod crypto;

--- a/client/src-tauri/src/lib.rs
+++ b/client/src-tauri/src/lib.rs
@@ -145,6 +145,12 @@ pub fn run() {
             commands::clipboard::get_clipboard_status,
             commands::clipboard::update_clipboard_settings,
             commands::clipboard::get_clipboard_settings,
+            // Call commands
+            commands::calls::start_dm_call,
+            commands::calls::join_dm_call,
+            commands::calls::decline_dm_call,
+            commands::calls::leave_dm_call,
+            commands::calls::get_dm_call,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/client/src/components/home/DMConversation.tsx
+++ b/client/src/components/home/DMConversation.tsx
@@ -12,7 +12,7 @@ import MessageInput from "@/components/messages/MessageInput";
 import TypingIndicator from "@/components/messages/TypingIndicator";
 import { CallBanner } from "@/components/call";
 import { callState, startCall, isInCallForChannel } from "@/stores/call";
-import { startDMCall } from "@/lib/tauri";
+import { startDMCall, joinVoice } from "@/lib/tauri";
 
 const DMConversation: Component = () => {
   const dm = () => getSelectedDM();
@@ -26,6 +26,8 @@ const DMConversation: Component = () => {
     try {
       await startDMCall(currentDM.id);
       startCall(currentDM.id);
+      // Start voice connection immediately as the initiator
+      await joinVoice(currentDM.id);
     } catch (err) {
       console.error("Failed to start call:", err);
     } finally {

--- a/client/src/components/home/DMItem.tsx
+++ b/client/src/components/home/DMItem.tsx
@@ -5,8 +5,10 @@
  */
 
 import { Component, Show } from "solid-js";
+import { Phone } from "lucide-solid";
 import type { DMListItem } from "@/lib/types";
 import { dmsState, selectDM } from "@/stores/dms";
+import { hasActiveCallInChannel, callState } from "@/stores/call";
 
 interface DMItemProps {
   dm: DMListItem;
@@ -30,6 +32,17 @@ const DMItem: Component<DMItemProps> = (props) => {
     if (isGroupDM()) return false;
     // TODO: Check presence store for online status
     return false;
+  };
+
+  // Check if there's an active call in this DM
+  const hasActiveCall = () => hasActiveCallInChannel(props.dm.id);
+
+  // Check if this is an incoming call (ringing)
+  const isIncomingCall = () => {
+    const current = callState.currentCall;
+    return current.status === "incoming_ringing" &&
+           "channelId" in current &&
+           current.channelId === props.dm.id;
   };
 
   const formatTimestamp = (dateStr: string) => {
@@ -95,6 +108,20 @@ const DMItem: Component<DMItemProps> = (props) => {
         {/* Online indicator for 1:1 DMs */}
         <Show when={!isGroupDM() && isOnline()}>
           <div class="absolute bottom-0 right-0 w-3 h-3 bg-green-500 border-2 border-surface-base rounded-full" />
+        </Show>
+
+        {/* Call indicator */}
+        <Show when={hasActiveCall()}>
+          <div
+            class="absolute -bottom-0.5 -right-0.5 w-4 h-4 rounded-full flex items-center justify-center"
+            classList={{
+              "bg-green-500 animate-pulse": isIncomingCall(),
+              "bg-green-500": !isIncomingCall(),
+            }}
+            title={isIncomingCall() ? "Incoming call" : "Active call"}
+          >
+            <Phone class="w-2.5 h-2.5 text-white" />
+          </div>
         </Show>
       </div>
 

--- a/client/src/lib/sound/index.ts
+++ b/client/src/lib/sound/index.ts
@@ -8,6 +8,7 @@
 import type { SoundEvent, SoundOption } from "./types";
 import { playSound, preloadSounds, isWebAudioSupported, playNotificationFallback } from "./browser";
 import { initTabLeader, isTabLeader, cleanup as cleanupTabLeader } from "./tab-leader";
+import { preloadRingSound, stopRinging } from "./ring";
 import {
   getSoundEnabled,
   getSelectedSound,
@@ -58,6 +59,7 @@ export async function initSoundService(): Promise<void> {
   // Preload sounds
   if (isWebAudioSupported()) {
     await preloadSounds();
+    await preloadRingSound();
   }
 
   // Handle pending sound if AudioContext was suspended
@@ -82,6 +84,9 @@ export async function initSoundService(): Promise<void> {
  * Cleanup sound service resources.
  */
 export function cleanupSoundService(): void {
+  // Stop any active ring
+  stopRinging();
+
   if (!isTauri()) {
     cleanupTabLeader();
   }
@@ -206,3 +211,4 @@ export async function testSound(soundId?: SoundOption): Promise<void> {
 
 export * from "./types";
 export { isTabLeader };
+export { startRinging, stopRinging, isRinging } from "./ring";

--- a/client/src/lib/sound/ring.ts
+++ b/client/src/lib/sound/ring.ts
@@ -1,0 +1,169 @@
+/**
+ * Call Ring Service
+ *
+ * Manages the looping ring sound for incoming calls.
+ * Uses Web Audio API for precise looping and volume control.
+ */
+
+import { getSoundVolume, getSoundEnabled } from "@/stores/sound";
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+// Use "bell" sound for ringing (can be replaced with a dedicated ring sound later)
+const RING_SOUND_PATH = "/sounds/bell.wav";
+const RING_INTERVAL_MS = 2000; // Ring every 2 seconds
+
+// ============================================================================
+// State
+// ============================================================================
+
+let ringInterval: ReturnType<typeof setInterval> | null = null;
+let audioContext: AudioContext | null = null;
+let ringBuffer: AudioBuffer | null = null;
+let currentSource: AudioBufferSourceNode | null = null;
+let gainNode: GainNode | null = null;
+
+// ============================================================================
+// Initialization
+// ============================================================================
+
+/**
+ * Get or create the AudioContext for ring sounds.
+ */
+function getAudioContext(): AudioContext {
+  if (!audioContext) {
+    audioContext = new AudioContext();
+  }
+  return audioContext;
+}
+
+/**
+ * Load the ring sound buffer.
+ */
+async function loadRingBuffer(): Promise<AudioBuffer | null> {
+  if (ringBuffer) return ringBuffer;
+
+  try {
+    const ctx = getAudioContext();
+    const response = await fetch(RING_SOUND_PATH);
+    if (!response.ok) {
+      console.warn(`Failed to fetch ring sound: ${RING_SOUND_PATH}`);
+      return null;
+    }
+    const arrayBuffer = await response.arrayBuffer();
+    ringBuffer = await ctx.decodeAudioData(arrayBuffer);
+    return ringBuffer;
+  } catch (error) {
+    console.warn("Failed to load ring sound:", error);
+    return null;
+  }
+}
+
+// ============================================================================
+// Playback
+// ============================================================================
+
+/**
+ * Play the ring sound once.
+ */
+async function playRingOnce(): Promise<void> {
+  // Check if sounds are enabled
+  if (!getSoundEnabled()) return;
+
+  try {
+    const ctx = getAudioContext();
+
+    // Resume if suspended
+    if (ctx.state === "suspended") {
+      await ctx.resume();
+    }
+
+    // Load buffer if needed
+    const buffer = await loadRingBuffer();
+    if (!buffer) return;
+
+    // Stop any currently playing ring
+    if (currentSource) {
+      try {
+        currentSource.stop();
+      } catch {
+        // Ignore errors from already stopped sources
+      }
+    }
+
+    // Create nodes
+    currentSource = ctx.createBufferSource();
+    gainNode = ctx.createGain();
+
+    // Configure
+    currentSource.buffer = buffer;
+    gainNode.gain.value = getSoundVolume() / 100;
+
+    // Connect: source -> gain -> destination
+    currentSource.connect(gainNode);
+    gainNode.connect(ctx.destination);
+
+    // Play
+    currentSource.start(0);
+  } catch (error) {
+    console.warn("Failed to play ring sound:", error);
+  }
+}
+
+/**
+ * Start the ring loop for an incoming call.
+ */
+export function startRinging(): void {
+  // Don't start if already ringing
+  if (ringInterval) return;
+
+  // Play immediately
+  playRingOnce();
+
+  // Set up interval for repeated rings
+  ringInterval = setInterval(() => {
+    playRingOnce();
+  }, RING_INTERVAL_MS);
+
+  console.log("[Ring] Started ringing");
+}
+
+/**
+ * Stop the ring loop.
+ */
+export function stopRinging(): void {
+  // Clear interval
+  if (ringInterval) {
+    clearInterval(ringInterval);
+    ringInterval = null;
+  }
+
+  // Stop any currently playing sound
+  if (currentSource) {
+    try {
+      currentSource.stop();
+    } catch {
+      // Ignore errors from already stopped sources
+    }
+    currentSource = null;
+  }
+
+  console.log("[Ring] Stopped ringing");
+}
+
+/**
+ * Check if currently ringing.
+ */
+export function isRinging(): boolean {
+  return ringInterval !== null;
+}
+
+/**
+ * Preload the ring sound buffer.
+ * Call this after user interaction to ensure audio is ready.
+ */
+export async function preloadRingSound(): Promise<void> {
+  await loadRingBuffer();
+}

--- a/client/src/stores/call.ts
+++ b/client/src/stores/call.ts
@@ -5,6 +5,7 @@
  */
 
 import { createStore, produce } from "solid-js/store";
+import { startRinging, stopRinging } from "@/lib/sound/ring";
 
 // Constants
 const CALL_ENDED_DISPLAY_MS = 3000;
@@ -67,6 +68,8 @@ export function receiveIncomingCall(
       initiator,
       initiatorName,
     });
+    // Start ringing for incoming call
+    startRinging();
   }
   // Always track in activeCallsByChannel for sidebar indicator
   setCallState("activeCallsByChannel", channelId, {
@@ -80,6 +83,8 @@ export function receiveIncomingCall(
  * Transition to connecting state when joining a call.
  */
 export function joinCall(channelId: string): void {
+  // Stop ringing when answering the call
+  stopRinging();
   setCallState("currentCall", {
     status: "connecting",
     channelId,
@@ -162,6 +167,8 @@ export function participantLeft(channelId: string, userId: string): void {
 export function declineCall(channelId: string): void {
   const current = callState.currentCall;
   if (current.status === "incoming_ringing" && current.channelId === channelId) {
+    // Stop ringing when declining the call
+    stopRinging();
     setCallState("currentCall", { status: "idle" });
   }
 }
@@ -216,6 +223,10 @@ export function callEndedExternally(
   // Update current call if it's the one that ended
   const current = callState.currentCall;
   if (current.status !== "idle" && "channelId" in current && current.channelId === channelId) {
+    // Stop ringing if we were being called
+    if (current.status === "incoming_ringing") {
+      stopRinging();
+    }
     endCall(channelId, reason, duration);
   }
 }


### PR DESCRIPTION
## Summary
- Wire voice connection to call flow: WebRTC starts after accepting/starting calls
- Add Tauri commands for DM calls (start, join, decline, leave, get)
- Add looping ring sound for incoming calls with preloading
- Add call indicator to DM sidebar with pulsing animation for incoming calls

## Implementation Details

### Voice Connection Integration
- `DMConversation.tsx`: Calls `joinVoice()` immediately after starting a call
- `CallBanner.tsx`: Calls `joinVoice()` after accepting, `leaveVoice()` before leaving/canceling

### Tauri Commands (`calls.rs`)
- `start_dm_call` - POST `/api/dm/{id}/call/start`
- `join_dm_call` - POST `/api/dm/{id}/call/join`
- `decline_dm_call` - POST `/api/dm/{id}/call/decline` (handles 404 gracefully)
- `leave_dm_call` - POST `/api/dm/{id}/call/leave` (handles 404 gracefully)
- `get_dm_call` - GET `/api/dm/{id}/call`

### Ring Sound (`ring.ts`)
- Plays bell sound on loop every 2 seconds
- Stops on answer, decline, or external call end
- Preloaded during app initialization

### Sidebar Indicator (`DMItem.tsx`)
- Shows phone icon when there's an active call in a DM
- Pulsing animation for incoming calls (ringing state)
- Uses `hasActiveCallInChannel` and `callState` from call store

## Test plan
- [ ] Start a DM call - verify voice connection starts
- [ ] Accept an incoming call - verify ring stops and voice connects
- [ ] Decline a call - verify ring stops
- [ ] Leave a call - verify voice disconnects
- [ ] Cancel an outgoing call - verify cleanup
- [ ] Check sidebar shows call indicator during active calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)