### PR TITLE
test(server): add RAII cleanup guards, shared pool, test server, concurrent HTTP tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9187,6 +9187,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "reqwest 0.11.27",
+ "reqwest 0.13.1",
  "rustls 0.23.36",
  "serde",
  "serde_json",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -103,6 +103,7 @@ tokio-util = { version = "0.7.18", features = ["io", "compat"] }
 tokio-test = "0.4"
 serial_test = "3.2"
 http-body-util = "0.1"
+reqwest = { version = "0.13", features = ["json"] }
 
 [features]
 # Enable test utilities for integration tests

--- a/server/tests/helpers/mod.rs
+++ b/server/tests/helpers/mod.rs
@@ -2,6 +2,19 @@
 //!
 //! Provides `TestApp` for building and sending requests through the full axum router,
 //! plus utilities for user creation, admin grants, and JWT generation.
+//!
+//! ## Shared Resources
+//!
+//! Use [`shared_pool()`] and [`shared_redis()`] to avoid creating new connections per test.
+//!
+//! ## Cleanup Guards
+//!
+//! Use [`CleanupGuard`] for RAII-based cleanup that runs even if a test panics.
+//!
+//! ## Test Servers
+//!
+//! Use [`spawn_test_server()`] when you need stateful middleware testing
+//! (rate limiting, request IDs, etc.) instead of `tower::ServiceExt::oneshot`.
 #![allow(dead_code)]
 
 use axum::{
@@ -11,7 +24,12 @@ use axum::{
 };
 use http_body_util::BodyExt;
 use sqlx::PgPool;
+use std::future::Future;
+use std::net::SocketAddr;
+use std::pin::Pin;
 use std::sync::Arc;
+use tokio::sync::OnceCell;
+use tokio::task::JoinHandle;
 use tower::ServiceExt;
 use uuid::Uuid;
 use vc_server::{
@@ -22,6 +40,166 @@ use vc_server::{
     voice::sfu::SfuServer,
 };
 
+// ============================================================================
+// Shared resources (Issue #138)
+// ============================================================================
+
+/// Shared database pool across all tests in the same binary.
+static SHARED_POOL: OnceCell<PgPool> = OnceCell::const_new();
+
+/// Shared Redis client across all tests in the same binary.
+static SHARED_REDIS: OnceCell<fred::clients::Client> = OnceCell::const_new();
+
+/// Shared config across all tests in the same binary.
+static SHARED_CONFIG: OnceCell<Config> = OnceCell::const_new();
+
+/// Get or create a shared database pool.
+///
+/// Reuses a single pool across all test cases in the same binary,
+/// avoiding connection exhaustion from creating pools per-test.
+pub async fn shared_pool() -> &'static PgPool {
+    SHARED_POOL
+        .get_or_init(|| async {
+            let config = shared_config().await;
+            db::create_pool(&config.database_url)
+                .await
+                .expect("Failed to connect to test DB")
+        })
+        .await
+}
+
+/// Get or create a shared Redis client.
+pub async fn shared_redis() -> &'static fred::clients::Client {
+    SHARED_REDIS
+        .get_or_init(|| async {
+            let config = shared_config().await;
+            db::create_redis_client(&config.redis_url)
+                .await
+                .expect("Failed to connect to test Redis")
+        })
+        .await
+}
+
+/// Get or create a shared config.
+pub async fn shared_config() -> &'static Config {
+    SHARED_CONFIG
+        .get_or_init(|| async { Config::default_for_test() })
+        .await
+}
+
+// ============================================================================
+// Cleanup Guard (Issue #137)
+// ============================================================================
+
+/// Async cleanup action type.
+type CleanupAction = Box<dyn FnOnce(PgPool) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send>;
+
+/// RAII guard that runs cleanup actions on drop, even if the test panics.
+///
+/// # Example
+///
+/// ```ignore
+/// let mut guard = CleanupGuard::new(app.pool.clone());
+/// guard.delete_user(user_id);
+/// guard.restore_setup_complete(prev);
+///
+/// // Test assertions here — cleanup runs even if these panic
+/// assert_eq!(resp.status(), 200);
+/// // guard dropped here → cleanup runs
+/// ```
+pub struct CleanupGuard {
+    pool: PgPool,
+    actions: Vec<CleanupAction>,
+}
+
+impl CleanupGuard {
+    /// Create a new cleanup guard for the given pool.
+    pub fn new(pool: PgPool) -> Self {
+        Self {
+            pool,
+            actions: Vec::new(),
+        }
+    }
+
+    /// Register a generic async cleanup action.
+    pub fn add<F, Fut>(&mut self, action: F)
+    where
+        F: FnOnce(PgPool) -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        self.actions
+            .push(Box::new(move |pool| Box::pin(action(pool))));
+    }
+
+    /// Register cleanup to delete a user by ID.
+    pub fn delete_user(&mut self, user_id: Uuid) {
+        self.add(move |pool| async move {
+            let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+                .bind(user_id)
+                .execute(&pool)
+                .await;
+        });
+    }
+
+    /// Register cleanup to restore `setup_complete` to a previous value.
+    pub fn restore_setup_complete(&mut self, value: bool) {
+        self.add(move |pool| async move {
+            let _ =
+                sqlx::query("UPDATE server_config SET value = $1::jsonb WHERE key = 'setup_complete'")
+                    .bind(serde_json::json!(value))
+                    .execute(&pool)
+                    .await;
+        });
+    }
+
+    /// Register cleanup to restore default config values.
+    pub fn restore_config_defaults(&mut self) {
+        self.add(|pool| async move {
+            for (key, val) in [
+                ("server_name", serde_json::json!("Canis Server")),
+                ("registration_policy", serde_json::json!("open")),
+                ("terms_url", serde_json::Value::Null),
+                ("privacy_url", serde_json::Value::Null),
+            ] {
+                let _ =
+                    sqlx::query("UPDATE server_config SET value = $1, updated_by = NULL WHERE key = $2")
+                        .bind(val)
+                        .bind(key)
+                        .execute(&pool)
+                        .await;
+            }
+        });
+    }
+}
+
+impl Drop for CleanupGuard {
+    fn drop(&mut self) {
+        let actions = std::mem::take(&mut self.actions);
+        if actions.is_empty() {
+            return;
+        }
+
+        let pool = self.pool.clone();
+        let handle = tokio::runtime::Handle::current();
+
+        // Spawn a blocking thread to run async cleanup.
+        // This works regardless of tokio runtime flavor.
+        std::thread::spawn(move || {
+            handle.block_on(async move {
+                for action in actions {
+                    action(pool.clone()).await;
+                }
+            });
+        })
+        .join()
+        .expect("Cleanup thread panicked");
+    }
+}
+
+// ============================================================================
+// Test App
+// ============================================================================
+
 /// A test application wrapping the full axum router.
 pub struct TestApp {
     pub router: Router,
@@ -30,15 +208,11 @@ pub struct TestApp {
 }
 
 impl TestApp {
-    /// Create a new test app with real DB and Redis connections.
+    /// Create a new test app using shared DB and Redis connections.
     pub async fn new() -> Self {
-        let config = Config::default_for_test();
-        let pool = db::create_pool(&config.database_url)
-            .await
-            .expect("Failed to connect to test DB");
-        let redis = db::create_redis_client(&config.redis_url)
-            .await
-            .expect("Failed to connect to test Redis");
+        let pool = shared_pool().await.clone();
+        let redis = shared_redis().await.clone();
+        let config = shared_config().await.clone();
         let sfu =
             SfuServer::new(Arc::new(config.clone()), None).expect("Failed to create SfuServer");
 
@@ -75,7 +249,65 @@ impl TestApp {
             .await
             .expect("oneshot request failed")
     }
+
+    /// Create a [`CleanupGuard`] for this app's pool.
+    pub fn cleanup_guard(&self) -> CleanupGuard {
+        CleanupGuard::new(self.pool.clone())
+    }
 }
+
+// ============================================================================
+// Test Server (Issue #139)
+// ============================================================================
+
+/// A running test server bound to a random port.
+pub struct TestServer {
+    /// Server address (127.0.0.1:PORT).
+    pub addr: SocketAddr,
+    /// Base URL for HTTP requests (e.g., `http://127.0.0.1:12345`).
+    pub url: String,
+    /// Handle to the server task for cleanup.
+    _handle: JoinHandle<()>,
+}
+
+/// Spawn a real HTTP server on a random port.
+///
+/// Use this instead of `oneshot` when testing stateful middleware behavior
+/// (rate limiting, request IDs, CORS preflight caching, etc.) since `oneshot`
+/// resets middleware state between requests.
+///
+/// # Example
+///
+/// ```ignore
+/// let app = TestApp::new().await;
+/// let server = spawn_test_server(app.router.clone()).await;
+///
+/// let client = reqwest::Client::new();
+/// let resp = client.get(format!("{}/api/health", server.url)).send().await?;
+/// ```
+pub async fn spawn_test_server(router: Router) -> TestServer {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("Failed to bind test server");
+    let addr = listener.local_addr().expect("Failed to get local addr");
+    let url = format!("http://{addr}");
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, router)
+            .await
+            .expect("Test server failed");
+    });
+
+    TestServer {
+        addr,
+        url,
+        _handle: handle,
+    }
+}
+
+// ============================================================================
+// User & Auth helpers
+// ============================================================================
 
 /// Create a test user and return `(user_id, username)`.
 pub async fn create_test_user(pool: &PgPool) -> (Uuid, String) {

--- a/server/tests/ratelimit_http_test.rs
+++ b/server/tests/ratelimit_http_test.rs
@@ -1,0 +1,169 @@
+//! HTTP-Level Rate Limiting Tests
+//!
+//! Tests rate limiting behavior through a real HTTP server, verifying
+//! that the middleware correctly tracks request counts across calls
+//! and returns appropriate 429 responses.
+//!
+//! These tests use `spawn_test_server` instead of `oneshot` because
+//! rate limiting is stateful middleware that needs to persist state
+//! across multiple requests.
+//!
+//! Run with: `cargo test --test ratelimit_http_test --ignored -- --nocapture`
+
+mod helpers;
+
+use helpers::spawn_test_server;
+use std::collections::HashSet;
+use std::sync::Arc;
+use vc_server::{
+    api::{create_router, AppState},
+    config::Config,
+    ratelimit::{LimitConfig, RateLimitConfig, RateLimiter, RateLimits},
+    voice::sfu::SfuServer,
+};
+
+/// Create a test app with rate limiting enabled using a real server.
+async fn create_rate_limited_app(limits: RateLimits) -> (helpers::TestServer, Config) {
+    let config = Config::default_for_test();
+    let pool = helpers::shared_pool().await.clone();
+    let redis = helpers::shared_redis().await.clone();
+    let sfu =
+        SfuServer::new(Arc::new(config.clone()), None).expect("Failed to create SfuServer");
+
+    let rl_config = RateLimitConfig {
+        enabled: true,
+        redis_key_prefix: format!("test:rl:{}", uuid::Uuid::new_v4()),
+        fail_open: false,
+        trust_proxy: false,
+        allowlist: HashSet::new(),
+        limits,
+    };
+    let mut limiter = RateLimiter::new(redis.clone(), rl_config);
+    limiter.init().await.expect("Failed to initialize limiter");
+
+    let state = AppState::new(
+        pool,
+        redis,
+        config.clone(),
+        None,
+        sfu,
+        Some(limiter),
+        None,
+        None,
+    );
+    let router = create_router(state);
+    let server = spawn_test_server(router).await;
+
+    (server, config)
+}
+
+/// Test that requests under the rate limit succeed and over-limit returns 429.
+#[tokio::test]
+#[ignore] // Requires Redis
+async fn test_http_rate_limiting_returns_429() {
+    let limits = RateLimits {
+        read: LimitConfig {
+            requests: 3,
+            window_secs: 60,
+        },
+        ..RateLimits::default()
+    };
+
+    let (server, _config) = create_rate_limited_app(limits).await;
+    let client = reqwest::Client::new();
+
+    // First 3 requests should succeed (200 from setup/status)
+    for i in 0..3 {
+        let resp = client
+            .get(format!("{}/api/setup/status", server.url))
+            .send()
+            .await
+            .expect("Request failed");
+        assert_eq!(
+            resp.status(),
+            200,
+            "Request {} should succeed (under limit)",
+            i + 1
+        );
+    }
+
+    // 4th request should be rate limited
+    let resp = client
+        .get(format!("{}/api/setup/status", server.url))
+        .send()
+        .await
+        .expect("Request failed");
+    assert_eq!(
+        resp.status(),
+        429,
+        "4th request should be rate limited (429)"
+    );
+
+    // Verify Retry-After header is present
+    let retry_after = resp.headers().get("retry-after");
+    assert!(
+        retry_after.is_some(),
+        "429 response should include Retry-After header"
+    );
+}
+
+/// Test that rate limit headers are present in responses.
+#[tokio::test]
+#[ignore] // Requires Redis
+async fn test_http_rate_limit_headers() {
+    let limits = RateLimits {
+        read: LimitConfig {
+            requests: 10,
+            window_secs: 60,
+        },
+        ..RateLimits::default()
+    };
+
+    let (server, _config) = create_rate_limited_app(limits).await;
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!("{}/api/setup/status", server.url))
+        .send()
+        .await
+        .expect("Request failed");
+
+    assert_eq!(resp.status(), 200);
+
+    // Check for standard rate limit headers
+    let limit = resp.headers().get("x-ratelimit-limit");
+    let remaining = resp.headers().get("x-ratelimit-remaining");
+
+    assert!(limit.is_some(), "Should include X-RateLimit-Limit header");
+    assert!(
+        remaining.is_some(),
+        "Should include X-RateLimit-Remaining header"
+    );
+}
+
+/// Test that request IDs are unique across multiple requests.
+#[tokio::test]
+#[ignore] // Requires Redis
+async fn test_request_ids_are_unique() {
+    let limits = RateLimits::default();
+    let (server, _config) = create_rate_limited_app(limits).await;
+    let client = reqwest::Client::new();
+
+    let mut request_ids = HashSet::new();
+
+    for _ in 0..10 {
+        let resp = client
+            .get(format!("{}/api/setup/status", server.url))
+            .send()
+            .await
+            .expect("Request failed");
+
+        if let Some(id) = resp.headers().get("x-request-id") {
+            let id_str = id.to_str().unwrap().to_string();
+            assert!(
+                request_ids.insert(id_str.clone()),
+                "Duplicate request ID found: {id_str}"
+            );
+        }
+    }
+}

