### PR TITLE
feat(client): screen share Tauri parity, tests, and viewer shortcuts

### DIFF
--- a/client/src-tauri/src/network/websocket.rs
+++ b/client/src-tauri/src/network/websocket.rs
@@ -171,6 +171,26 @@ pub enum ServerEvent {
         channel_id: String,
         name: String,
     },
+    // Screen share events
+    ScreenShareStarted {
+        channel_id: String,
+        user_id: String,
+        username: String,
+        source_label: String,
+        has_audio: bool,
+        quality: String,
+    },
+    ScreenShareStopped {
+        channel_id: String,
+        user_id: String,
+        reason: String,
+    },
+    ScreenShareQualityChanged {
+        channel_id: String,
+        user_id: String,
+        new_quality: String,
+        reason: String,
+    },
     // Reaction events
     ReactionAdd {
         channel_id: String,
@@ -425,6 +445,10 @@ fn handle_server_message(app: &AppHandle, text: &str) {
                 ServerEvent::ChannelRead { .. } => "ws:channel_read",
                 ServerEvent::DmRead { .. } => "ws:dm_read",
                 ServerEvent::DmNameUpdated { .. } => "ws:dm_name_updated",
+                // Screen share events
+                ServerEvent::ScreenShareStarted { .. } => "ws:screen_share_started",
+                ServerEvent::ScreenShareStopped { .. } => "ws:screen_share_stopped",
+                ServerEvent::ScreenShareQualityChanged { .. } => "ws:screen_share_quality_changed",
                 // Reaction events
                 ServerEvent::ReactionAdd { .. } => "ws:reaction_add",
                 ServerEvent::ReactionRemove { .. } => "ws:reaction_remove",

--- a/client/src/components/voice/ScreenShareViewer.tsx
+++ b/client/src/components/voice/ScreenShareViewer.tsx
@@ -1,4 +1,4 @@
-import { Component, Show, createEffect, createSignal, onCleanup } from "solid-js";
+import { Component, Show, createEffect, createSignal, onMount, onCleanup } from "solid-js";
 import { Portal } from "solid-js/web";
 import { X, Minimize2, Maximize2, Volume2, VolumeX, Play } from "lucide-solid";
 import {
@@ -72,6 +72,51 @@ const ScreenShareViewer: Component = () => {
     const nextIndex = (currentIndex + 1) % modes.length;
     setViewMode(modes[nextIndex]);
   };
+
+  // Keyboard shortcuts (only active when viewing a screen share)
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (!viewerState.viewingUserId) return;
+
+    // Ignore when typing in input elements
+    const tag = (e.target as HTMLElement)?.tagName;
+    if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
+
+    switch (e.key) {
+      case "Escape":
+        e.preventDefault();
+        stopViewing();
+        break;
+      case "v":
+      case "V":
+        if (!e.ctrlKey && !e.metaKey && !e.altKey) {
+          e.preventDefault();
+          cycleViewMode();
+        }
+        break;
+      case "m":
+      case "M":
+        if (!e.ctrlKey && !e.metaKey && !e.altKey) {
+          e.preventDefault();
+          setScreenVolume(viewerState.screenVolume === 0 ? 100 : 0);
+        }
+        break;
+      case "f":
+      case "F":
+        if (!e.ctrlKey && !e.metaKey && !e.altKey) {
+          e.preventDefault();
+          setViewMode("spotlight");
+        }
+        break;
+    }
+  };
+
+  onMount(() => {
+    window.addEventListener("keydown", handleKeyDown);
+  });
+
+  onCleanup(() => {
+    window.removeEventListener("keydown", handleKeyDown);
+  });
 
   return (
     <Show when={viewerState.viewingUserId && viewerState.videoTrack}>

--- a/client/src/stores/__tests__/websocketScreenShare.test.ts
+++ b/client/src/stores/__tests__/websocketScreenShare.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { produce } from "solid-js/store";
+import { voiceState, setVoiceState } from "@/stores/voice";
+import {
+  handleScreenShareStarted,
+  handleScreenShareStopped,
+} from "@/stores/websocket";
+
+/**
+ * Tests for WebSocket screen share event handlers.
+ *
+ * Calls the actual exported handlers from websocket.ts to verify
+ * they correctly mutate voiceState.
+ */
+
+function resetVoiceState() {
+  setVoiceState({
+    channelId: "test-channel-1",
+    screenShares: [],
+    screenSharing: false,
+    screenShareInfo: null,
+    participants: {},
+  });
+}
+
+describe("WebSocket screen share event handlers", () => {
+  beforeEach(() => {
+    resetVoiceState();
+  });
+
+  describe("handleScreenShareStarted", () => {
+    it("should add share to voiceState.screenShares", async () => {
+      await handleScreenShareStarted({
+        channel_id: "test-channel-1",
+        user_id: "user-1",
+        username: "alice",
+        source_label: "Display 1",
+        has_audio: true,
+        quality: "high",
+      });
+
+      expect(voiceState.screenShares.length).toBe(1);
+      expect(voiceState.screenShares[0].user_id).toBe("user-1");
+      expect(voiceState.screenShares[0].username).toBe("alice");
+      expect(voiceState.screenShares[0].source_label).toBe("Display 1");
+      expect(voiceState.screenShares[0].has_audio).toBe(true);
+      expect(voiceState.screenShares[0].quality).toBe("high");
+    });
+
+    it("should set participant.screen_sharing = true", async () => {
+      setVoiceState(
+        produce((state) => {
+          state.participants["user-1"] = {
+            user_id: "user-1",
+            username: "alice",
+            display_name: "Alice",
+            muted: false,
+            screen_sharing: false,
+          } as any;
+        })
+      );
+
+      await handleScreenShareStarted({
+        channel_id: "test-channel-1",
+        user_id: "user-1",
+        username: "alice",
+        source_label: "Display 1",
+        has_audio: false,
+        quality: "medium",
+      });
+
+      expect(voiceState.participants["user-1"].screen_sharing).toBe(true);
+    });
+
+    it("should not add share if channel_id does not match", async () => {
+      await handleScreenShareStarted({
+        channel_id: "other-channel",
+        user_id: "user-1",
+        username: "alice",
+        source_label: "Display 1",
+        has_audio: false,
+        quality: "high",
+      });
+
+      expect(voiceState.screenShares.length).toBe(0);
+    });
+  });
+
+  describe("handleScreenShareStopped", () => {
+    it("should remove share from voiceState.screenShares", async () => {
+      // Pre-populate a screen share
+      setVoiceState(
+        produce((state) => {
+          state.screenShares.push({
+            user_id: "user-1",
+            username: "alice",
+            source_label: "Display 1",
+            has_audio: true,
+            quality: "high" as any,
+            started_at: new Date().toISOString(),
+          });
+        })
+      );
+
+      expect(voiceState.screenShares.length).toBe(1);
+
+      await handleScreenShareStopped({
+        channel_id: "test-channel-1",
+        user_id: "user-1",
+        reason: "user_stopped",
+      });
+
+      expect(voiceState.screenShares.length).toBe(0);
+    });
+
+    it("should set participant.screen_sharing = false", async () => {
+      setVoiceState(
+        produce((state) => {
+          state.participants["user-1"] = {
+            user_id: "user-1",
+            username: "alice",
+            display_name: "Alice",
+            muted: false,
+            screen_sharing: true,
+          } as any;
+          state.screenShares.push({
+            user_id: "user-1",
+            username: "alice",
+            source_label: "Display 1",
+            has_audio: false,
+            quality: "high" as any,
+            started_at: new Date().toISOString(),
+          });
+        })
+      );
+
+      await handleScreenShareStopped({
+        channel_id: "test-channel-1",
+        user_id: "user-1",
+        reason: "user_stopped",
+      });
+
+      expect(voiceState.participants["user-1"].screen_sharing).toBe(false);
+    });
+
+    it("should not remove share if channel_id does not match", async () => {
+      setVoiceState(
+        produce((state) => {
+          state.screenShares.push({
+            user_id: "user-1",
+            username: "alice",
+            source_label: "Display 1",
+            has_audio: false,
+            quality: "high" as any,
+            started_at: new Date().toISOString(),
+          });
+        })
+      );
+
+      await handleScreenShareStopped({
+        channel_id: "other-channel",
+        user_id: "user-1",
+        reason: "user_stopped",
+      });
+
+      expect(voiceState.screenShares.length).toBe(1);
+    });
+  });
+});

--- a/client/src/stores/websocket.ts
+++ b/client/src/stores/websocket.ts
@@ -999,7 +999,7 @@ async function handleVoiceRoomState(channelId: string, participants: any[], scre
 
 // Screen share event handlers
 
-async function handleScreenShareStarted(event: any): Promise<void> {
+export async function handleScreenShareStarted(event: any): Promise<void> {
   const { voiceState, setVoiceState } = await import("@/stores/voice");
   const { produce } = await import("solid-js/store");
 
@@ -1027,7 +1027,7 @@ async function handleScreenShareStarted(event: any): Promise<void> {
   }
 }
 
-async function handleScreenShareStopped(event: any): Promise<void> {
+export async function handleScreenShareStopped(event: any): Promise<void> {
   const { voiceState, setVoiceState } = await import("@/stores/voice");
   const { produce } = await import("solid-js/store");
 
@@ -1054,7 +1054,7 @@ async function handleScreenShareStopped(event: any): Promise<void> {
   }
 }
 
-async function handleScreenShareQualityChanged(event: any): Promise<void> {
+export async function handleScreenShareQualityChanged(event: any): Promise<void> {
   const { voiceState, setVoiceState } = await import("@/stores/voice");
   const { produce } = await import("solid-js/store");
 

--- a/server/tests/screenshare_test.rs
+++ b/server/tests/screenshare_test.rs
@@ -1,0 +1,250 @@
+//! Screen Share integration tests.
+//!
+//! Tests for screen sharing REST endpoints and WebSocket broadcast events.
+//!
+//! Run with: `cargo test --test screenshare_test`
+//! Run ignored (integration) tests: `cargo test --test screenshare_test -- --ignored`
+
+use uuid::Uuid;
+
+// ============================================================================
+// Unit Tests (no database/Redis required)
+// ============================================================================
+
+use vc_server::voice::{
+    Quality, ScreenShareCheckResponse, ScreenShareError, ScreenShareInfo, ScreenShareStartRequest,
+};
+
+#[test]
+fn test_screen_share_check_response_allowed_serialization() {
+    let resp = ScreenShareCheckResponse::allowed(Quality::High);
+    let json = serde_json::to_string(&resp).unwrap();
+
+    assert!(json.contains("\"allowed\":true"));
+    assert!(json.contains("\"granted_quality\""));
+    assert!(!json.contains("\"error\""));
+}
+
+#[test]
+fn test_screen_share_check_response_denied_serialization() {
+    let resp = ScreenShareCheckResponse::denied(ScreenShareError::NoPermission);
+    let json = serde_json::to_string(&resp).unwrap();
+
+    assert!(json.contains("\"allowed\":false"));
+    assert!(json.contains("\"error\":\"no_permission\""));
+}
+
+#[test]
+fn test_screen_share_error_into_response_status_codes() {
+    // Verify that each error variant maps to the expected status concept
+    let test_cases = [
+        (ScreenShareError::NoPermission, "no_permission"),
+        (ScreenShareError::LimitReached, "limit_reached"),
+        (ScreenShareError::NotInChannel, "not_in_channel"),
+        (ScreenShareError::QualityNotAllowed, "quality_not_allowed"),
+        (
+            ScreenShareError::RenegotiationFailed,
+            "renegotiation_failed",
+        ),
+        (ScreenShareError::InternalError, "internal_error"),
+        (ScreenShareError::InvalidSourceLabel, "invalid_source_label"),
+        (ScreenShareError::AlreadySharing, "already_sharing"),
+    ];
+
+    for (error, expected_str) in test_cases {
+        let json = serde_json::to_string(&error).unwrap();
+        assert_eq!(json, format!("\"{}\"", expected_str));
+    }
+}
+
+#[test]
+fn test_screen_share_start_request_deserialization() {
+    let json = r#"{"quality":"high","has_audio":true,"source_label":"Display 1"}"#;
+    let req: ScreenShareStartRequest = serde_json::from_str(json).unwrap();
+
+    assert_eq!(req.quality, Quality::High);
+    assert!(req.has_audio);
+    assert_eq!(req.source_label, "Display 1");
+}
+
+#[test]
+fn test_screen_share_info_roundtrip() {
+    let user_id = Uuid::new_v4();
+    let info = ScreenShareInfo::new(
+        user_id,
+        "testuser".to_string(),
+        "Display 1".to_string(),
+        true,
+        Quality::High,
+    );
+
+    let json = serde_json::to_string(&info).unwrap();
+    let deserialized: ScreenShareInfo = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(deserialized.user_id, user_id);
+    assert_eq!(deserialized.username, "testuser");
+    assert_eq!(deserialized.source_label, "Display 1");
+    assert!(deserialized.has_audio);
+    assert_eq!(deserialized.quality, Quality::High);
+}
+
+// ============================================================================
+// ServerEvent serialization tests (screen share events)
+// ============================================================================
+
+#[test]
+fn test_server_event_screen_share_started_serialization() {
+    use vc_server::ws::ServerEvent;
+
+    let channel_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+
+    let event = ServerEvent::ScreenShareStarted {
+        channel_id,
+        user_id,
+        username: "alice".to_string(),
+        source_label: "Display 1".to_string(),
+        has_audio: true,
+        quality: Quality::High,
+    };
+
+    let json = serde_json::to_string(&event).unwrap();
+    assert!(json.contains("\"type\":\"screen_share_started\""));
+    assert!(json.contains(&format!("\"channel_id\":\"{}\"", channel_id)));
+    assert!(json.contains(&format!("\"user_id\":\"{}\"", user_id)));
+    assert!(json.contains("\"username\":\"alice\""));
+    assert!(json.contains("\"source_label\":\"Display 1\""));
+    assert!(json.contains("\"has_audio\":true"));
+}
+
+#[test]
+fn test_server_event_screen_share_stopped_serialization() {
+    use vc_server::ws::ServerEvent;
+
+    let channel_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+
+    let event = ServerEvent::ScreenShareStopped {
+        channel_id,
+        user_id,
+        reason: "user_stopped".to_string(),
+    };
+
+    let json = serde_json::to_string(&event).unwrap();
+    assert!(json.contains("\"type\":\"screen_share_stopped\""));
+    assert!(json.contains("\"reason\":\"user_stopped\""));
+}
+
+#[test]
+fn test_server_event_screen_share_quality_changed_serialization() {
+    use vc_server::ws::ServerEvent;
+
+    let channel_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+
+    let event = ServerEvent::ScreenShareQualityChanged {
+        channel_id,
+        user_id,
+        new_quality: Quality::Medium,
+        reason: "bandwidth_adaptation".to_string(),
+    };
+
+    let json = serde_json::to_string(&event).unwrap();
+    assert!(json.contains("\"type\":\"screen_share_quality_changed\""));
+    assert!(json.contains("\"reason\":\"bandwidth_adaptation\""));
+}
+
+// ============================================================================
+// Integration Tests (require database + Redis)
+// ============================================================================
+
+/// Screen share check endpoint requires authentication.
+#[tokio::test]
+#[ignore]
+async fn test_screen_share_check_requires_auth() {
+    // This test verifies that unauthenticated requests to the check endpoint
+    // are rejected with 401. Requires a running server instance.
+    //
+    // When integration test infrastructure is available:
+    // 1. POST /channels/{id}/screenshare/check without Authorization header
+    // 2. Expect 401 Unauthorized
+}
+
+/// Screen share check endpoint requires SCREEN_SHARE permission.
+#[tokio::test]
+#[ignore]
+async fn test_screen_share_check_requires_permission() {
+    // This test verifies that users without SCREEN_SHARE permission
+    // receive a denied response.
+    //
+    // When integration test infrastructure is available:
+    // 1. Create user without SCREEN_SHARE permission
+    // 2. POST /channels/{id}/screenshare/check with valid auth
+    // 3. Expect allowed: false, error: "no_permission"
+}
+
+/// Screen share check allows permitted users.
+#[tokio::test]
+#[ignore]
+async fn test_screen_share_check_allowed() {
+    // This test verifies that users with proper permissions
+    // receive an allowed response.
+    //
+    // When integration test infrastructure is available:
+    // 1. Create user with SCREEN_SHARE + VOICE_CONNECT permissions
+    // 2. POST /channels/{id}/screenshare/check
+    // 3. Expect allowed: true, granted_quality present
+}
+
+/// Full screen share lifecycle: check → start → verify → stop → verify.
+#[tokio::test]
+#[ignore]
+async fn test_screen_share_start_and_stop_flow() {
+    // This test verifies the complete screen share lifecycle.
+    //
+    // When integration test infrastructure is available:
+    // 1. User joins voice channel
+    // 2. POST /channels/{id}/screenshare/start
+    // 3. Verify response allowed: true
+    // 4. Verify room has active screen share for user
+    // 5. POST /channels/{id}/screenshare/stop
+    // 6. Verify room no longer has screen share for user
+}
+
+/// Screen share limit enforcement.
+#[tokio::test]
+#[ignore]
+async fn test_screen_share_start_limit_enforcement() {
+    // This test verifies that the max_screen_shares limit is enforced.
+    //
+    // When integration test infrastructure is available:
+    // 1. Set channel max_screen_shares = 1
+    // 2. User A starts screen share → success
+    // 3. User B starts screen share → expect LimitReached error
+}
+
+/// Duplicate screen share start returns AlreadySharing.
+#[tokio::test]
+#[ignore]
+async fn test_screen_share_start_already_sharing() {
+    // This test verifies that starting a second screen share returns error.
+    //
+    // When integration test infrastructure is available:
+    // 1. User starts screen share → success
+    // 2. User starts screen share again → expect AlreadySharing (409)
+}
+
+/// Screen share broadcasts events via Redis pub/sub.
+#[tokio::test]
+#[ignore]
+async fn test_screen_share_broadcasts_events() {
+    // This test verifies that ScreenShareStarted and ScreenShareStopped
+    // events are broadcast to channel subscribers via Redis.
+    //
+    // When integration test infrastructure is available:
+    // 1. Subscribe to channel events via Redis
+    // 2. User starts screen share
+    // 3. Verify ScreenShareStarted event received
+    // 4. User stops screen share
+    // 5. Verify ScreenShareStopped event received with reason "user_stopped"
+}


### PR DESCRIPTION
## Summary
- Add 3 screen share WebSocket event variants (`ScreenShareStarted`, `ScreenShareStopped`, `ScreenShareQualityChanged`) to Tauri client `ServerEvent` enum with corresponding match arms for event forwarding
- Add keyboard shortcuts to `ScreenShareViewer`: **Escape** (close), **V** (cycle view mode), **M** (toggle mute), **F** (spotlight/fullscreen)
- Export screen share handlers from `websocket.ts` for testability
- Add server-side screen share event serialization tests (`screenshare_test.rs`)
- Add client-side WebSocket handler tests (`websocketScreenShare.test.ts`) calling actual exported handlers

## Test plan
- [x] `cargo check -p vc-client` — Tauri client compiles with new enum variants
- [x] `bun test src/stores/__tests__/websocketScreenShare.test.ts` — 6 handler tests pass
- [x] `bun test src/stores/__tests__/screenShareViewer.test.ts` — 13 existing tests still pass (no regressions)
- [ ] `cargo test --test screenshare_test` — server tests (blocked by pre-existing compile error in `social/friends.rs`)
- [ ] Manual: open screen share viewer, verify Escape/V/M/F shortcuts work

🤖 Generated with [Claude Code](https://claude.com/claude-code)