### PR TITLE
feat(chat,client): thread participant avatars and unread indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Thread participant avatars — ThreadIndicator shows small overlapping avatar thumbnails of the most recent thread participants
+- Thread unread indicator — blue dot and bold text on threads with unread replies, clears when thread is opened or marked as read
 - #channel autocomplete — type `#` in guild channels to mention text channels with fuzzy matching
 - /command autocomplete — type `/` at the start of a message to browse available slash commands from installed bots
 - Reaction keyboard shortcuts — press Alt+1 through Alt+4 while hovering a message to quick-react (👍, ❤️, 😂, 😮)

--- a/client/src/components/ui/Avatar.tsx
+++ b/client/src/components/ui/Avatar.tsx
@@ -5,12 +5,13 @@ import StatusIndicator from "./StatusIndicator";
 interface AvatarProps {
   src?: string | null;
   alt: string;
-  size?: "sm" | "md" | "lg";
+  size?: "xs" | "sm" | "md" | "lg";
   status?: UserStatus;
   showStatus?: boolean;
 }
 
 const sizeClasses = {
+  xs: "w-5 h-5 text-[8px]",
   sm: "w-8 h-8 text-xs",
   md: "w-10 h-10 text-sm",
   lg: "w-12 h-12 text-base",

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -217,6 +217,7 @@ export interface Message {
   created_at: string;
   mention_type: "direct" | "everyone" | "here" | null;
   reactions?: Reaction[];
+  thread_info?: ThreadInfo;
 }
 
 export interface ThreadInfo {
@@ -224,6 +225,7 @@ export interface ThreadInfo {
   last_reply_at: string | null;
   participant_ids: string[];
   participant_avatars: Array<string | null>;
+  has_unread?: boolean;
 }
 
 // Paginated Response Types

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -503,23 +503,17 @@ This roadmap outlines the development path from the current prototype to a produ
     - **Rate Limiting:**
       - Add per-guild rate limiting to prevent resource exhaustion
       - Protect export endpoints from abuse
-- [ ] **[Chat] Slack-style Message Threads**
+- [x] **[Chat] Slack-style Message Threads** ✅
   - **Context:** Keep channel conversations organized by allowing side-discussions without cluttering the main feed.
-  - **Implementation:**
-    - **Database:**
-      - Migration to add `parent_id` (foreign key to `messages.id`) to `messages` table
-      - Add `thread_count` field to parent messages for quick display
-      - Add index on `parent_id` for efficient thread queries
-    - **Backend:**
-      - Update `Message` model with thread fields
-      - Implement recursive thread retrieval logic
-      - Add thread-specific WebSocket events
-      - Add guild-level toggle to enable/disable threads
-    - **Frontend:**
-      - Create `ThreadSidebar.tsx` for side conversation UI
-      - Add "Reply in Thread" action to message context menu
-      - Show thread participant count and last reply timestamp
-      - Implement thread notifications (separate from channel notifications)
+  - **Completed:**
+    - ✅ Database migration: `parent_id` FK, `thread_reply_count`, `thread_last_reply_at`, `thread_read_state` table
+    - ✅ Backend: Thread reply CRUD, WebSocket events (`thread_reply_new`, `thread_reply_delete`, `thread_read`)
+    - ✅ Frontend: `ThreadSidebar`, `ThreadIndicator` with participant avatars and unread dot
+    - ✅ Batch thread info in message list response (participants, avatars, unread state) — no N+1
+    - ✅ Thread unread tracking: server-side read state + client-side WebSocket tracking
+    - ✅ 11+ server integration tests
+  - **Remaining:**
+    - [ ] Guild-level toggle to enable/disable threads
 - [ ] **[Media] Advanced Media Processing**
   - **Context:** Improve perceived performance and bandwidth efficiency.
   - **Implementation:**

--- a/server/src/chat/messages.rs
+++ b/server/src/chat/messages.rs
@@ -145,6 +145,10 @@ pub struct ThreadInfoResponse {
     pub last_reply_at: Option<DateTime<Utc>>,
     pub participant_ids: Vec<Uuid>,
     pub participant_avatars: Vec<Option<String>>,
+    /// Whether the thread has unread replies for the requesting user.
+    /// Only populated for authenticated message list requests.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub has_unread: Option<bool>,
 }
 
 /// Full message response with author info (matches client Message type).
@@ -931,6 +935,21 @@ async fn build_message_responses(
             });
     }
 