--- a/server/tests/setup_concurrent_http_test.rs
+++ b/server/tests/setup_concurrent_http_test.rs
@@ -1,0 +1,189 @@
+//! HTTP-Level Concurrent Setup Completion Test
+//!
+//! Tests that concurrent HTTP requests to `POST /api/setup/complete`
+//! result in exactly one success (204) while others receive 403.
+//!
+//! This extends the database-level concurrency tests in
+//! `setup_integration_test.rs` by exercising the full HTTP stack:
+//! auth middleware, JSON deserialization, validation, compare-and-swap,
+//! and response serialization — all under concurrent load.
+//!
+//! Run with: `cargo test --test setup_concurrent_http_test -- --nocapture`
+
+mod helpers;
+
+use axum::{body::Body, http::Method};
+use helpers::{create_test_user, generate_access_token, make_admin, TestApp};
+use serial_test::serial;
+use tower::ServiceExt;
+
+/// Set `setup_complete` to the given value and return the previous value.
+async fn set_setup_complete(pool: &sqlx::PgPool, complete: bool) -> bool {
+    let prev: serde_json::Value =
+        sqlx::query_scalar("SELECT value FROM server_config WHERE key = 'setup_complete'")
+            .fetch_one(pool)
+            .await
+            .expect("Failed to read setup_complete");
+
+    sqlx::query("UPDATE server_config SET value = $1::jsonb WHERE key = 'setup_complete'")
+        .bind(serde_json::json!(complete))
+        .execute(pool)
+        .await
+        .expect("Failed to set setup_complete");
+
+    prev.as_bool().unwrap_or_else(|| {
+        panic!("setup_complete has invalid type in database, expected boolean, got: {prev:?}")
+    })
+}
+
+/// Test that concurrent HTTP setup completion requests result in exactly one 204.
+///
+/// Two admin users simultaneously POST to `/api/setup/complete`.
+/// The compare-and-swap pattern ensures exactly one succeeds (204),
+/// while the other gets 403 (SETUP_ALREADY_COMPLETE).
+#[tokio::test]
+#[serial]
+async fn test_concurrent_http_setup_completion() {
+    let app = TestApp::new().await;
+
+    // Create two separate admin users
+    let (admin1_id, _) = create_test_user(&app.pool).await;
+    let (admin2_id, _) = create_test_user(&app.pool).await;
+    make_admin(&app.pool, admin1_id).await;
+    make_admin(&app.pool, admin2_id).await;
+
+    let token1 = generate_access_token(&app.config, admin1_id);
+    let token2 = generate_access_token(&app.config, admin2_id);
+
+    // Reset setup to incomplete
+    let prev = set_setup_complete(&app.pool, false).await;
+
+    // Guard ensures cleanup even if assertions panic
+    let mut guard = app.cleanup_guard();
+    guard.restore_config_defaults();
+    guard.restore_setup_complete(prev);
+    guard.delete_user(admin1_id);
+    guard.delete_user(admin2_id);
+
+    // Build two concurrent completion requests
+    let req1 = TestApp::request(Method::POST, "/api/setup/complete")
+        .header("Content-Type", "application/json")
+        .header("Authorization", format!("Bearer {token1}"))
+        .body(Body::from(
+            serde_json::json!({
+                "server_name": "Server from Admin 1",
+                "registration_policy": "open"
+            })
+            .to_string(),
+        ))
+        .unwrap();
+
+    let req2 = TestApp::request(Method::POST, "/api/setup/complete")
+        .header("Content-Type", "application/json")
+        .header("Authorization", format!("Bearer {token2}"))
+        .body(Body::from(
+            serde_json::json!({
+                "server_name": "Server from Admin 2",
+                "registration_policy": "invite_only"
+            })
+            .to_string(),
+        ))
+        .unwrap();
+
+    // Send both requests concurrently through the full HTTP stack
+    let router1 = app.router.clone();
+    let router2 = app.router.clone();
+    let (resp1, resp2) = tokio::join!(router1.oneshot(req1), router2.oneshot(req2),);
+
+    let s1 = resp1.expect("Request 1 failed").status();
+    let s2 = resp2.expect("Request 2 failed").status();
+
+    // Exactly one should succeed (204), the other should get 403
+    assert!(
+        (s1 == 204 && s2 == 403) || (s1 == 403 && s2 == 204),
+        "Expected one 204 and one 403, got {s1} and {s2}"
+    );
+
+    // Verify setup is marked complete
+    let setup_val: serde_json::Value =
+        sqlx::query_scalar("SELECT value FROM server_config WHERE key = 'setup_complete'")
+            .fetch_one(&app.pool)
+            .await
+            .expect("Failed to read setup_complete");
+    assert_eq!(
+        setup_val.as_bool(),
+        Some(true),
+        "setup_complete should be true after concurrent completion"
+    );
+}
+
+/// Test that concurrent completion with 5 admins still results in exactly one success.
+#[tokio::test]
+#[serial]
+async fn test_concurrent_http_setup_five_admins() {
+    let app = TestApp::new().await;
+
+    let num_admins = 5;
+    let mut admin_ids = Vec::new();
+    let mut tokens = Vec::new();
+
+    for _ in 0..num_admins {
+        let (user_id, _) = create_test_user(&app.pool).await;
+        make_admin(&app.pool, user_id).await;
+        let token = generate_access_token(&app.config, user_id);
+        admin_ids.push(user_id);
+        tokens.push(token);
+    }
+
+    let prev = set_setup_complete(&app.pool, false).await;
+
+    let mut guard = app.cleanup_guard();
+    guard.restore_config_defaults();
+    guard.restore_setup_complete(prev);
+    for &id in &admin_ids {
+        guard.delete_user(id);
+    }
+
+    // Spawn concurrent requests
+    let mut handles = Vec::new();
+    for (i, token) in tokens.into_iter().enumerate() {
+        let router = app.router.clone();
+        handles.push(tokio::spawn(async move {
+            let req = TestApp::request(Method::POST, "/api/setup/complete")
+                .header("Content-Type", "application/json")
+                .header("Authorization", format!("Bearer {token}"))
+                .body(Body::from(
+                    serde_json::json!({
+                        "server_name": format!("Server from Admin {}", i),
+                        "registration_policy": "open"
+                    })
+                    .to_string(),
+                ))
+                .unwrap();
+
+            router.oneshot(req).await.expect("Request failed").status()
+        }));
+    }
+
+    let mut success_count = 0;
+    let mut forbidden_count = 0;
+
+    for handle in handles {
+        let status = handle.await.expect("Task panicked");
+        match status.as_u16() {
+            204 => success_count += 1,
+            403 => forbidden_count += 1,
+            other => panic!("Unexpected status: {other}"),
+        }
+    }
+
+    assert_eq!(
+        success_count, 1,
+        "Exactly one admin should succeed, got {success_count}"
+    );
+    assert_eq!(
+        forbidden_count,
+        num_admins - 1,
+        "All other admins should get 403"
+    );
+}


