### PR TITLE
fix(test): use multi_thread runtime for setup HTTP tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,5 @@
 [profile.default]
 # Kill individual tests that take longer than 2 minutes
 slow-timeout = { period = "120s", terminate-after = 1 }
+# Continue running other tests even if one fails or times out
+fail-fast = false


### PR DESCRIPTION
## Summary
- Switch all `setup_http_test` tests from `current_thread` to `multi_thread` tokio runtime, matching the working `setup_concurrent_http_test` convention
- Add `tokio::time::timeout(10s)` safety wrapper around the previously hanging `test_complete_already_done` oneshot call
- Add `fail-fast = false` to nextest config so remaining tests continue after a timeout

## Problem
`test_complete_already_done` consistently timed out (120s) in CI with `cargo nextest run -j 1`. This was test #504/569 and blocked all subsequent tests from running. The hang occurred at the `app.oneshot(req).await` call.

## Root Cause
Likely a subtle interaction between `current_thread` tokio runtime and background tasks (fred Redis client connection management / sqlx pool maintenance) under nextest's per-process execution model. The concurrent setup tests which use `multi_thread` runtime always passed.

## Test plan
- [ ] CI Rust Tests job passes (all 569 tests should now run)
- [ ] `test_complete_already_done` completes within 10s instead of timing out at 120s
- [ ] Remaining setup_http_test tests (previously blocked) now execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)