+    // Batch-fetch thread info for parent messages with replies
+    let parent_ids_with_threads: Vec<Uuid> = messages
+        .iter()
+        .filter(|m| m.parent_id.is_none() && m.thread_reply_count > 0)
+        .map(|m| m.id)
+        .collect();
+
+    let mut thread_infos = build_batch_thread_infos(
+        pool,
+        requesting_user_id,
+        &parent_ids_with_threads,
+        &messages,
+    )
+    .await;
+
     // Build response objects
     let response = messages
         .into_iter()
@@ -954,6 +973,8 @@ async fn build_message_responses(
                 detect_mention_type(&msg.content, Some(&author.username))
             };
 
+            let thread_info = thread_infos.remove(&msg.id);
+
             MessageResponse {
                 id: msg.id,
                 channel_id: msg.channel_id,
@@ -969,7 +990,7 @@ async fn build_message_responses(
                 created_at: msg.created_at,
                 mention_type,
                 reactions,
-                thread_info: None,
+                thread_info,
             }
         })
         .collect();
@@ -1014,7 +1035,134 @@ async fn build_thread_info(pool: &sqlx::PgPool, parent_id: Uuid) -> ThreadInfoRe
         last_reply_at: parent.and_then(|p| p.thread_last_reply_at),
         participant_ids,
         participant_avatars,
+        has_unread: None,
     }
