### PR TITLE
feat(voice): add screen share server integration

### DIFF
--- a/client/src/lib/tauri.ts
+++ b/client/src/lib/tauri.ts
@@ -1169,6 +1169,34 @@ export async function wsAdminUnsubscribe(): Promise<void> {
   await wsSend({ type: "admin_unsubscribe" });
 }
 
+/**
+ * Start screen sharing in a voice channel (notifies server).
+ */
+export async function wsScreenShareStart(
+  channelId: string,
+  quality: "low" | "medium" | "high" | "premium",
+  hasAudio: boolean,
+  sourceLabel: string
+): Promise<void> {
+  await wsSend({
+    type: "voice_screen_share_start",
+    channel_id: channelId,
+    quality,
+    has_audio: hasAudio,
+    source_label: sourceLabel,
+  });
+}
+
+/**
+ * Stop screen sharing in a voice channel (notifies server).
+ */
+export async function wsScreenShareStop(channelId: string): Promise<void> {
+  await wsSend({
+    type: "voice_screen_share_stop",
+    channel_id: channelId,
+  });
+}
+
 // Pages Commands
 
 /**

--- a/client/src/lib/webrtc/browser.ts
+++ b/client/src/lib/webrtc/browser.ts
@@ -612,6 +612,24 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
     return this.screenShareStream !== null;
   }
 
+  /**
+   * Get information about the current screen share.
+   * Returns null if not sharing.
+   */
+  getScreenShareInfo(): { hasAudio: boolean; sourceLabel: string } | null {
+    if (!this.screenShareStream) {
+      return null;
+    }
+
+    const videoTrack = this.screenShareStream.getVideoTracks()[0];
+    const hasAudio = this.screenShareStream.getAudioTracks().length > 0;
+
+    // Get source label from video track (e.g., "screen:0:0", window title, etc.)
+    const sourceLabel = videoTrack?.label || "Screen";
+
+    return { hasAudio, sourceLabel };
+  }
+
   async startScreenShare(options?: ScreenShareOptions): Promise<VoiceResult<void>> {
     if (!this.peerConnection) {
       return { ok: false, error: { type: "not_connected" } };

--- a/client/src/lib/webrtc/tauri.ts
+++ b/client/src/lib/webrtc/tauri.ts
@@ -260,6 +260,24 @@ export class TauriVoiceAdapter implements VoiceAdapter {
     return this.screenSharing;
   }
 
+  /**
+   * Get information about the current screen share.
+   * Returns null if not sharing.
+   */
+  getScreenShareInfo(): { hasAudio: boolean; sourceLabel: string } | null {
+    if (!this.screenShareStream) {
+      return null;
+    }
+
+    const videoTrack = this.screenShareStream.getVideoTracks()[0];
+    const hasAudio = this.screenShareStream.getAudioTracks().length > 0;
+
+    // Get source label from video track (e.g., "screen:0:0", window title, etc.)
+    const sourceLabel = videoTrack?.label || "Screen";
+
+    return { hasAudio, sourceLabel };
+  }
+
   async startScreenShare(options?: ScreenShareOptions): Promise<VoiceResult<void>> {
     console.log("[TauriVoiceAdapter] Starting screen share via WebView", options);
 

--- a/client/src/lib/webrtc/types.ts
+++ b/client/src/lib/webrtc/types.ts
@@ -198,6 +198,8 @@ export interface VoiceAdapter {
   startScreenShare(options?: ScreenShareOptions): Promise<VoiceResult<void>>;
   stopScreenShare(): Promise<VoiceResult<void>>;
   isScreenSharing(): boolean;
+  /** Get info about current screen share (hasAudio, sourceLabel). Returns null if not sharing. */
+  getScreenShareInfo(): { hasAudio: boolean; sourceLabel: string } | null;
 
   // Cleanup
   dispose(): void;

--- a/server/src/ws/mod.rs
+++ b/server/src/ws/mod.rs
@@ -127,6 +127,22 @@ pub enum ClientEvent {
         /// Timestamp when stats were collected (Unix epoch ms).
         timestamp: i64,
     },
+    /// Start screen sharing in voice channel
+    VoiceScreenShareStart {
+        /// Voice channel.
+        channel_id: Uuid,
+        /// Requested quality tier.
+        quality: Quality,
+        /// Whether to include system audio.
+        has_audio: bool,
+        /// Label of the shared source (e.g., "Display 1", "Firefox").
+        source_label: String,
+    },
+    /// Stop screen sharing in voice channel
+    VoiceScreenShareStop {
+        /// Voice channel.
+        channel_id: Uuid,
+    },
 
     /// Set rich presence activity (game, music, etc).
     SetActivity {
@@ -782,7 +798,9 @@ async fn handle_client_message(
         | ClientEvent::VoiceIceCandidate { .. }
         | ClientEvent::VoiceMute { .. }
         | ClientEvent::VoiceUnmute { .. }
-        | ClientEvent::VoiceStats { .. } => {
+        | ClientEvent::VoiceStats { .. }
+        | ClientEvent::VoiceScreenShareStart { .. }
+        | ClientEvent::VoiceScreenShareStop { .. } => {
             if let Err(e) = crate::voice::ws_handler::handle_voice_event(
                 &state.sfu, &state.db, &state.redis, user_id, event, tx,
             )


### PR DESCRIPTION
## Summary
- Adds WebSocket events (`VoiceScreenShareStart`, `VoiceScreenShareStop`) for client-server screen share coordination
- Server validates input, checks Redis limits, and broadcasts events to room participants
- Client notifies server with real `hasAudio` and `sourceLabel` values from the captured stream
- Adds `getScreenShareInfo()` method to VoiceAdapter interface for both browser and Tauri adapters

## Changes

### Server (`server/`)
- `src/ws/mod.rs`: Add `VoiceScreenShareStart` and `VoiceScreenShareStop` client events with routing
- `src/voice/ws_handler.rs`: Add `handle_screen_share_start()` and `handle_screen_share_stop()` handlers

### Client (`client/`)
- `src/lib/tauri.ts`: Add `wsScreenShareStart()` and `wsScreenShareStop()` helper functions
- `src/lib/webrtc/types.ts`: Add `getScreenShareInfo()` to VoiceAdapter interface
- `src/lib/webrtc/browser.ts`: Implement `getScreenShareInfo()` for browser adapter
- `src/lib/webrtc/tauri.ts`: Implement `getScreenShareInfo()` for Tauri adapter
- `src/stores/voice.ts`: Update `startScreenShare()` to use real values, add toast for stop failures

## Test plan
- [ ] Start screen share in voice channel, verify server receives notification
- [ ] Stop screen share, verify server is notified and other clients see it end
- [ ] Test with system audio enabled, verify `hasAudio` is correctly reported
- [ ] Test concurrent screen share limit (Redis check)
- [ ] Disconnect during screen share, verify cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)