### PR TITLE
feat(chat): add full-text message search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Optional rpm-ostree layering fallback (with reboot requirement)
   - Export of development tools (cargo, bun, sqlx) to host `~/.local/bin`
   - Podman support alongside Docker for container orchestration
+- Full-text message search using PostgreSQL tsvector
+  - Search messages within a guild using `websearch_to_tsquery` syntax (supports AND, OR, quotes)
+  - GIN index for fast search performance
+  - Search panel in sidebar with debounced input (300ms)
+  - Results show channel name, author, timestamp, and highlighted content preview
+  - Click results to navigate directly to the message
+  - Pagination support with "Load more" for large result sets
 
 ### Changed
 - Replaced Redis with Valkey as key-value store

--- a/client/src/components/layout/Sidebar.tsx
+++ b/client/src/components/layout/Sidebar.tsx
@@ -11,10 +11,11 @@
 
 import { Component, createSignal, createEffect, onMount, Show } from "solid-js";
 import { useNavigate } from "@solidjs/router";
-import { ChevronDown, Settings } from "lucide-solid";
+import { ChevronDown, Settings, Search } from "lucide-solid";
 import { loadChannels } from "@/stores/channels";
 import { getActiveGuild } from "@/stores/guilds";
 import { loadFavorites } from "@/stores/favorites";