+}
+
+/// Batch-build thread info for multiple parent messages.
+///
+/// Efficiently fetches participants, avatars, read states, and latest replies
+/// in bulk queries to avoid N+1 patterns.
+async fn build_batch_thread_infos(
+    pool: &sqlx::PgPool,
+    requesting_user_id: Uuid,
+    parent_ids: &[Uuid],
+    messages: &[db::Message],
+) -> std::collections::HashMap<Uuid, ThreadInfoResponse> {
+    if parent_ids.is_empty() {
+        return std::collections::HashMap::new();
+    }
+
+    // Batch fetch participants (up to 5 per thread)
+    let participants_map = match db::get_batch_thread_participants(pool, parent_ids, 5).await {
+        Ok(map) => map,
+        Err(e) => {
+            tracing::warn!(
+                parent_count = parent_ids.len(),
+                error = %e,
+                "Failed to batch-fetch thread participants, avatars will be missing"
+            );
+            std::collections::HashMap::new()
+        }
+    };
+
+    // Collect all unique participant user IDs for avatar lookup
+    let all_participant_ids: Vec<Uuid> = participants_map
+        .values()
+        .flatten()
+        .copied()
+        .collect::<std::collections::HashSet<Uuid>>()
+        .into_iter()
+        .collect();
+
+    // Single bulk user lookup for all participant avatars
+    let users = if all_participant_ids.is_empty() {
+        vec![]
+    } else {
+        match db::find_users_by_ids(pool, &all_participant_ids).await {
+            Ok(users) => users,
+            Err(e) => {
+                tracing::warn!(
+                    user_count = all_participant_ids.len(),
+                    error = %e,
+                    "Failed to fetch thread participant users, avatars will be missing"
+                );
+                vec![]
+            }
+        }
+    };
+    let user_map: std::collections::HashMap<Uuid, &db::User> =
+        users.iter().map(|u| (u.id, u)).collect();
+
+    // Batch fetch read states and latest reply IDs for unread detection
+    let read_states =
+        match db::get_batch_thread_read_states(pool, requesting_user_id, parent_ids).await {
+            Ok(states) => states,
+            Err(e) => {
+                tracing::warn!(
+                    parent_count = parent_ids.len(),
+                    error = %e,
+                    "Failed to batch-fetch thread read states, unread indicators may be inaccurate"
+                );
+                std::collections::HashMap::new()
+            }
+        };
+    let latest_replies = match db::get_batch_thread_latest_reply_ids(pool, parent_ids).await {
+        Ok(replies) => replies,
+        Err(e) => {
+            tracing::warn!(
+                parent_count = parent_ids.len(),
+                error = %e,
+                "Failed to batch-fetch latest thread replies, unread indicators may be inaccurate"
+            );
+            std::collections::HashMap::new()
+        }
+    };
+
+    // Build a map of parent_id -> message data for counters
+    let msg_map: std::collections::HashMap<Uuid, &db::Message> =
+        messages.iter().map(|m| (m.id, m)).collect();
+
+    // Assemble ThreadInfoResponse per parent
+    let mut result = std::collections::HashMap::new();
+
+    for &parent_id in parent_ids {
+        let participant_ids = participants_map
+            .get(&parent_id)
+            .cloned()
+            .unwrap_or_default();
+
+        let participant_avatars: Vec<Option<String>> = participant_ids
+            .iter()
+            .map(|uid| user_map.get(uid).and_then(|u| u.avatar_url.clone()))
+            .collect();
+
+        // Determine unread status
+        let has_unread = if let Some(latest_reply_id) = latest_replies.get(&parent_id) {
+            match read_states.get(&parent_id) {
+                Some(Some(last_read_id)) => Some(last_read_id != latest_reply_id),
+                Some(None) => Some(true), // Has read state but no message ID → unread
+                None => Some(true),       // No read state at all → unread
+            }
+        } else {
+            None // No replies → no unread state
+        };
+
+        let msg = msg_map.get(&parent_id);
+
+        result.insert(
+            parent_id,
+            ThreadInfoResponse {
+                reply_count: msg.map_or(0, |m| m.thread_reply_count),
+                last_reply_at: msg.and_then(|m| m.thread_last_reply_at),
+                participant_ids,
+                participant_avatars,
+                has_unread,
+            },
+        );
+    }
+
+    result
 }
 
 /// List thread replies for a parent message.


### PR DESCRIPTION
## Summary
- **Thread participant avatars** — ThreadIndicator shows up to 3 overlapping avatar thumbnails of the most recent thread participants, populated via batch SQL queries (no N+1)
- **Thread unread indicator** — Blue dot and bold text on threads with unread replies; server compares read state vs latest reply, client tracks via WebSocket events
- **Avatar `xs` size variant** — 20px size for thread participant thumbnails

## Backend
- 3 new batch queries in `queries.rs`: `get_batch_thread_participants`, `get_batch_thread_read_states`, `get_batch_thread_latest_reply_ids`
- `build_batch_thread_infos()` assembles `ThreadInfoResponse` per parent message and attaches to message list responses
- All batch DB calls use `tracing::warn!` on failure for graceful degradation with observability

## Client
- `ThreadIndicator` renders participant avatars + unread dot, with cache-first priority for WebSocket reactivity
- `updateThreadInfo` preserves existing `has_unread` flag to prevent race conditions
- `markThreadRead` restores unread indicator on API failure for honest UI state
- `handleThreadReplyDelete` preserves unread state through the `updateThreadInfo` preservation logic

## Test plan
- [x] `cargo test --lib` — 302 passed
- [x] `cargo test --test threads_test` — 11 passed (including `test_parent_message_includes_thread_info`)
- [x] `cargo clippy -p vc-server -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: load channel with threaded messages → ThreadIndicator shows avatar thumbnails
- [ ] Manual: receive thread reply via WebSocket → avatars update, unread dot appears
- [ ] Manual: open thread → unread dot clears
- [ ] Manual: reload page → unread state persists from server

🤖 Generated with [Claude Code](https://claude.com/claude-code)