### PR DESCRIPTION
## Summary
- **RAII Cleanup Guards** (#137): `CleanupGuard` struct ensures cleanup runs even if test assertions panic. Migrated `setup_http_test.rs` as reference.
- **Shared Pool/Redis** (#138): `shared_pool()` / `shared_redis()` via `tokio::sync::OnceCell` — `TestApp::new()` reuses connections instead of creating per-test.
- **Stateful Middleware Testing** (#139): `spawn_test_server()` binds to random port for real HTTP testing. New `ratelimit_http_test.rs` tests 429 responses and headers.
- **Concurrent HTTP Setup Test** (#140): `setup_concurrent_http_test.rs` verifies compare-and-swap with 2 and 5 concurrent admins at HTTP level.

Closes #137, closes #138, closes #139, closes #140

## Test plan
- [ ] `cargo check -p vc-server --tests` passes (verified)
- [ ] `cargo test --test setup_http_test` — existing tests pass with CleanupGuard pattern
- [ ] `cargo test --test setup_concurrent_http_test` — concurrent setup tests pass
- [ ] `cargo test --test ratelimit_http_test --ignored` — rate limit HTTP tests pass (requires Redis)
- [ ] Verify no connection exhaustion during full `cargo test` run

🤖 Generated with [Claude Code](https://claude.com/claude-code)