+import { clearSearch } from "@/stores/search";
 import FavoritesSection from "./FavoritesSection";
 import {
   pagesState,
@@ -23,6 +24,7 @@ import {
 } from "@/stores/pages";
 import ChannelList from "@/components/channels/ChannelList";
 import { PageSection } from "@/components/pages";
+import { SearchPanel } from "@/components/search";
 import UserPanel from "./UserPanel";
 import GuildSettingsModal from "@/components/guilds/GuildSettingsModal";
 import type { PageListItem } from "@/lib/types";
@@ -32,6 +34,13 @@ const Sidebar: Component = () => {
   const [showGuildSettings, setShowGuildSettings] = createSignal(false);
   const [selectedPageId, setSelectedPageId] = createSignal<string | null>(null);
   const [pagesExpanded, setPagesExpanded] = createSignal(true);
+  const [showSearch, setShowSearch] = createSignal(false);
+
+  // Close search panel and clear results
+  const handleCloseSearch = () => {
+    setShowSearch(false);
+    clearSearch();
+  };
 
   // Load channels and favorites when sidebar mounts
   onMount(() => {
@@ -94,12 +103,24 @@ const Sidebar: Component = () => {
 
       {/* Search Bar */}
       <div class="px-3 py-2">
-        <input
-          type="text"
-          placeholder="Search..."
-          class="w-full px-3 py-2 rounded-xl text-sm text-text-input placeholder:text-text-secondary/50 outline-none focus:ring-2 focus:ring-accent-primary/30 border border-white/5"
-          style="background-color: var(--color-surface-base)"
-        />
+        <Show when={activeGuild()}>
+          <button
+            onClick={() => setShowSearch(true)}
+            class="w-full flex items-center gap-2 px-3 py-2 rounded-xl text-sm text-text-secondary/50 border border-white/5 hover:border-white/10 transition-colors"
+            style="background-color: var(--color-surface-base)"
+          >
+            <Search class="w-4 h-4" />
+            <span>Search messages...</span>
+          </button>
+        </Show>
+        <Show when={!activeGuild()}>
+          <div
+            class="w-full px-3 py-2 rounded-xl text-sm text-text-secondary/50 border border-white/5"
+            style="background-color: var(--color-surface-base)"
+          >
+            Search...
+          </div>
+        </Show>
       </div>
 
       {/* Separator */}
@@ -133,6 +154,11 @@ const Sidebar: Component = () => {
           guildId={activeGuild()!.id}
           onClose={() => setShowGuildSettings(false)}
         />
+      </Show>
+
+      {/* Search Panel Overlay */}
+      <Show when={showSearch() && activeGuild()}>
+        <SearchPanel onClose={handleCloseSearch} />
       </Show>
     </aside>
   );

--- a/client/src/components/search/SearchPanel.tsx
+++ b/client/src/components/search/SearchPanel.tsx
@@ -1,0 +1,220 @@
+/**
+ * SearchPanel Component
+ *
+ * Displays message search results with pagination.
+ * Shown as overlay when searching in the sidebar.
+ */
+
+import { Component, Show, For, createSignal, createEffect } from "solid-js";
+import { useNavigate } from "@solidjs/router";
+import { Search, X, Loader2, Hash } from "lucide-solid";
+import { searchState, search, loadMore, clearSearch, hasMore } from "@/stores/search";
+import { getActiveGuild } from "@/stores/guilds";
+import Avatar from "@/components/ui/Avatar";
+import { formatTimestamp } from "@/lib/utils";
+
+interface SearchPanelProps {
+  onClose: () => void;
+}
+
+const SearchPanel: Component<SearchPanelProps> = (props) => {
+  const navigate = useNavigate();
+  const [inputValue, setInputValue] = createSignal("");
+  let searchTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  // Debounced search
+  const handleInput = (e: Event) => {
+    const value = (e.target as HTMLInputElement).value;
+    setInputValue(value);
+
+    // Clear existing timeout
+    if (searchTimeout) {
+      clearTimeout(searchTimeout);
+    }
+
+    // Debounce search by 300ms
+    searchTimeout = setTimeout(() => {
+      const guild = getActiveGuild();
+      if (guild && value.trim().length >= 2) {
+        search(guild.id, value);
+      } else if (value.trim().length < 2) {
+        clearSearch();
+      }
+    }, 300);
+  };
+
+  // Navigate to the message's channel when clicked
+  const handleResultClick = (channelId: string, messageId: string) => {
+    const guild = getActiveGuild();
+    if (guild) {
+      navigate(`/guilds/${guild.id}/channels/${channelId}?highlight=${messageId}`);
+      props.onClose();
+    }
+  };
+
+  // Escape HTML to prevent XSS
+  const escapeHtml = (text: string): string => {
+    const div = document.createElement("div");
+    div.textContent = text;
+    return div.innerHTML;
+  };
+
+  // Escape regex special characters
+  const escapeRegex = (text: string): string => {
+    return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  };
+
+  // Highlight search terms in content (XSS-safe)
+  const highlightMatches = (content: string) => {
+    const query = searchState.query.toLowerCase();
+    if (!query) return escapeHtml(content);
+
+    // First escape HTML in content
+    const safeContent = escapeHtml(content);
+
+    // Simple word-based highlighting (not using Postgres ts_headline)
+    const words = query.split(/\s+/).filter(w => w.length >= 2);
+    let result = safeContent;
+
+    for (const word of words) {
+      // Escape regex special characters in search word
+      const safeWord = escapeRegex(word);
+      const regex = new RegExp(`(${safeWord})`, "gi");
+      result = result.replace(regex, '<mark class="bg-accent-primary/30 text-text-primary rounded px-0.5">$1</mark>');
+    }
+
+    return result;
+  };
+
+  // Cleanup on unmount
+  createEffect(() => {
+    return () => {
+      if (searchTimeout) {
+        clearTimeout(searchTimeout);
+      }
+    };
+  });
+
+  return (
+    <div class="absolute inset-0 z-50 flex flex-col bg-surface-layer2">
+      {/* Search Header */}
+      <div class="p-3 border-b border-white/10">
+        <div class="relative">
+          <Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-secondary" />
+          <input
+            type="text"
+            placeholder="Search messages..."
+            value={inputValue()}
+            onInput={handleInput}
+            autofocus
+            class="w-full pl-10 pr-10 py-2 rounded-lg text-sm text-text-primary placeholder:text-text-secondary bg-surface-layer1 border border-white/10 outline-none focus:ring-2 focus:ring-accent-primary/30"
+          />
+          <button
+            onClick={props.onClose}
+            class="absolute right-3 top-1/2 -translate-y-1/2 p-1 text-text-secondary hover:text-text-primary rounded transition-colors"
+          >
+            <X class="w-4 h-4" />
+          </button>
+        </div>
+        <Show when={searchState.total > 0}>
+          <p class="mt-2 text-xs text-text-secondary">
+            {searchState.total} result{searchState.total !== 1 ? "s" : ""}
+          </p>
+        </Show>
+      </div>
+
+      {/* Results */}
+      <div class="flex-1 overflow-y-auto">
+        {/* Loading State */}
+        <Show when={searchState.isSearching && searchState.results.length === 0}>
+          <div class="flex items-center justify-center py-8">
+            <Loader2 class="w-6 h-6 text-text-secondary animate-spin" />
+          </div>
+        </Show>
+
+        {/* Empty State */}
+        <Show when={!searchState.isSearching && searchState.query.length >= 2 && searchState.results.length === 0}>
+          <div class="flex flex-col items-center justify-center py-8 text-text-secondary">
+            <Search class="w-12 h-12 mb-3 opacity-50" />
+            <p class="text-sm">No results found</p>
+            <p class="text-xs mt-1">Try different keywords</p>
+          </div>
+        </Show>
+
+        {/* Hint State */}
+        <Show when={searchState.query.length < 2}>
+          <div class="flex flex-col items-center justify-center py-8 text-text-secondary">
+            <Search class="w-12 h-12 mb-3 opacity-50" />
+            <p class="text-sm">Type at least 2 characters to search</p>
+          </div>
+        </Show>
+
+        {/* Error State */}
+        <Show when={searchState.error}>
+          <div class="p-4 text-center text-red-400 text-sm">
+            {searchState.error}
+          </div>
+        </Show>
+
+        {/* Results List */}
+        <Show when={searchState.results.length > 0}>
+          <div class="divide-y divide-white/5">
+            <For each={searchState.results}>
+              {(result) => (
+                <button
+                  onClick={() => handleResultClick(result.channel_id, result.id)}
+                  class="w-full p-3 text-left hover:bg-white/5 transition-colors"
+                >
+                  {/* Channel Name */}
+                  <div class="flex items-center gap-1 text-xs text-text-secondary mb-1">
+                    <Hash class="w-3 h-3" />
+                    <span>{result.channel_name}</span>
+                  </div>
+
+                  {/* Author and Time */}
+                  <div class="flex items-center gap-2 mb-1">
+                    <Avatar
+                      src={result.author.avatar_url}
+                      alt={result.author.display_name}
+                      size="sm"
+                    />
+                    <span class="text-sm font-medium text-text-primary">
+                      {result.author.display_name}
+                    </span>
+                    <span class="text-xs text-text-secondary">
+                      {formatTimestamp(result.created_at)}
+                    </span>
+                  </div>
+
+                  {/* Content Preview */}
+                  <p
+                    class="text-sm text-text-secondary line-clamp-2"
+                    innerHTML={highlightMatches(result.content.substring(0, 200))}
+                  />
+                </button>
+              )}
+            </For>
+          </div>
+
+          {/* Load More Button */}
+          <Show when={hasMore()}>
+            <div class="p-3 text-center">
+              <button
+                onClick={loadMore}
+                disabled={searchState.isSearching}
+                class="px-4 py-2 text-sm text-accent-primary hover:bg-white/5 rounded-lg disabled:opacity-50"
+              >
+                <Show when={searchState.isSearching} fallback="Load more">
+                  <Loader2 class="w-4 h-4 animate-spin inline mr-2" />
+                  Loading...
+                </Show>
+              </button>
+            </div>
+          </Show>
+        </Show>
+      </div>
+    </div>
+  );
+};
+
+export default SearchPanel;

--- a/client/src/components/search/index.ts
+++ b/client/src/components/search/index.ts
@@ -1,0 +1,1 @@
+export { default as SearchPanel } from "./SearchPanel";

--- a/client/src/lib/tauri.ts
+++ b/client/src/lib/tauri.ts
@@ -49,10 +49,11 @@ import type {
   ClaimedPrekeyInput,
   UserKeysResponse,
   ClaimedPrekeyResponse,
+  SearchResponse,
 } from "./types";
 
 // Re-export types for convenience
-export type { User, Channel, ChannelCategory, Message, AppSettings, Guild, GuildMember, GuildInvite, InviteResponse, InviteExpiry, Friend, Friendship, DMChannel, DMListItem, Page, PageListItem, GuildRole, ChannelOverride, CreateRoleRequest, UpdateRoleRequest, SetChannelOverrideRequest, AssignRoleResponse, RemoveRoleResponse, DeleteRoleResponse, AdminStats, AdminStatus, UserSummary, GuildSummary, AuditLogEntry, PaginatedResponse, ElevateResponse, UserDetailsResponse, GuildDetailsResponse, BulkBanResponse, BulkSuspendResponse, CallEndReason, CallStateResponse, E2EEStatus, InitE2EEResponse, PrekeyData, E2EEContent, ClaimedPrekeyInput, UserKeysResponse, ClaimedPrekeyResponse };
+export type { User, Channel, ChannelCategory, Message, AppSettings, Guild, GuildMember, GuildInvite, InviteResponse, InviteExpiry, Friend, Friendship, DMChannel, DMListItem, Page, PageListItem, GuildRole, ChannelOverride, CreateRoleRequest, UpdateRoleRequest, SetChannelOverrideRequest, AssignRoleResponse, RemoveRoleResponse, DeleteRoleResponse, AdminStats, AdminStatus, UserSummary, GuildSummary, AuditLogEntry, PaginatedResponse, ElevateResponse, UserDetailsResponse, GuildDetailsResponse, BulkBanResponse, BulkSuspendResponse, CallEndReason, CallStateResponse, E2EEStatus, InitE2EEResponse, PrekeyData, E2EEContent, ClaimedPrekeyInput, UserKeysResponse, ClaimedPrekeyResponse, SearchResponse };
 
 // Detect if running in Tauri
 const isTauri = typeof window !== "undefined" && "__TAURI__" in window;
@@ -661,6 +662,24 @@ export async function getGuildChannels(guildId: string): Promise<Channel[]> {
   }
 
   return httpRequest<Channel[]>("GET", `/api/guilds/${guildId}/channels`);
+}
+
+/**
+ * Search messages in a guild using full-text search.
+ */
+export async function searchGuildMessages(
+  guildId: string,
+  query: string,
+  limit: number = 25,
+  offset: number = 0
+): Promise<SearchResponse> {
+  // Always use HTTP for search - no Tauri command needed since search is server-side
+  const params = new URLSearchParams({
+    q: query,
+    limit: limit.toString(),
+    offset: offset.toString(),
+  });
+  return httpRequest<SearchResponse>("GET", `/api/guilds/${guildId}/search?${params}`);
 }
 
 // Guild Invite Commands

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -196,6 +196,31 @@ export interface Message {
   reactions?: Reaction[];
 }
 
+// Search Types
+
+export interface SearchAuthor {
+  id: string;
+  username: string;
+  display_name: string;
+  avatar_url: string | null;
+}
+
+export interface SearchResult {
+  id: string;
+  channel_id: string;
+  channel_name: string;
+  author: SearchAuthor;
+  content: string;
+  created_at: string;
+}
+
+export interface SearchResponse {
+  results: SearchResult[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
 // Voice Types
 
 export interface VoiceParticipant {

--- a/client/src/stores/search.ts
+++ b/client/src/stores/search.ts
@@ -1,0 +1,170 @@
+/**
+ * Search Store
+ *
+ * Manages message search state including results, loading, and pagination.
+ */
+
+import { createStore } from "solid-js/store";
+import type { SearchResult } from "@/lib/types";
+import { searchGuildMessages } from "@/lib/tauri";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface SearchState {
+  /** Current search query */
+  query: string;
+  /** Search results */
+  results: SearchResult[];
+  /** Total number of results (for pagination) */
+  total: number;
+  /** Current offset */
+  offset: number;
+  /** Results per page */
+  limit: number;
+  /** Loading state */
+  isSearching: boolean;
+  /** Error message if search failed */
+  error: string | null;
+  /** Guild ID being searched */
+  guildId: string | null;
+}
+
+// ============================================================================
+// Store
+// ============================================================================
+
+const [searchState, setSearchState] = createStore<SearchState>({
+  query: "",
+  results: [],
+  total: 0,
+  offset: 0,
+  limit: 25,
+  isSearching: false,
+  error: null,
+  guildId: null,
+});
+
+// ============================================================================
+// Actions
+// ============================================================================
+
+/**
+ * Search messages in a guild.
+ */
+export async function search(guildId: string, query: string): Promise<void> {
+  // Skip if query is too short
+  if (query.trim().length < 2) {
+    setSearchState({
+      query: query.trim(),
+      results: [],
+      total: 0,
+      offset: 0,
+      error: null,
+      isSearching: false,
+      guildId,
+    });
+    return;
+  }
+
+  setSearchState({
+    query: query.trim(),
+    isSearching: true,
+    error: null,
+    guildId,
+    offset: 0,
+  });
+
+  try {
+    const response = await searchGuildMessages(
+      guildId,
+      query.trim(),
+      searchState.limit,
+      0
+    );
+
+    setSearchState({
+      results: response.results,
+      total: response.total,
+      offset: 0,
+      isSearching: false,
+    });
+  } catch (err) {
+    console.error("Search failed:", err);
+    setSearchState({
+      results: [],
+      total: 0,
+      error: err instanceof Error ? err.message : "Search failed",
+      isSearching: false,
+    });
+  }
+}
+
+/**
+ * Load more results (pagination).
+ */
+export async function loadMore(): Promise<void> {
+  if (!searchState.guildId || !searchState.query || searchState.isSearching) {
+    return;
+  }
+
+  // Check if there are more results
+  if (searchState.offset + searchState.limit >= searchState.total) {
+    return;
+  }
+
+  const newOffset = searchState.offset + searchState.limit;
+
+  setSearchState({ isSearching: true, error: null });
+
+  try {
+    const response = await searchGuildMessages(
+      searchState.guildId,
+      searchState.query,
+      searchState.limit,
+      newOffset
+    );
+
+    setSearchState({
+      results: [...searchState.results, ...response.results],
+      total: response.total,
+      offset: newOffset,
+      isSearching: false,
+    });
+  } catch (err) {
+    console.error("Load more failed:", err);
+    setSearchState({
+      error: err instanceof Error ? err.message : "Load more failed",
+      isSearching: false,
+    });
+  }
+}
+
+/**
+ * Clear search results.
+ */
+export function clearSearch(): void {
+  setSearchState({
+    query: "",
+    results: [],
+    total: 0,
+    offset: 0,
+    error: null,
+    isSearching: false,
+    guildId: null,
+  });
+}
+
+/**
+ * Check if there are more results to load.
+ */
+export function hasMore(): boolean {
+  return searchState.offset + searchState.limit < searchState.total;
+}
+
+// ============================================================================
+// Export
+// ============================================================================
+
+export { searchState };

--- a/server/migrations/20260125000000_add_message_search.sql
+++ b/server/migrations/20260125000000_add_message_search.sql
@@ -1,0 +1,14 @@
+-- Add full-text search capability to messages table
+-- Uses PostgreSQL tsvector with GIN index for fast search
+
+-- Add generated tsvector column for full-text search
+ALTER TABLE messages
+ADD COLUMN content_search tsvector
+GENERATED ALWAYS AS (to_tsvector('english', content)) STORED;
+
+-- Create GIN index for fast full-text search
+CREATE INDEX idx_messages_content_search ON messages USING GIN (content_search);
+
+-- Add index on channel_id + created_at for efficient channel-scoped searches
+-- This supports the common query pattern: search within a channel, ordered by time
+CREATE INDEX idx_messages_channel_created ON messages (channel_id, created_at DESC);

--- a/server/src/guild/mod.rs
+++ b/server/src/guild/mod.rs
@@ -1,11 +1,12 @@
 //! Guild (Server) Management Module
 //!
-//! Handles guild creation, membership, invites, roles, categories, and management.
+//! Handles guild creation, membership, invites, roles, categories, search, and management.
 
 pub mod categories;
 pub mod handlers;
 pub mod invites;
 pub mod roles;
+pub mod search;
 pub mod types;
 
 use axum::{
@@ -60,6 +61,8 @@ pub fn router() -> Router<AppState> {
             patch(categories::update_category).delete(categories::delete_category),
         )
         .route("/:id/categories/reorder", post(categories::reorder_categories))
+        // Search route
+        .route("/:id/search", get(search::search_messages))
 }
 
 /// Create the invite join router (separate for public access pattern)

--- a/server/src/guild/search.rs
+++ b/server/src/guild/search.rs
@@ -1,0 +1,221 @@
+//! Guild Message Search Handler
+//!
+//! Full-text search for messages within a guild using PostgreSQL tsvector.
+
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{api::AppState, auth::AuthUser, db};
+
+// ============================================================================
+// Error Types
+// ============================================================================
+
+#[derive(Debug)]
+pub enum SearchError {
+    GuildNotFound,
+    NotMember,
+    InvalidQuery(String),
+    Database(sqlx::Error),
+}
+
+impl IntoResponse for SearchError {
+    fn into_response(self) -> Response {
+        let (status, body) = match &self {
+            Self::GuildNotFound => (
+                StatusCode::NOT_FOUND,
+                serde_json::json!({"error": "not_found", "message": "Guild not found"}),
+            ),
+            Self::NotMember => (
+                StatusCode::FORBIDDEN,
+                serde_json::json!({"error": "forbidden", "message": "Not a member of this guild"}),
+            ),
+            Self::InvalidQuery(msg) => (
+                StatusCode::BAD_REQUEST,
+                serde_json::json!({"error": "invalid_query", "message": msg}),
+            ),
+            Self::Database(_) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                serde_json::json!({"error": "internal_error", "message": "Database error"}),
+            ),
+        };
+        (status, Json(body)).into_response()
+    }
+}
+
+impl From<sqlx::Error> for SearchError {
+    fn from(err: sqlx::Error) -> Self {
+        tracing::error!(error = %err, "Search database error");
+        Self::Database(err)
+    }
+}
+
+// ============================================================================
+// Request/Response Types
+// ============================================================================
+
+#[derive(Debug, Deserialize)]
+pub struct SearchQuery {
+    /// Search query string (supports websearch syntax: AND, OR, quotes)
+    pub q: String,
+    /// Maximum results to return (default 25, max 100)
+    #[serde(default = "default_limit")]
+    pub limit: i64,
+    /// Offset for pagination (default 0)
+    #[serde(default)]
+    pub offset: i64,
+}
+
+const fn default_limit() -> i64 {
+    25
+}
+
+/// Author info for search results
+#[derive(Debug, Serialize)]
+pub struct SearchAuthor {
+    pub id: Uuid,
+    pub username: String,
+    pub display_name: String,
+    pub avatar_url: Option<String>,
+}
+
+/// Search result item
+#[derive(Debug, Serialize)]
+pub struct SearchResult {
+    pub id: Uuid,
+    pub channel_id: Uuid,
+    pub channel_name: String,
+    pub author: SearchAuthor,
+    pub content: String,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Search response with results and pagination
+#[derive(Debug, Serialize)]
+pub struct SearchResponse {
+    pub results: Vec<SearchResult>,
+    pub total: i64,
+    pub limit: i64,
+    pub offset: i64,
+}
+
+// ============================================================================
+// Handler
+// ============================================================================
+
+/// Search messages within a guild.
+/// GET /api/guilds/:guild_id/search?q=...
+#[tracing::instrument(skip(state))]
+pub async fn search_messages(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path(guild_id): Path<Uuid>,
+    Query(query): Query<SearchQuery>,
+) -> Result<Json<SearchResponse>, SearchError> {
+    // Validate query
+    let search_term = query.q.trim();
+    if search_term.is_empty() {
+        return Err(SearchError::InvalidQuery(
+            "Search query cannot be empty".to_string(),
+        ));
+    }
+    if search_term.len() < 2 {
+        return Err(SearchError::InvalidQuery(
+            "Search query must be at least 2 characters".to_string(),
+        ));
+    }
+
+    // Check guild exists
+    let guild_exists: (bool,) =
+        sqlx::query_as("SELECT EXISTS(SELECT 1 FROM guilds WHERE id = $1)")
+            .bind(guild_id)
+            .fetch_one(&state.db)
+            .await?;
+    if !guild_exists.0 {
+        return Err(SearchError::GuildNotFound);
+    }
+
+    // Check user is a member of the guild
+    let is_member = db::is_guild_member(&state.db, guild_id, auth.id).await?;
+    if !is_member {
+        return Err(SearchError::NotMember);
+    }
+
+    // Clamp limit
+    let limit = query.limit.clamp(1, 100);
+    let offset = query.offset.max(0);
+
+    // Get total count
+    let total = db::count_search_messages(&state.db, guild_id, search_term).await?;
+
+    // Search messages
+    let messages = db::search_messages(&state.db, guild_id, search_term, limit, offset).await?;
+
+    // Get user IDs and channel IDs for bulk lookup
+    let user_ids: Vec<Uuid> = messages.iter().map(|m| m.user_id).collect();
+    let channel_ids: Vec<Uuid> = messages.iter().map(|m| m.channel_id).collect();
+
+    // Bulk fetch users
+    let users = db::find_users_by_ids(&state.db, &user_ids).await?;
+    let user_map: std::collections::HashMap<Uuid, db::User> =
+        users.into_iter().map(|u| (u.id, u)).collect();
+
+    // Bulk fetch channel names
+    let channels: Vec<(Uuid, String)> = sqlx::query_as(
+        "SELECT id, name FROM channels WHERE id = ANY($1)",
+    )
+    .bind(&channel_ids)
+    .fetch_all(&state.db)
+    .await?;
+    let channel_map: std::collections::HashMap<Uuid, String> =
+        channels.into_iter().collect();
+
+    // Build results
+    let results: Vec<SearchResult> = messages
+        .into_iter()
+        .map(|msg| {
+            let author = user_map
+                .get(&msg.user_id)
+                .map(|u| SearchAuthor {
+                    id: u.id,
+                    username: u.username.clone(),
+                    display_name: u.display_name.clone(),
+                    avatar_url: u.avatar_url.clone(),
+                })
+                .unwrap_or_else(|| SearchAuthor {
+                    id: msg.user_id,
+                    username: "deleted".to_string(),
+                    display_name: "Deleted User".to_string(),
+                    avatar_url: None,
+                });
+
+            let channel_name = channel_map
+                .get(&msg.channel_id)
+                .cloned()
+                .unwrap_or_else(|| "unknown".to_string());
+
+            SearchResult {
+                id: msg.id,
+                channel_id: msg.channel_id,
+                channel_name,
+                author,
+                content: msg.content,
+                created_at: msg.created_at,
+            }
+        })
+        .collect();
+
+    Ok(Json(SearchResponse {
+        results,
+        total,
+        limit,
+        offset,
+    }))
+}

--- a/server/tests/search_test.rs
+++ b/server/tests/search_test.rs
@@ -1,0 +1,450 @@
+//! Integration tests for the message search system.
+//!
+//! These tests require a running PostgreSQL instance with the schema applied.
+//! Run with: `cargo test search --ignored -- --nocapture`
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Helper to create a test database pool.
+async fn create_test_pool() -> PgPool {
+    let database_url =
+        std::env::var("DATABASE_URL").unwrap_or_else(|_| "postgres://localhost/vc_test".into());
+
+    PgPool::connect(&database_url)
+        .await
+        .expect("Failed to connect to test database")
+}
+
+/// Helper to create a test user and return their ID.
+async fn create_test_user(pool: &PgPool) -> Uuid {
+    let user_id = Uuid::new_v4();
+    let username = format!("testuser_{}", &user_id.to_string()[..8]);
+
+    sqlx::query(
+        r#"
+        INSERT INTO users (id, username, display_name, password_hash, email)
+        VALUES ($1, $2, $3, 'fake_hash', $4)
+        "#,
+    )
+    .bind(user_id)
+    .bind(&username)
+    .bind(&username)
+    .bind(format!("{}@test.com", username))
+    .execute(pool)
+    .await
+    .expect("Failed to create test user");
+
+    user_id
+}
+
+/// Helper to create a test guild and return its ID.
+async fn create_test_guild(pool: &PgPool, owner_id: Uuid) -> Uuid {
+    let guild_id = Uuid::new_v4();
+    let guild_name = format!("Test Guild {}", &guild_id.to_string()[..8]);
+
+    sqlx::query(
+        r#"
+        INSERT INTO guilds (id, name, owner_id)
+        VALUES ($1, $2, $3)
+        "#,
+    )
+    .bind(guild_id)
+    .bind(&guild_name)
+    .bind(owner_id)
+    .execute(pool)
+    .await
+    .expect("Failed to create test guild");
+
+    // Add owner as guild member
+    sqlx::query(
+        r#"
+        INSERT INTO guild_members (guild_id, user_id)
+        VALUES ($1, $2)
+        "#,
+    )
+    .bind(guild_id)
+    .bind(owner_id)
+    .execute(pool)
+    .await
+    .expect("Failed to add guild member");
+
+    guild_id
+}
+
+/// Helper to create a test channel and return its ID.
+async fn create_test_channel(pool: &PgPool, guild_id: Uuid, name: &str) -> Uuid {
+    let channel_id = Uuid::new_v4();
+
+    sqlx::query(
+        r#"
+        INSERT INTO channels (id, guild_id, name, channel_type)
+        VALUES ($1, $2, $3, 'text')
+        "#,
+    )
+    .bind(channel_id)
+    .bind(guild_id)
+    .bind(name)
+    .execute(pool)
+    .await
+    .expect("Failed to create test channel");
+
+    channel_id
+}
+
+/// Helper to create a test message and return its ID.
+async fn create_test_message(
+    pool: &PgPool,
+    channel_id: Uuid,
+    user_id: Uuid,
+    content: &str,
+) -> Uuid {
+    let message_id = Uuid::new_v4();
+
+    sqlx::query(
+        r#"
+        INSERT INTO messages (id, channel_id, user_id, content)
+        VALUES ($1, $2, $3, $4)
+        "#,
+    )
+    .bind(message_id)
+    .bind(channel_id)
+    .bind(user_id)
+    .bind(content)
+    .execute(pool)
+    .await
+    .expect("Failed to create test message");
+
+    message_id
+}
+
+/// Helper to cleanup test data.
+async fn cleanup_test_data(pool: &PgPool, user_id: Uuid, guild_id: Uuid) {
+    // Delete messages first (FK constraint)
+    sqlx::query("DELETE FROM messages WHERE user_id = $1")
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .ok();
+
+    // Delete channels
+    sqlx::query("DELETE FROM channels WHERE guild_id = $1")
+        .bind(guild_id)
+        .execute(pool)
+        .await
+        .ok();
+
+    // Delete guild members
+    sqlx::query("DELETE FROM guild_members WHERE guild_id = $1")
+        .bind(guild_id)
+        .execute(pool)
+        .await
+        .ok();
+
+    // Delete guild
+    sqlx::query("DELETE FROM guilds WHERE id = $1")
+        .bind(guild_id)
+        .execute(pool)
+        .await
+        .ok();
+
+    // Delete user
+    sqlx::query("DELETE FROM users WHERE id = $1")
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .ok();
+}
+
+// ============================================================================
+// Search Query Tests
+// ============================================================================
+
+#[tokio::test]
+#[ignore = "requires database"]
+async fn test_search_messages_basic() {
+    let pool = create_test_pool().await;
+    let user_id = create_test_user(&pool).await;
+    let guild_id = create_test_guild(&pool, user_id).await;
+    let channel_id = create_test_channel(&pool, guild_id, "general").await;
+
+    // Create messages with different content
+    create_test_message(&pool, channel_id, user_id, "Hello world").await;
+    create_test_message(&pool, channel_id, user_id, "Testing search functionality").await;
+    create_test_message(&pool, channel_id, user_id, "Another test message").await;
+
+    // Search for "test"
+    let results: Vec<(Uuid, String)> = sqlx::query_as(
+        r#"
+        SELECT m.id, m.content
+        FROM messages m
+        JOIN channels c ON m.channel_id = c.id
+        WHERE c.guild_id = $1
+          AND m.deleted_at IS NULL
+          AND m.content_search @@ websearch_to_tsquery('english', $2)
+        ORDER BY m.created_at DESC
+        "#,
+    )
+    .bind(guild_id)
+    .bind("test")
+    .fetch_all(&pool)
+    .await
+    .expect("Search query failed");
+
+    assert_eq!(results.len(), 2, "Expected 2 results for 'test'");
+
+    cleanup_test_data(&pool, user_id, guild_id).await;
+}
+
+#[tokio::test]
+#[ignore = "requires database"]
+async fn test_search_messages_no_results() {
+    let pool = create_test_pool().await;
+    let user_id = create_test_user(&pool).await;
+    let guild_id = create_test_guild(&pool, user_id).await;
+    let channel_id = create_test_channel(&pool, guild_id, "general").await;
+
+    // Create messages that won't match
+    create_test_message(&pool, channel_id, user_id, "Hello world").await;
+
+    // Search for something that doesn't exist
+    let results: Vec<(Uuid,)> = sqlx::query_as(
+        r#"
+        SELECT m.id
+        FROM messages m
+        JOIN channels c ON m.channel_id = c.id
+        WHERE c.guild_id = $1
+          AND m.deleted_at IS NULL
+          AND m.content_search @@ websearch_to_tsquery('english', $2)
+        "#,
+    )
+    .bind(guild_id)
+    .bind("nonexistent")
+    .fetch_all(&pool)
+    .await
+    .expect("Search query failed");
+
+    assert_eq!(results.len(), 0, "Expected no results for 'nonexistent'");
+
+    cleanup_test_data(&pool, user_id, guild_id).await;
+}
+
+#[tokio::test]
+#[ignore = "requires database"]
+async fn test_search_messages_pagination() {
+    let pool = create_test_pool().await;
+    let user_id = create_test_user(&pool).await;
+    let guild_id = create_test_guild(&pool, user_id).await;
+    let channel_id = create_test_channel(&pool, guild_id, "general").await;
+
+    // Create 10 test messages
+    for i in 0..10 {
+        create_test_message(
+            &pool,
+            channel_id,
+            user_id,
+            &format!("Test message number {}", i),
+        )
+        .await;
+    }
+
+    // Get first page (limit 5)
+    let page1: Vec<(Uuid,)> = sqlx::query_as(
+        r#"
+        SELECT m.id
+        FROM messages m
+        JOIN channels c ON m.channel_id = c.id
+        WHERE c.guild_id = $1
+          AND m.deleted_at IS NULL
+          AND m.content_search @@ websearch_to_tsquery('english', $2)
+        ORDER BY m.created_at DESC
+        LIMIT $3 OFFSET $4
+        "#,
+    )
+    .bind(guild_id)
+    .bind("test")
+    .bind(5_i64)
+    .bind(0_i64)
+    .fetch_all(&pool)
+    .await
+    .expect("Search query failed");
+
+    assert_eq!(page1.len(), 5, "Expected 5 results on first page");
+
+    // Get second page
+    let page2: Vec<(Uuid,)> = sqlx::query_as(
+        r#"
+        SELECT m.id
+        FROM messages m
+        JOIN channels c ON m.channel_id = c.id
+        WHERE c.guild_id = $1
+          AND m.deleted_at IS NULL
+          AND m.content_search @@ websearch_to_tsquery('english', $2)
+        ORDER BY m.created_at DESC
+        LIMIT $3 OFFSET $4
+        "#,
+    )
+    .bind(guild_id)
+    .bind("test")
+    .bind(5_i64)
+    .bind(5_i64)
+    .fetch_all(&pool)
+    .await
+    .expect("Search query failed");
+
+    assert_eq!(page2.len(), 5, "Expected 5 results on second page");
+
+    // Verify no overlap between pages
+    let page1_ids: Vec<Uuid> = page1.iter().map(|(id,)| *id).collect();
+    let page2_ids: Vec<Uuid> = page2.iter().map(|(id,)| *id).collect();
+    for id in &page2_ids {
+        assert!(
+            !page1_ids.contains(id),
+            "Pages should not have overlapping results"
+        );
+    }
+
+    cleanup_test_data(&pool, user_id, guild_id).await;
+}
+
+#[tokio::test]
+#[ignore = "requires database"]
+async fn test_search_messages_count() {
+    let pool = create_test_pool().await;
+    let user_id = create_test_user(&pool).await;
+    let guild_id = create_test_guild(&pool, user_id).await;
+    let channel_id = create_test_channel(&pool, guild_id, "general").await;
+
+    // Create messages
+    for i in 0..15 {
+        create_test_message(
+            &pool,
+            channel_id,
+            user_id,
+            &format!("Test message {}", i),
+        )
+        .await;
+    }
+    // Create some non-matching messages
+    create_test_message(&pool, channel_id, user_id, "Hello world").await;
+    create_test_message(&pool, channel_id, user_id, "Goodbye").await;
+
+    // Count matching messages
+    let count: (i64,) = sqlx::query_as(
+        r#"
+        SELECT COUNT(*)
+        FROM messages m
+        JOIN channels c ON m.channel_id = c.id
+        WHERE c.guild_id = $1
+          AND m.deleted_at IS NULL
+          AND m.content_search @@ websearch_to_tsquery('english', $2)
+        "#,
+    )
+    .bind(guild_id)
+    .bind("test")
+    .fetch_one(&pool)
+    .await
+    .expect("Count query failed");
+
+    assert_eq!(count.0, 15, "Expected 15 matching messages");
+
+    cleanup_test_data(&pool, user_id, guild_id).await;
+}
+
+#[tokio::test]
+#[ignore = "requires database"]
+async fn test_search_excludes_deleted_messages() {
+    let pool = create_test_pool().await;
+    let user_id = create_test_user(&pool).await;
+    let guild_id = create_test_guild(&pool, user_id).await;
+    let channel_id = create_test_channel(&pool, guild_id, "general").await;
+
+    // Create a message
+    let msg_id = create_test_message(&pool, channel_id, user_id, "Test message to delete").await;
+
+    // Soft-delete the message
+    sqlx::query("UPDATE messages SET deleted_at = NOW() WHERE id = $1")
+        .bind(msg_id)
+        .execute(&pool)
+        .await
+        .expect("Failed to soft-delete message");
+
+    // Create another non-deleted message
+    create_test_message(&pool, channel_id, user_id, "Test message visible").await;
+
+    // Search should only find the non-deleted message
+    let results: Vec<(Uuid,)> = sqlx::query_as(
+        r#"
+        SELECT m.id
+        FROM messages m
+        JOIN channels c ON m.channel_id = c.id
+        WHERE c.guild_id = $1
+          AND m.deleted_at IS NULL
+          AND m.content_search @@ websearch_to_tsquery('english', $2)
+        "#,
+    )
+    .bind(guild_id)
+    .bind("test")
+    .fetch_all(&pool)
+    .await
+    .expect("Search query failed");
+
+    assert_eq!(results.len(), 1, "Expected 1 result (deleted message excluded)");
+    assert_ne!(results[0].0, msg_id, "Deleted message should not be in results");
+
+    cleanup_test_data(&pool, user_id, guild_id).await;
+}
+
+#[tokio::test]
+#[ignore = "requires database"]
+async fn test_search_websearch_syntax() {
+    let pool = create_test_pool().await;
+    let user_id = create_test_user(&pool).await;
+    let guild_id = create_test_guild(&pool, user_id).await;
+    let channel_id = create_test_channel(&pool, guild_id, "general").await;
+
+    // Create test messages
+    create_test_message(&pool, channel_id, user_id, "The quick brown fox").await;
+    create_test_message(&pool, channel_id, user_id, "A lazy brown dog").await;
+    create_test_message(&pool, channel_id, user_id, "The quick red fox").await;
+
+    // Search with AND (implicit in websearch_to_tsquery)
+    let and_results: Vec<(Uuid,)> = sqlx::query_as(
+        r#"
+        SELECT m.id
+        FROM messages m
+        JOIN channels c ON m.channel_id = c.id
+        WHERE c.guild_id = $1
+          AND m.deleted_at IS NULL
+          AND m.content_search @@ websearch_to_tsquery('english', $2)
+        "#,
+    )
+    .bind(guild_id)
+    .bind("quick brown")
+    .fetch_all(&pool)
+    .await
+    .expect("Search query failed");
+
+    assert_eq!(and_results.len(), 1, "Expected 1 result for 'quick brown'");
+
+    // Search with OR
+    let or_results: Vec<(Uuid,)> = sqlx::query_as(
+        r#"
+        SELECT m.id
+        FROM messages m
+        JOIN channels c ON m.channel_id = c.id
+        WHERE c.guild_id = $1
+          AND m.deleted_at IS NULL
+          AND m.content_search @@ websearch_to_tsquery('english', $2)
+        "#,
+    )
+    .bind(guild_id)
+    .bind("quick OR lazy")
+    .fetch_all(&pool)
+    .await
+    .expect("Search query failed");
+
+    assert_eq!(or_results.len(), 3, "Expected 3 results for 'quick OR lazy'");
+
+    cleanup_test_data(&pool, user_id, guild_id).await;
+}


### PR DESCRIPTION
## Summary
- Add PostgreSQL full-text search for messages using `tsvector` and `websearch_to_tsquery`
- GIN index for fast search performance across large message volumes
- Search panel in sidebar with debounced input (300ms) and pagination
- Results show channel name, author, timestamp, and highlighted content preview
- Click results to navigate directly to the message

## Changes
- **Database**: Migration adds `content_search` tsvector column with GIN index
- **Server**: New `/api/guilds/:id/search` endpoint with pagination
- **Client**: SearchPanel component with XSS-safe highlighting
- **Tests**: Integration tests for search queries

## Security
- XSS protection via HTML escaping before highlight injection
- Regex special characters escaped in search terms
- Guild membership verification before search

## Test Plan
- [ ] Run migration: `sqlx migrate run`
- [ ] Search for existing messages in a guild
- [ ] Verify pagination works (create >25 matching messages)
- [ ] Verify deleted messages excluded from results
- [ ] Test websearch syntax: quotes, OR operator
- [ ] Click result navigates to correct channel/message

🤖 Generated with [Claude Code](https://claude.com/claude-code)