### PR TITLE
test(client): add unit tests for 9 critical stores (#165)

### DIFF
--- a/client/src/stores/__tests__/auth.test.ts
+++ b/client/src/stores/__tests__/auth.test.ts
@@ -1,0 +1,363 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/tauri", () => ({
+  getCurrentUser: vi.fn(),
+  login: vi.fn(),
+  register: vi.fn(),
+  logout: vi.fn(),
+  oidcCompleteLogin: vi.fn(),
+}));
+
+vi.mock("@/stores/websocket", () => ({
+  initWebSocket: vi.fn(),
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+  cleanupWebSocket: vi.fn(),
+}));
+
+vi.mock("@/stores/presence", () => ({
+  initPresence: vi.fn(),
+  cleanupPresence: vi.fn(),
+  initIdleDetection: vi.fn(),
+  stopIdleDetectionCleanup: vi.fn(),
+}));
+
+vi.mock("@/stores/preferences", () => ({
+  initPreferences: vi.fn(),
+}));
+
+vi.mock("@/stores/drafts", () => ({
+  clearAllDrafts: vi.fn(),
+  cleanupDrafts: vi.fn(),
+}));
+
+import * as tauri from "@/lib/tauri";
+import { initWebSocket, connect as wsConnect, disconnect as wsDisconnect, cleanupWebSocket } from "@/stores/websocket";
+import { initPresence, cleanupPresence, initIdleDetection, stopIdleDetectionCleanup } from "@/stores/presence";
+import { initPreferences } from "@/stores/preferences";
+import { clearAllDrafts, cleanupDrafts } from "@/stores/drafts";
+import type { User } from "@/lib/types";
+import {
+  authState,
+  setAuthState,
+  initAuth,
+  login,
+  register,
+  loginWithOidc,
+  logout,
+  clearError,
+  updateUser,
+  clearSetupRequired,
+  isAuthenticated,
+  currentUser,
+} from "../auth";
+
+function createUser(overrides: Partial<User> = {}): User {
+  return {
+    id: "user-1",
+    username: "alice",
+    display_name: "Alice",
+    avatar_url: null,
+    status: "online",
+    email: "alice@example.com",
+    mfa_enabled: false,
+    created_at: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("auth store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setAuthState({
+      user: null,
+      serverUrl: null,
+      isLoading: false,
+      isInitialized: false,
+      error: null,
+      setupRequired: false,
+    });
+  });
+
+  describe("initial state", () => {
+    it("has null user and not initialized", () => {
+      expect(authState.user).toBeNull();
+      expect(authState.isLoading).toBe(false);
+      expect(authState.isInitialized).toBe(false);
+      expect(authState.error).toBeNull();
+      expect(authState.setupRequired).toBe(false);
+    });
+  });
+
+  describe("derived state", () => {
+    it("isAuthenticated returns false when no user", () => {
+      expect(isAuthenticated()).toBe(false);
+    });
+
+    it("isAuthenticated returns true when user present", () => {
+      setAuthState({ user: createUser() });
+
+      expect(isAuthenticated()).toBe(true);
+    });
+
+    it("currentUser returns the user", () => {
+      const user = createUser();
+      setAuthState({ user });
+
+      expect(currentUser()?.id).toBe(user.id);
+    });
+  });
+
+  describe("initAuth", () => {
+    it("restores session and inits subsystems", async () => {
+      const user = createUser();
+      vi.mocked(tauri.getCurrentUser).mockResolvedValue(user);
+      vi.mocked(initWebSocket).mockResolvedValue(undefined);
+      vi.mocked(initPresence).mockResolvedValue(undefined);
+      vi.mocked(wsConnect).mockResolvedValue(undefined);
+      vi.mocked(initPreferences).mockResolvedValue(undefined);
+
+      await initAuth();
+
+      expect(authState.user).toEqual(user);
+      expect(authState.isInitialized).toBe(true);
+      expect(initWebSocket).toHaveBeenCalled();
+      expect(initPresence).toHaveBeenCalled();
+      expect(wsConnect).toHaveBeenCalled();
+      expect(initPreferences).toHaveBeenCalled();
+      expect(initIdleDetection).toHaveBeenCalled();
+    });
+
+    it("handles no session gracefully", async () => {
+      vi.mocked(tauri.getCurrentUser).mockResolvedValue(null);
+
+      await initAuth();
+
+      expect(authState.user).toBeNull();
+      expect(authState.isInitialized).toBe(true);
+      expect(authState.error).toBeNull();
+      expect(initWebSocket).not.toHaveBeenCalled();
+    });
+
+    it("sets error on WS failure but completes", async () => {
+      vi.mocked(tauri.getCurrentUser).mockResolvedValue(createUser());
+      vi.mocked(initWebSocket).mockResolvedValue(undefined);
+      vi.mocked(initPresence).mockResolvedValue(undefined);
+      vi.mocked(wsConnect).mockRejectedValue(new Error("WS fail"));
+      vi.mocked(initPreferences).mockResolvedValue(undefined);
+
+      await initAuth();
+
+      expect(authState.user).not.toBeNull();
+      expect(authState.error).toContain("Real-time messaging temporarily unavailable");
+    });
+
+    it("skips if already initialized", async () => {
+      setAuthState({ isInitialized: true });
+
+      await initAuth();
+
+      expect(tauri.getCurrentUser).not.toHaveBeenCalled();
+    });
+
+    it("continues if preferences init fails", async () => {
+      vi.mocked(tauri.getCurrentUser).mockResolvedValue(createUser());
+      vi.mocked(initWebSocket).mockResolvedValue(undefined);
+      vi.mocked(initPresence).mockResolvedValue(undefined);
+      vi.mocked(wsConnect).mockResolvedValue(undefined);
+      vi.mocked(initPreferences).mockRejectedValue(new Error("prefs fail"));
+
+      await initAuth();
+
+      expect(authState.user).not.toBeNull();
+      expect(initIdleDetection).toHaveBeenCalled();
+    });
+
+    it("handles session restore failure gracefully", async () => {
+      vi.mocked(tauri.getCurrentUser).mockRejectedValue(new Error("no session"));
+
+      await initAuth();
+
+      expect(authState.user).toBeNull();
+      expect(authState.isInitialized).toBe(true);
+      expect(authState.error).toBeNull(); // Don't show error for session restoration
+    });
+  });
+
+  describe("login", () => {
+    it("logs in and inits subsystems", async () => {
+      const user = createUser();
+      vi.mocked(tauri.login).mockResolvedValue({ user, setup_required: false });
+      vi.mocked(initWebSocket).mockResolvedValue(undefined);
+      vi.mocked(initPresence).mockResolvedValue(undefined);
+      vi.mocked(wsConnect).mockResolvedValue(undefined);
+      vi.mocked(initPreferences).mockResolvedValue(undefined);
+
+      const result = await login("https://server.com", "alice", "password");
+
+      expect(result.id).toBe(user.id);
+      expect(authState.user).toEqual(user);
+      expect(authState.serverUrl).toBe("https://server.com");
+      expect(authState.setupRequired).toBe(false);
+      expect(initWebSocket).toHaveBeenCalled();
+    });
+
+    it("sets setupRequired from response", async () => {
+      vi.mocked(tauri.login).mockResolvedValue({ user: createUser(), setup_required: true });
+      vi.mocked(initWebSocket).mockResolvedValue(undefined);
+      vi.mocked(initPresence).mockResolvedValue(undefined);
+      vi.mocked(wsConnect).mockResolvedValue(undefined);
+      vi.mocked(initPreferences).mockResolvedValue(undefined);
+
+      await login("https://server.com", "alice", "password");
+
+      expect(authState.setupRequired).toBe(true);
+    });
+
+    it("sets error and re-throws on failure", async () => {
+      vi.mocked(tauri.login).mockRejectedValue(new Error("Invalid credentials"));
+
+      await expect(login("https://server.com", "alice", "wrong")).rejects.toThrow("Invalid credentials");
+      expect(authState.error).toBe("Invalid credentials");
+      expect(authState.isLoading).toBe(false);
+    });
+  });
+
+  describe("register", () => {
+    it("registers and inits subsystems", async () => {
+      const user = createUser();
+      vi.mocked(tauri.register).mockResolvedValue({ user, setup_required: false });
+      vi.mocked(initWebSocket).mockResolvedValue(undefined);
+      vi.mocked(initPresence).mockResolvedValue(undefined);
+      vi.mocked(wsConnect).mockResolvedValue(undefined);
+      vi.mocked(initPreferences).mockResolvedValue(undefined);
+
+      const result = await register("https://server.com", "alice", "password");
+
+      expect(result.id).toBe(user.id);
+      expect(authState.user).toEqual(user);
+    });
+
+    it("passes setupRequired flag", async () => {
+      vi.mocked(tauri.register).mockResolvedValue({ user: createUser(), setup_required: true });
+      vi.mocked(initWebSocket).mockResolvedValue(undefined);
+      vi.mocked(initPresence).mockResolvedValue(undefined);
+      vi.mocked(wsConnect).mockResolvedValue(undefined);
+      vi.mocked(initPreferences).mockResolvedValue(undefined);
+
+      await register("https://server.com", "alice", "password");
+
+      expect(authState.setupRequired).toBe(true);
+    });
+
+    it("sets error and re-throws on failure", async () => {
+      vi.mocked(tauri.register).mockRejectedValue(new Error("Username taken"));
+
+      await expect(register("https://server.com", "alice", "password")).rejects.toThrow("Username taken");
+      expect(authState.error).toBe("Username taken");
+    });
+  });
+
+  describe("loginWithOidc", () => {
+    it("completes OIDC login", async () => {
+      const user = createUser();
+      vi.mocked(tauri.oidcCompleteLogin).mockResolvedValue(undefined);
+      vi.mocked(tauri.getCurrentUser).mockResolvedValue(user);
+      vi.mocked(initWebSocket).mockResolvedValue(undefined);
+      vi.mocked(initPresence).mockResolvedValue(undefined);
+      vi.mocked(wsConnect).mockResolvedValue(undefined);
+      vi.mocked(initPreferences).mockResolvedValue(undefined);
+
+      await loginWithOidc("https://server.com", "token", "refresh", 3600);
+
+      expect(authState.user).toEqual(user);
+    });
+
+    it("throws if getCurrentUser returns null", async () => {
+      vi.mocked(tauri.oidcCompleteLogin).mockResolvedValue(undefined);
+      vi.mocked(tauri.getCurrentUser).mockResolvedValue(null);
+
+      await expect(loginWithOidc("https://server.com", "token", "refresh", 3600))
+        .rejects.toThrow("Failed to fetch user after OIDC login");
+    });
+  });
+
+  describe("logout", () => {
+    it("runs cleanup chain and clears state", async () => {
+      setAuthState({ user: createUser() });
+      vi.mocked(wsDisconnect).mockResolvedValue(undefined);
+      vi.mocked(cleanupWebSocket).mockResolvedValue(undefined);
+      vi.mocked(tauri.logout).mockResolvedValue(undefined);
+
+      await logout();
+
+      expect(authState.user).toBeNull();
+      expect(authState.isLoading).toBe(false);
+      expect(wsDisconnect).toHaveBeenCalled();
+      expect(cleanupWebSocket).toHaveBeenCalled();
+      expect(stopIdleDetectionCleanup).toHaveBeenCalled();
+      expect(cleanupPresence).toHaveBeenCalled();
+      expect(clearAllDrafts).toHaveBeenCalled();
+      expect(cleanupDrafts).toHaveBeenCalled();
+    });
+
+    it("clears state even if server logout fails", async () => {
+      setAuthState({ user: createUser() });
+      vi.mocked(wsDisconnect).mockResolvedValue(undefined);
+      vi.mocked(cleanupWebSocket).mockResolvedValue(undefined);
+      vi.mocked(tauri.logout).mockRejectedValue(new Error("Server error"));
+
+      await logout();
+
+      expect(authState.user).toBeNull();
+    });
+
+    it("clears state even if cleanup fails", async () => {
+      setAuthState({ user: createUser() });
+      vi.mocked(wsDisconnect).mockRejectedValue(new Error("cleanup fail"));
+      vi.mocked(tauri.logout).mockResolvedValue(undefined);
+
+      await logout();
+
+      expect(authState.user).toBeNull();
+    });
+  });
+
+  describe("clearError", () => {
+    it("clears error", () => {
+      setAuthState({ error: "some error" });
+
+      clearError();
+
+      expect(authState.error).toBeNull();
+    });
+  });
+
+  describe("updateUser", () => {
+    it("merges updates into user", () => {
+      setAuthState({ user: createUser() });
+
+      updateUser({ display_name: "Alice Updated" });
+
+      expect(authState.user?.display_name).toBe("Alice Updated");
+    });
+
+    it("no-ops if user is null", () => {
+      setAuthState({ user: null });
+
+      updateUser({ display_name: "Alice" });
+
+      expect(authState.user).toBeNull();
+    });
+  });
+
+  describe("clearSetupRequired", () => {
+    it("sets setupRequired to false", () => {
+      setAuthState({ setupRequired: true });
+
+      clearSetupRequired();
+
+      expect(authState.setupRequired).toBe(false);
+    });
+  });
+});

--- a/client/src/stores/__tests__/channels.test.ts
+++ b/client/src/stores/__tests__/channels.test.ts
@@ -1,0 +1,332 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/tauri", () => ({
+  getChannels: vi.fn(),
+  getGuildChannels: vi.fn(),
+  createChannel: vi.fn(),
+  markChannelAsRead: vi.fn(),
+  markAllGuildChannelsRead: vi.fn(),
+  reorderGuildChannels: vi.fn(),
+  wsStatus: vi.fn(),
+}));
+
+vi.mock("@/stores/websocket", () => ({
+  subscribeChannel: vi.fn(),
+}));
+
+vi.mock("@/components/ui/Toast", () => ({
+  showToast: vi.fn(),
+}));
+
+import * as tauri from "@/lib/tauri";
+import { subscribeChannel } from "@/stores/websocket";
+import { showToast } from "@/components/ui/Toast";
+import type { Channel, ChannelWithUnread } from "@/lib/types";
+import {
+  channelsState,
+  setChannelsState,
+  loadChannels,
+  loadChannelsForGuild,
+  selectChannel,
+  clearSelection,
+  getChannel,
+  getUnreadCount,
+  getTotalUnreadCount,
+  incrementUnreadCount,
+  markChannelAsRead,
+  markAllGuildChannelsAsRead,
+  handleChannelReadEvent,
+  createChannel,
+  textChannels,
+  voiceChannels,
+} from "../channels";
+
+function createChannelWithUnread(overrides: Partial<ChannelWithUnread> = {}): ChannelWithUnread {
+  return {
+    id: "ch-1",
+    name: "general",
+    channel_type: "text",
+    category_id: null,
+    guild_id: "guild-1",
+    topic: null,
+    icon_url: null,
+    user_limit: null,
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    unread_count: 0,
+    ...overrides,
+  };
+}
+
+describe("channels store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setChannelsState({
+      channels: [],
+      selectedChannelId: null,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  describe("initial state", () => {
+    it("has empty channels and no selection", () => {
+      expect(channelsState.channels).toEqual([]);
+      expect(channelsState.selectedChannelId).toBeNull();
+      expect(channelsState.isLoading).toBe(false);
+      expect(channelsState.error).toBeNull();
+    });
+  });
+
+  describe("loadChannels", () => {
+    it("loads channels and auto-selects first text channel", async () => {
+      const channels: Channel[] = [
+        { id: "v1", name: "voice", channel_type: "voice", category_id: null, guild_id: "g1", topic: null, icon_url: null, user_limit: null, position: 0, created_at: "2025-01-01T00:00:00Z" },
+        { id: "t1", name: "general", channel_type: "text", category_id: null, guild_id: "g1", topic: null, icon_url: null, user_limit: null, position: 1, created_at: "2025-01-01T00:00:00Z" },
+      ];
+      vi.mocked(tauri.getChannels).mockResolvedValue(channels);
+
+      await loadChannels();
+
+      expect(channelsState.channels).toHaveLength(2);
+      expect(channelsState.selectedChannelId).toBe("t1");
+      expect(channelsState.isLoading).toBe(false);
+    });
+
+    it("sets error on failure", async () => {
+      vi.mocked(tauri.getChannels).mockRejectedValue(new Error("Network error"));
+
+      await loadChannels();
+
+      expect(channelsState.error).toBe("Network error");
+      expect(channelsState.isLoading).toBe(false);
+    });
+  });
+
+  describe("loadChannelsForGuild", () => {
+    it("loads guild channels, auto-selects first text, and subscribes", async () => {
+      const channels: ChannelWithUnread[] = [
+        createChannelWithUnread({ id: "t1", name: "general", channel_type: "text", position: 0 }),
+        createChannelWithUnread({ id: "v1", name: "voice", channel_type: "voice", position: 1 }),
+      ];
+      vi.mocked(tauri.getGuildChannels).mockResolvedValue(channels);
+      vi.mocked(tauri.wsStatus).mockResolvedValue({ type: "connected" } as any);
+      vi.mocked(subscribeChannel).mockResolvedValue(undefined);
+
+      await loadChannelsForGuild("guild-1");
+
+      expect(channelsState.channels).toEqual(channels);
+      expect(channelsState.selectedChannelId).toBe("t1");
+      expect(subscribeChannel).toHaveBeenCalledWith("t1");
+      expect(subscribeChannel).not.toHaveBeenCalledWith("v1"); // voice channels not subscribed
+    });
+
+    it("clears selection when no text channels", async () => {
+      const channels: ChannelWithUnread[] = [
+        createChannelWithUnread({ id: "v1", channel_type: "voice" }),
+      ];
+      vi.mocked(tauri.getGuildChannels).mockResolvedValue(channels);
+      vi.mocked(tauri.wsStatus).mockResolvedValue({ type: "connected" } as any);
+
+      await loadChannelsForGuild("guild-1");
+
+      expect(channelsState.selectedChannelId).toBeNull();
+    });
+
+    it("skips WS subscribe when disconnected", async () => {
+      vi.useFakeTimers();
+      try {
+        vi.mocked(tauri.getGuildChannels).mockResolvedValue([createChannelWithUnread()]);
+        vi.mocked(tauri.wsStatus).mockResolvedValue({ type: "disconnected" } as any);
+
+        const promise = loadChannelsForGuild("guild-1");
+        // Advance past the 5s polling timeout
+        await vi.advanceTimersByTimeAsync(6000);
+        await promise;
+
+        expect(subscribeChannel).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("sets error on failure", async () => {
+      vi.mocked(tauri.getGuildChannels).mockRejectedValue(new Error("fail"));
+
+      await loadChannelsForGuild("guild-1");
+
+      expect(channelsState.error).toBe("fail");
+    });
+  });
+
+  describe("selectChannel", () => {
+    it("sets selected channel ID", () => {
+      selectChannel("ch-1");
+
+      expect(channelsState.selectedChannelId).toBe("ch-1");
+    });
+  });
+
+  describe("clearSelection", () => {
+    it("clears channel selection", () => {
+      setChannelsState({ selectedChannelId: "ch-1" });
+
+      clearSelection();
+
+      expect(channelsState.selectedChannelId).toBeNull();
+    });
+  });
+
+  describe("getChannel", () => {
+    it("returns channel by ID", () => {
+      setChannelsState({ channels: [createChannelWithUnread({ id: "ch-1" })] });
+
+      expect(getChannel("ch-1")?.id).toBe("ch-1");
+    });
+
+    it("returns undefined for unknown channel", () => {
+      expect(getChannel("unknown")).toBeUndefined();
+    });
+  });
+
+  describe("getUnreadCount", () => {
+    it("returns unread count for a channel", () => {
+      setChannelsState({ channels: [createChannelWithUnread({ id: "ch-1", unread_count: 5 })] });
+
+      expect(getUnreadCount("ch-1")).toBe(5);
+    });
+
+    it("returns 0 for unknown channel", () => {
+      expect(getUnreadCount("unknown")).toBe(0);
+    });
+  });
+
+  describe("getTotalUnreadCount", () => {
+    it("sums unread across text channels only", () => {
+      setChannelsState({
+        channels: [
+          createChannelWithUnread({ id: "t1", channel_type: "text", unread_count: 3 }),
+          createChannelWithUnread({ id: "t2", channel_type: "text", unread_count: 5 }),
+          createChannelWithUnread({ id: "v1", channel_type: "voice", unread_count: 2 }),
+        ],
+      });
+
+      expect(getTotalUnreadCount()).toBe(8); // voice excluded
+    });
+  });
+
+  describe("incrementUnreadCount", () => {
+    it("increments unread count by 1", () => {
+      setChannelsState({ channels: [createChannelWithUnread({ id: "ch-1", unread_count: 3 })] });
+
+      incrementUnreadCount("ch-1");
+
+      expect(channelsState.channels[0].unread_count).toBe(4);
+    });
+  });
+
+  describe("markChannelAsRead", () => {
+    it("optimistically zeros unread and calls API", async () => {
+      setChannelsState({ channels: [createChannelWithUnread({ id: "ch-1", unread_count: 5 })] });
+      vi.mocked(tauri.markChannelAsRead).mockResolvedValue(undefined);
+
+      await markChannelAsRead("ch-1");
+
+      expect(channelsState.channels[0].unread_count).toBe(0);
+      expect(tauri.markChannelAsRead).toHaveBeenCalledWith("ch-1");
+    });
+
+    it("skips if already read", async () => {
+      setChannelsState({ channels: [createChannelWithUnread({ id: "ch-1", unread_count: 0 })] });
+
+      await markChannelAsRead("ch-1");
+
+      expect(tauri.markChannelAsRead).not.toHaveBeenCalled();
+    });
+
+    it("shows toast on API error", async () => {
+      setChannelsState({ channels: [createChannelWithUnread({ id: "ch-1", unread_count: 3 })] });
+      vi.mocked(tauri.markChannelAsRead).mockRejectedValue(new Error("fail"));
+
+      await markChannelAsRead("ch-1");
+
+      expect(showToast).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "error" }),
+      );
+    });
+  });
+
+  describe("markAllGuildChannelsAsRead", () => {
+    it("optimistically zeros unread for guild text channels", async () => {
+      setChannelsState({
+        channels: [
+          createChannelWithUnread({ id: "t1", guild_id: "g1", channel_type: "text", unread_count: 5 }),
+          createChannelWithUnread({ id: "t2", guild_id: "g1", channel_type: "text", unread_count: 3 }),
+          createChannelWithUnread({ id: "v1", guild_id: "g1", channel_type: "voice", unread_count: 1 }),
+        ],
+      });
+      vi.mocked(tauri.markAllGuildChannelsRead).mockResolvedValue(undefined);
+
+      await markAllGuildChannelsAsRead("g1");
+
+      expect(channelsState.channels[0].unread_count).toBe(0);
+      expect(channelsState.channels[1].unread_count).toBe(0);
+      expect(channelsState.channels[2].unread_count).toBe(1); // voice untouched
+    });
+  });
+
+  describe("handleChannelReadEvent", () => {
+    it("zeros unread count for the channel", () => {
+      setChannelsState({ channels: [createChannelWithUnread({ id: "ch-1", unread_count: 7 })] });
+
+      handleChannelReadEvent("ch-1");
+
+      expect(channelsState.channels[0].unread_count).toBe(0);
+    });
+  });
+
+  describe("createChannel", () => {
+    it("adds channel to store", async () => {
+      const channel: Channel = {
+        id: "new-ch",
+        name: "new-channel",
+        channel_type: "text",
+        category_id: null,
+        guild_id: "g1",
+        topic: null,
+        icon_url: null,
+        user_limit: null,
+        position: 0,
+        created_at: "2025-01-01T00:00:00Z",
+      };
+      vi.mocked(tauri.createChannel).mockResolvedValue(channel);
+
+      const result = await createChannel("new-channel", "text", "g1");
+
+      expect(result.id).toBe("new-ch");
+      expect(result.unread_count).toBe(0);
+      expect(channelsState.channels).toHaveLength(1);
+    });
+  });
+
+  describe("textChannels / voiceChannels derived", () => {
+    it("filters and sorts by position", () => {
+      setChannelsState({
+        channels: [
+          createChannelWithUnread({ id: "t2", channel_type: "text", position: 2 }),
+          createChannelWithUnread({ id: "v1", channel_type: "voice", position: 0 }),
+          createChannelWithUnread({ id: "t1", channel_type: "text", position: 1 }),
+        ],
+      });
+
+      const tc = textChannels();
+      expect(tc).toHaveLength(2);
+      expect(tc[0].id).toBe("t1");
+      expect(tc[1].id).toBe("t2");
+
+      const vc = voiceChannels();
+      expect(vc).toHaveLength(1);
+      expect(vc[0].id).toBe("v1");
+    });
+  });
+});

--- a/client/src/stores/__tests__/dms.test.ts
+++ b/client/src/stores/__tests__/dms.test.ts
@@ -1,0 +1,287 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/tauri", () => ({
+  getDMList: vi.fn(),
+  wsStatus: vi.fn(),
+  markDMAsRead: vi.fn(),
+  markAllDMsRead: vi.fn(),
+}));
+
+vi.mock("@/stores/websocket", () => ({
+  subscribeChannel: vi.fn(),
+}));
+
+vi.mock("@/components/ui/Toast", () => ({
+  showToast: vi.fn(),
+}));
+
+import * as tauri from "@/lib/tauri";
+import { subscribeChannel } from "@/stores/websocket";
+import { showToast } from "@/components/ui/Toast";
+import type { DMListItem, Message } from "@/lib/types";
+import {
+  dmsState,
+  setDmsState,
+  loadDMs,
+  selectDM,
+  selectFriendsTab,
+  updateDMLastMessage,
+  markDMAsRead,
+  markAllDMsAsRead,
+  handleDMReadEvent,
+  handleDMNameUpdated,
+  getSelectedDM,
+  getTotalUnreadCount,
+} from "../dms";
+
+function createDM(overrides: Partial<DMListItem> = {}): DMListItem {
+  return {
+    id: "dm-1",
+    name: "Alice",
+    channel_type: "dm",
+    category_id: null,
+    guild_id: null,
+    topic: null,
+    icon_url: null,
+    user_limit: null,
+    position: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    participants: [{ user_id: "user-1", username: "alice", display_name: "Alice", avatar_url: null, joined_at: "2025-01-01T00:00:00Z" }],
+    last_message: null,
+    unread_count: 0,
+    ...overrides,
+  };
+}
+
+function createMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: "msg-1",
+    channel_id: "dm-1",
+    author: { id: "user-1", username: "alice", display_name: "Alice", avatar_url: null, status: "online" },
+    content: "hello",
+    encrypted: false,
+    attachments: [],
+    reply_to: null,
+    parent_id: null,
+    thread_reply_count: 0,
+    thread_last_reply_at: null,
+    edited_at: null,
+    created_at: "2025-01-01T12:00:00Z",
+    mention_type: null,
+    reactions: [],
+    ...overrides,
+  };
+}
+
+describe("dms store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setDmsState({
+      dms: [],
+      selectedDMId: null,
+      isShowingFriends: true,
+      typingUsers: {},
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  describe("initial state", () => {
+    it("has empty DMs and friends tab active", () => {
+      expect(dmsState.dms).toEqual([]);
+      expect(dmsState.selectedDMId).toBeNull();
+      expect(dmsState.isShowingFriends).toBe(true);
+      expect(dmsState.isLoading).toBe(false);
+      expect(dmsState.error).toBeNull();
+    });
+  });
+
+  describe("loadDMs", () => {
+    it("loads DMs and subscribes to channels when WS connected", async () => {
+      const dms = [createDM(), createDM({ id: "dm-2", name: "Bob" })];
+      vi.mocked(tauri.getDMList).mockResolvedValue(dms);
+      vi.mocked(tauri.wsStatus).mockResolvedValue({ type: "connected" } as any);
+      vi.mocked(subscribeChannel).mockResolvedValue(undefined);
+
+      await loadDMs();
+
+      expect(dmsState.dms).toEqual(dms);
+      expect(dmsState.isLoading).toBe(false);
+      expect(subscribeChannel).toHaveBeenCalledTimes(2);
+    });
+
+    it("skips subscriptions when WS not connected", async () => {
+      vi.useFakeTimers();
+      try {
+        const dms = [createDM()];
+        vi.mocked(tauri.getDMList).mockResolvedValue(dms);
+        vi.mocked(tauri.wsStatus).mockResolvedValue({ type: "disconnected" } as any);
+
+        const promise = loadDMs();
+        // Advance past the 5s polling timeout
+        await vi.advanceTimersByTimeAsync(6000);
+        await promise;
+
+        expect(dmsState.dms).toEqual(dms);
+        expect(subscribeChannel).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("sets error on failure", async () => {
+      vi.mocked(tauri.getDMList).mockRejectedValue(new Error("Network error"));
+
+      await loadDMs();
+
+      expect(dmsState.dms).toEqual([]);
+      expect(dmsState.isLoading).toBe(false);
+      expect(dmsState.error).toBe("Network error");
+    });
+  });
+
+  describe("selectDM", () => {
+    it("sets selected DM and hides friends tab", () => {
+      selectDM("dm-1");
+
+      expect(dmsState.selectedDMId).toBe("dm-1");
+      expect(dmsState.isShowingFriends).toBe(false);
+    });
+  });
+
+  describe("selectFriendsTab", () => {
+    it("clears DM selection and shows friends", () => {
+      setDmsState({ selectedDMId: "dm-1", isShowingFriends: false });
+
+      selectFriendsTab();
+
+      expect(dmsState.selectedDMId).toBeNull();
+      expect(dmsState.isShowingFriends).toBe(true);
+    });
+  });
+
+  describe("updateDMLastMessage", () => {
+    it("updates last message and increments unread", () => {
+      setDmsState({ dms: [createDM({ id: "dm-1", unread_count: 0 })] });
+      const msg = createMessage({ channel_id: "dm-1" });
+
+      updateDMLastMessage("dm-1", msg);
+
+      expect(dmsState.dms[0].last_message).toEqual({
+        id: msg.id,
+        content: msg.content,
+        user_id: msg.author.id,
+        username: msg.author.username,
+        created_at: msg.created_at,
+      });
+      expect(dmsState.dms[0].unread_count).toBe(1);
+    });
+
+    it("ignores unknown channel", () => {
+      setDmsState({ dms: [createDM()] });
+      const msg = createMessage({ channel_id: "unknown" });
+
+      updateDMLastMessage("unknown", msg);
+
+      expect(dmsState.dms[0].last_message).toBeNull();
+    });
+  });
+
+  describe("markDMAsRead", () => {
+    it("marks DM as read on success", async () => {
+      setDmsState({
+        dms: [createDM({ id: "dm-1", unread_count: 5, last_message: { id: "msg-1", content: "hi", user_id: "u1", username: "alice", created_at: "2025-01-01T00:00:00Z" } })],
+      });
+      vi.mocked(tauri.markDMAsRead).mockResolvedValue(undefined);
+
+      await markDMAsRead("dm-1");
+
+      expect(dmsState.dms[0].unread_count).toBe(0);
+      expect(tauri.markDMAsRead).toHaveBeenCalledWith("dm-1", "msg-1");
+    });
+
+    it("skips if already read", async () => {
+      setDmsState({ dms: [createDM({ id: "dm-1", unread_count: 0 })] });
+
+      await markDMAsRead("dm-1");
+
+      expect(tauri.markDMAsRead).not.toHaveBeenCalled();
+    });
+
+    it("shows toast on error", async () => {
+      setDmsState({
+        dms: [createDM({ id: "dm-1", unread_count: 3, last_message: { id: "msg-1", content: "hi", user_id: "u1", username: "alice", created_at: "2025-01-01T00:00:00Z" } })],
+      });
+      vi.mocked(tauri.markDMAsRead).mockRejectedValue(new Error("fail"));
+
+      await markDMAsRead("dm-1");
+
+      expect(showToast).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "error" }),
+      );
+    });
+  });
+
+  describe("markAllDMsAsRead", () => {
+    it("optimistically zeros all unread counts", async () => {
+      setDmsState({
+        dms: [
+          createDM({ id: "dm-1", unread_count: 3 }),
+          createDM({ id: "dm-2", unread_count: 5 }),
+        ],
+      });
+      vi.mocked(tauri.markAllDMsRead).mockResolvedValue(undefined);
+
+      await markAllDMsAsRead();
+
+      expect(dmsState.dms[0].unread_count).toBe(0);
+      expect(dmsState.dms[1].unread_count).toBe(0);
+    });
+  });
+
+  describe("handleDMReadEvent", () => {
+    it("zeros unread count for the channel", () => {
+      setDmsState({ dms: [createDM({ id: "dm-1", unread_count: 7 })] });
+
+      handleDMReadEvent("dm-1");
+
+      expect(dmsState.dms[0].unread_count).toBe(0);
+    });
+  });
+
+  describe("handleDMNameUpdated", () => {
+    it("updates DM name", () => {
+      setDmsState({ dms: [createDM({ id: "dm-1", name: "Old Name" })] });
+
+      handleDMNameUpdated("dm-1", "New Name");
+
+      expect(dmsState.dms[0].name).toBe("New Name");
+    });
+  });
+
+  describe("getTotalUnreadCount", () => {
+    it("sums unread counts across all DMs", () => {
+      setDmsState({
+        dms: [
+          createDM({ id: "dm-1", unread_count: 3 }),
+          createDM({ id: "dm-2", unread_count: 5 }),
+        ],
+      });
+
+      expect(getTotalUnreadCount()).toBe(8);
+    });
+  });
+
+  describe("getSelectedDM", () => {
+    it("returns null when no DM selected", () => {
+      expect(getSelectedDM()).toBeNull();
+    });
+
+    it("returns the selected DM", () => {
+      const dm = createDM({ id: "dm-1" });
+      setDmsState({ dms: [dm], selectedDMId: "dm-1" });
+
+      expect(getSelectedDM()?.id).toBe("dm-1");
+    });
+  });
+});

--- a/client/src/stores/__tests__/friends.test.ts
+++ b/client/src/stores/__tests__/friends.test.ts
@@ -1,0 +1,278 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/tauri", () => ({
+  getFriends: vi.fn(),
+  getPendingFriends: vi.fn(),
+  getBlockedFriends: vi.fn(),
+  sendFriendRequest: vi.fn(),
+  acceptFriendRequest: vi.fn(),
+  rejectFriendRequest: vi.fn(),
+  removeFriend: vi.fn(),
+  blockUser: vi.fn(),
+  unblockUser: vi.fn(),
+}));
+
+vi.mock("@/components/ui/Toast", () => ({
+  showToast: vi.fn(),
+}));
+
+import * as tauri from "@/lib/tauri";
+import { showToast } from "@/components/ui/Toast";
+import type { Friend } from "@/lib/types";
+import {
+  friendsState,
+  setFriendsState,
+  loadFriends,
+  loadPendingRequests,
+  loadBlocked,
+  sendFriendRequest,
+  acceptFriendRequest,
+  rejectFriendRequest,
+  removeFriend,
+  blockUser,
+  unblockUser,
+  handleUserBlocked,
+  handleUserUnblocked,
+  getOnlineFriends,
+} from "../friends";
+
+function createFriend(overrides: Partial<Friend> = {}): Friend {
+  return {
+    user_id: "user-1",
+    username: "alice",
+    display_name: "Alice",
+    avatar_url: null,
+    status_message: null,
+    is_online: false,
+    friendship_id: "fs-1",
+    friendship_status: "accepted",
+    created_at: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("friends store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setFriendsState({
+      friends: [],
+      pendingRequests: [],
+      blocked: [],
+      isLoading: false,
+      isPendingLoading: false,
+      isBlockedLoading: false,
+      error: null,
+    });
+  });
+
+  describe("initial state", () => {
+    it("has empty arrays and no loading/error", () => {
+      expect(friendsState.friends).toEqual([]);
+      expect(friendsState.pendingRequests).toEqual([]);
+      expect(friendsState.blocked).toEqual([]);
+      expect(friendsState.isLoading).toBe(false);
+      expect(friendsState.error).toBeNull();
+    });
+  });
+
+  describe("loadFriends", () => {
+    it("loads friends on success", async () => {
+      const friends = [createFriend(), createFriend({ user_id: "user-2", friendship_id: "fs-2" })];
+      vi.mocked(tauri.getFriends).mockResolvedValue(friends);
+
+      await loadFriends();
+
+      expect(friendsState.friends).toEqual(friends);
+      expect(friendsState.isLoading).toBe(false);
+      expect(friendsState.error).toBeNull();
+    });
+
+    it("sets error on failure", async () => {
+      vi.mocked(tauri.getFriends).mockRejectedValue(new Error("Network error"));
+
+      await loadFriends();
+
+      expect(friendsState.friends).toEqual([]);
+      expect(friendsState.isLoading).toBe(false);
+      expect(friendsState.error).toBe("Network error");
+    });
+  });
+
+  describe("loadPendingRequests", () => {
+    it("loads pending requests on success", async () => {
+      const pending = [createFriend({ friendship_status: "pending" })];
+      vi.mocked(tauri.getPendingFriends).mockResolvedValue(pending);
+
+      await loadPendingRequests();
+
+      expect(friendsState.pendingRequests).toEqual(pending);
+      expect(friendsState.isPendingLoading).toBe(false);
+    });
+
+    it("clears loading on failure", async () => {
+      vi.mocked(tauri.getPendingFriends).mockRejectedValue(new Error("fail"));
+
+      await loadPendingRequests();
+
+      expect(friendsState.isPendingLoading).toBe(false);
+    });
+  });
+
+  describe("loadBlocked", () => {
+    it("loads blocked users on success", async () => {
+      const blocked = [createFriend({ friendship_status: "blocked" })];
+      vi.mocked(tauri.getBlockedFriends).mockResolvedValue(blocked);
+
+      await loadBlocked();
+
+      expect(friendsState.blocked).toEqual(blocked);
+      expect(friendsState.isBlockedLoading).toBe(false);
+    });
+
+    it("clears loading on failure", async () => {
+      vi.mocked(tauri.getBlockedFriends).mockRejectedValue(new Error("fail"));
+
+      await loadBlocked();
+
+      expect(friendsState.isBlockedLoading).toBe(false);
+    });
+  });
+
+  describe("sendFriendRequest", () => {
+    it("sends request and reloads pending", async () => {
+      vi.mocked(tauri.sendFriendRequest).mockResolvedValue({} as any);
+      vi.mocked(tauri.getPendingFriends).mockResolvedValue([]);
+
+      await sendFriendRequest("bob");
+
+      expect(tauri.sendFriendRequest).toHaveBeenCalledWith("bob");
+      expect(tauri.getPendingFriends).toHaveBeenCalled();
+    });
+
+    it("shows toast on error and re-throws", async () => {
+      vi.mocked(tauri.sendFriendRequest).mockRejectedValue(new Error("not found"));
+
+      await expect(sendFriendRequest("bob")).rejects.toThrow();
+      expect(showToast).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "error", title: "Friend Request Failed" }),
+      );
+    });
+  });
+
+  describe("acceptFriendRequest", () => {
+    it("accepts and reloads friends + pending", async () => {
+      vi.mocked(tauri.acceptFriendRequest).mockResolvedValue({} as any);
+      vi.mocked(tauri.getFriends).mockResolvedValue([]);
+      vi.mocked(tauri.getPendingFriends).mockResolvedValue([]);
+
+      await acceptFriendRequest("fs-1");
+
+      expect(tauri.acceptFriendRequest).toHaveBeenCalledWith("fs-1");
+      expect(tauri.getFriends).toHaveBeenCalled();
+      expect(tauri.getPendingFriends).toHaveBeenCalled();
+    });
+  });
+
+  describe("rejectFriendRequest", () => {
+    it("rejects and reloads pending", async () => {
+      vi.mocked(tauri.rejectFriendRequest).mockResolvedValue(undefined);
+      vi.mocked(tauri.getPendingFriends).mockResolvedValue([]);
+
+      await rejectFriendRequest("fs-1");
+
+      expect(tauri.rejectFriendRequest).toHaveBeenCalledWith("fs-1");
+      expect(tauri.getPendingFriends).toHaveBeenCalled();
+    });
+  });
+
+  describe("removeFriend", () => {
+    it("removes friend optimistically from list", async () => {
+      const friend = createFriend({ friendship_id: "fs-1" });
+      setFriendsState({ friends: [friend] });
+      vi.mocked(tauri.removeFriend).mockResolvedValue(undefined);
+
+      await removeFriend("fs-1");
+
+      expect(friendsState.friends).toEqual([]);
+    });
+
+    it("shows toast on error and re-throws", async () => {
+      setFriendsState({ friends: [createFriend()] });
+      vi.mocked(tauri.removeFriend).mockRejectedValue(new Error("fail"));
+
+      await expect(removeFriend("fs-1")).rejects.toThrow();
+      expect(showToast).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "error", title: "Remove Failed" }),
+      );
+    });
+  });
+
+  describe("blockUser", () => {
+    it("blocks user and reloads all lists", async () => {
+      vi.mocked(tauri.blockUser).mockResolvedValue({} as any);
+      vi.mocked(tauri.getFriends).mockResolvedValue([]);
+      vi.mocked(tauri.getPendingFriends).mockResolvedValue([]);
+      vi.mocked(tauri.getBlockedFriends).mockResolvedValue([]);
+
+      await blockUser("user-1");
+
+      expect(tauri.blockUser).toHaveBeenCalledWith("user-1");
+      expect(tauri.getFriends).toHaveBeenCalled();
+      expect(tauri.getPendingFriends).toHaveBeenCalled();
+      expect(tauri.getBlockedFriends).toHaveBeenCalled();
+    });
+  });
+
+  describe("unblockUser", () => {
+    it("removes user from blocked list optimistically", async () => {
+      const blocked = createFriend({ user_id: "user-1", friendship_status: "blocked" });
+      setFriendsState({ blocked: [blocked] });
+      vi.mocked(tauri.unblockUser).mockResolvedValue(undefined);
+
+      await unblockUser("user-1");
+
+      expect(friendsState.blocked).toEqual([]);
+    });
+  });
+
+  describe("handleUserBlocked (WS handler)", () => {
+    it("removes user from friends and pending, reloads blocked", async () => {
+      const friend = createFriend({ user_id: "user-1" });
+      const pending = createFriend({ user_id: "user-1", friendship_status: "pending" });
+      setFriendsState({ friends: [friend], pendingRequests: [pending] });
+      vi.mocked(tauri.getBlockedFriends).mockResolvedValue([]);
+
+      handleUserBlocked("user-1");
+
+      expect(friendsState.friends).toEqual([]);
+      expect(friendsState.pendingRequests).toEqual([]);
+    });
+  });
+
+  describe("handleUserUnblocked (WS handler)", () => {
+    it("removes user from blocked list", () => {
+      const blocked = createFriend({ user_id: "user-1", friendship_status: "blocked" });
+      setFriendsState({ blocked: [blocked] });
+
+      handleUserUnblocked("user-1");
+
+      expect(friendsState.blocked).toEqual([]);
+    });
+  });
+
+  describe("getOnlineFriends", () => {
+    it("returns only online friends", () => {
+      setFriendsState({
+        friends: [
+          createFriend({ user_id: "u1", is_online: true }),
+          createFriend({ user_id: "u2", is_online: false }),
+          createFriend({ user_id: "u3", is_online: true }),
+        ],
+      });
+
+      const online = getOnlineFriends();
+      expect(online).toHaveLength(2);
+      expect(online.map((f) => f.user_id)).toEqual(["u1", "u3"]);
+    });
+  });
+});

--- a/client/src/stores/__tests__/guilds.test.ts
+++ b/client/src/stores/__tests__/guilds.test.ts
@@ -1,0 +1,419 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/tauri", () => ({
+  getGuilds: vi.fn(),
+  getGuildMembers: vi.fn(),
+  getGuildChannels: vi.fn(),
+  createGuild: vi.fn(),
+  updateGuild: vi.fn(),
+  deleteGuild: vi.fn(),
+  joinGuild: vi.fn(),
+  leaveGuild: vi.fn(),
+  getGuildInvites: vi.fn(),
+  createGuildInvite: vi.fn(),
+  deleteGuildInvite: vi.fn(),
+  joinViaInvite: vi.fn(),
+  kickGuildMember: vi.fn(),
+}));
+
+vi.mock("@/components/ui/Toast", () => ({
+  showToast: vi.fn(),
+}));
+
+// Dynamic imports used by selectGuild / selectHome — mock the modules
+vi.mock("./channels", () => ({
+  loadChannelsForGuild: vi.fn(),
+  loadDMChannels: vi.fn(),
+  channelsState: { channels: [] },
+}));
+
+vi.mock("./voice", () => ({
+  voiceState: { channelId: null },
+  leaveVoice: vi.fn(),
+}));
+
+import * as tauri from "@/lib/tauri";
+import type { Guild, GuildMember, GuildInvite } from "@/lib/types";
+import {
+  guildsState,
+  setGuildsState,
+  loadGuilds,
+  loadGuildMembers,
+  getActiveGuild,
+  createGuild,
+  updateGuild,
+  deleteGuild,
+  joinGuild,
+  leaveGuild,
+  loadGuildInvites,
+  createInvite,
+  deleteInvite,
+  kickMember,
+  isGuildOwner,
+  patchGuild,
+  areThreadsEnabled,
+  getGuildUnreadCount,
+  incrementGuildUnread,
+  clearGuildUnread,
+  getGuildIdForChannel,
+  joinViaInviteCode,
+  selectGuild,
+  selectHome,
+} from "../guilds";
+
+function createGuildObj(overrides: Partial<Guild> = {}): Guild {
+  return {
+    id: "guild-1",
+    name: "Test Guild",
+    owner_id: "owner-1",
+    icon_url: null,
+    description: null,
+    threads_enabled: true,
+    created_at: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function createMember(overrides: Partial<GuildMember> = {}): GuildMember {
+  return {
+    user_id: "user-1",
+    username: "alice",
+    display_name: "Alice",
+    avatar_url: null,
+    nickname: null,
+    joined_at: "2025-01-01T00:00:00Z",
+    status: "online",
+    last_seen_at: null,
+    ...overrides,
+  };
+}
+
+function createInviteObj(overrides: Partial<GuildInvite> = {}): GuildInvite {
+  return {
+    id: "inv-1",
+    guild_id: "guild-1",
+    code: "ABC123",
+    created_by: "owner-1",
+    expires_at: null,
+    use_count: 0,
+    created_at: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("guilds store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setGuildsState({
+      guilds: [],
+      activeGuildId: null,
+      members: {},
+      invites: {},
+      guildChannels: {},
+      guildUnreadCounts: {},
+      channelGuildMap: {},
+      isLoading: false,
+      isMembersLoading: false,
+      isInvitesLoading: false,
+      error: null,
+    });
+  });
+
+  describe("initial state", () => {
+    it("has empty arrays and no active guild", () => {
+      expect(guildsState.guilds).toEqual([]);
+      expect(guildsState.activeGuildId).toBeNull();
+      expect(guildsState.isLoading).toBe(false);
+      expect(guildsState.error).toBeNull();
+    });
+  });
+
+  describe("loadGuilds", () => {
+    it("loads guilds and prefetches unread counts", async () => {
+      const guilds = [createGuildObj({ id: "g1" }), createGuildObj({ id: "g2" })];
+      vi.mocked(tauri.getGuilds).mockResolvedValue(guilds);
+      vi.mocked(tauri.getGuildChannels).mockResolvedValue([]);
+
+      await loadGuilds();
+
+      expect(guildsState.guilds).toEqual(guilds);
+      expect(guildsState.isLoading).toBe(false);
+      // getGuildChannels called for each guild during unread prefetch
+      expect(tauri.getGuildChannels).toHaveBeenCalledTimes(2);
+    });
+
+    it("sets error on failure", async () => {
+      vi.mocked(tauri.getGuilds).mockRejectedValue(new Error("fail"));
+
+      await loadGuilds();
+
+      expect(guildsState.error).toBe("fail");
+      expect(guildsState.isLoading).toBe(false);
+    });
+  });
+
+  describe("loadGuildMembers", () => {
+    it("loads members for a guild", async () => {
+      const members = [createMember()];
+      vi.mocked(tauri.getGuildMembers).mockResolvedValue(members);
+
+      await loadGuildMembers("guild-1");
+
+      expect(guildsState.members["guild-1"]).toEqual(members);
+      expect(guildsState.isMembersLoading).toBe(false);
+    });
+  });
+
+  describe("getActiveGuild", () => {
+    it("returns null when no guild active", () => {
+      expect(getActiveGuild()).toBeNull();
+    });
+
+    it("returns the active guild", () => {
+      setGuildsState({ guilds: [createGuildObj()], activeGuildId: "guild-1" });
+
+      expect(getActiveGuild()?.id).toBe("guild-1");
+    });
+  });
+
+  describe("createGuild", () => {
+    it("creates and adds guild to store", async () => {
+      const guild = createGuildObj({ id: "new-g" });
+      vi.mocked(tauri.createGuild).mockResolvedValue(guild);
+
+      const result = await createGuild("Test Guild");
+
+      expect(result.id).toBe("new-g");
+      expect(guildsState.guilds).toHaveLength(1);
+    });
+  });
+
+  describe("updateGuild", () => {
+    it("updates guild in store", async () => {
+      setGuildsState({ guilds: [createGuildObj({ id: "g1", name: "Old" })] });
+      const updated = createGuildObj({ id: "g1", name: "New" });
+      vi.mocked(tauri.updateGuild).mockResolvedValue(updated);
+
+      await updateGuild("g1", "New");
+
+      expect(guildsState.guilds[0].name).toBe("New");
+    });
+  });
+
+  describe("deleteGuild", () => {
+    it("removes guild from store", async () => {
+      setGuildsState({ guilds: [createGuildObj({ id: "g1" })] });
+      vi.mocked(tauri.deleteGuild).mockResolvedValue(undefined);
+
+      await deleteGuild("g1");
+
+      expect(guildsState.guilds).toEqual([]);
+    });
+
+    it("selects home if deleted guild was active", async () => {
+      setGuildsState({ guilds: [createGuildObj({ id: "g1" })], activeGuildId: "g1" });
+      vi.mocked(tauri.deleteGuild).mockResolvedValue(undefined);
+
+      await deleteGuild("g1");
+
+      // selectHome sets activeGuildId to null
+      expect(guildsState.activeGuildId).toBeNull();
+    });
+  });
+
+  describe("joinGuild", () => {
+    it("joins guild and reloads", async () => {
+      vi.mocked(tauri.joinGuild).mockResolvedValue(undefined);
+      vi.mocked(tauri.getGuilds).mockResolvedValue([createGuildObj()]);
+      vi.mocked(tauri.getGuildChannels).mockResolvedValue([]);
+
+      await joinGuild("g1", "invite123");
+
+      expect(tauri.joinGuild).toHaveBeenCalledWith("g1", "invite123");
+      expect(tauri.getGuilds).toHaveBeenCalled();
+    });
+  });
+
+  describe("leaveGuild", () => {
+    it("leaves guild and removes from store", async () => {
+      setGuildsState({ guilds: [createGuildObj({ id: "g1" })] });
+      vi.mocked(tauri.leaveGuild).mockResolvedValue(undefined);
+
+      await leaveGuild("g1");
+
+      expect(guildsState.guilds).toEqual([]);
+    });
+  });
+
+  describe("loadGuildInvites", () => {
+    it("loads invites for a guild", async () => {
+      const invites = [createInviteObj()];
+      vi.mocked(tauri.getGuildInvites).mockResolvedValue(invites);
+
+      await loadGuildInvites("guild-1");
+
+      expect(guildsState.invites["guild-1"]).toEqual(invites);
+      expect(guildsState.isInvitesLoading).toBe(false);
+    });
+  });
+
+  describe("createInvite", () => {
+    it("creates invite and prepends to list", async () => {
+      const invite = createInviteObj({ code: "NEW" });
+      vi.mocked(tauri.createGuildInvite).mockResolvedValue(invite);
+
+      const result = await createInvite("guild-1");
+
+      expect(result.code).toBe("NEW");
+      expect(guildsState.invites["guild-1"]).toHaveLength(1);
+    });
+  });
+
+  describe("deleteInvite", () => {
+    it("removes invite from list", async () => {
+      setGuildsState("invites", "guild-1", [createInviteObj({ code: "ABC" })]);
+      vi.mocked(tauri.deleteGuildInvite).mockResolvedValue(undefined);
+
+      await deleteInvite("guild-1", "ABC");
+
+      expect(guildsState.invites["guild-1"]).toEqual([]);
+    });
+  });
+
+  describe("kickMember", () => {
+    it("kicks member and removes from store", async () => {
+      setGuildsState("members", "guild-1", [createMember({ user_id: "u1" })]);
+      vi.mocked(tauri.kickGuildMember).mockResolvedValue(undefined);
+
+      await kickMember("guild-1", "u1");
+
+      expect(guildsState.members["guild-1"]).toEqual([]);
+    });
+  });
+
+  describe("isGuildOwner", () => {
+    it("returns true for owner", () => {
+      setGuildsState({ guilds: [createGuildObj({ id: "g1", owner_id: "owner-1" })] });
+
+      expect(isGuildOwner("g1", "owner-1")).toBe(true);
+    });
+
+    it("returns false for non-owner", () => {
+      setGuildsState({ guilds: [createGuildObj({ id: "g1", owner_id: "owner-1" })] });
+
+      expect(isGuildOwner("g1", "other")).toBe(false);
+    });
+  });
+
+  describe("patchGuild", () => {
+    it("updates valid fields", () => {
+      setGuildsState({ guilds: [createGuildObj({ id: "g1", name: "Old" })] });
+
+      patchGuild("g1", { name: "New", description: "desc" });
+
+      expect(guildsState.guilds[0].name).toBe("New");
+      expect(guildsState.guilds[0].description).toBe("desc");
+    });
+
+    it("ignores unknown fields", () => {
+      setGuildsState({ guilds: [createGuildObj({ id: "g1" })] });
+
+      patchGuild("g1", { invalid_field: "value" });
+
+      // Should not throw and guild should be unchanged
+      expect(guildsState.guilds[0].name).toBe("Test Guild");
+    });
+
+    it("ignores unknown guild", () => {
+      patchGuild("unknown", { name: "New" });
+
+      // No error expected
+    });
+  });
+
+  describe("areThreadsEnabled", () => {
+    it("returns true for null/undefined guild ID (DMs)", () => {
+      expect(areThreadsEnabled(null)).toBe(true);
+      expect(areThreadsEnabled(undefined)).toBe(true);
+    });
+
+    it("returns guild's threads_enabled setting", () => {
+      setGuildsState({ guilds: [createGuildObj({ id: "g1", threads_enabled: false })] });
+
+      expect(areThreadsEnabled("g1")).toBe(false);
+    });
+
+    it("defaults to true for unknown guild", () => {
+      expect(areThreadsEnabled("unknown")).toBe(true);
+    });
+  });
+
+  describe("unread count management", () => {
+    it("getGuildUnreadCount returns 0 by default", () => {
+      expect(getGuildUnreadCount("g1")).toBe(0);
+    });
+
+    it("incrementGuildUnread increments count", () => {
+      incrementGuildUnread("g1");
+      incrementGuildUnread("g1");
+
+      expect(getGuildUnreadCount("g1")).toBe(2);
+    });
+
+    it("clearGuildUnread resets to 0", () => {
+      setGuildsState("guildUnreadCounts", "g1", 5);
+
+      clearGuildUnread("g1");
+
+      expect(getGuildUnreadCount("g1")).toBe(0);
+    });
+  });
+
+  describe("getGuildIdForChannel", () => {
+    it("returns guild ID from channel map", () => {
+      setGuildsState("channelGuildMap", "ch-1", "g1");
+
+      expect(getGuildIdForChannel("ch-1")).toBe("g1");
+    });
+
+    it("returns undefined for unmapped channel", () => {
+      expect(getGuildIdForChannel("unknown")).toBeUndefined();
+    });
+  });
+
+  describe("joinViaInviteCode", () => {
+    it("joins via invite code, reloads guilds and selects the joined guild", async () => {
+      vi.mocked(tauri.joinViaInvite).mockResolvedValue({ guild_id: "g1" } as any);
+      vi.mocked(tauri.getGuilds).mockResolvedValue([createGuildObj({ id: "g1" })]);
+      vi.mocked(tauri.getGuildChannels).mockResolvedValue([]);
+      vi.mocked(tauri.getGuildMembers).mockResolvedValue([]);
+
+      await joinViaInviteCode("INVITE");
+
+      expect(tauri.joinViaInvite).toHaveBeenCalledWith("INVITE");
+    });
+  });
+
+  describe("selectGuild", () => {
+    it("sets active guild and clears unread", async () => {
+      setGuildsState({ guildUnreadCounts: { "g1": 5 } });
+      vi.mocked(tauri.getGuildChannels).mockResolvedValue([]);
+      vi.mocked(tauri.getGuildMembers).mockResolvedValue([]);
+
+      await selectGuild("g1");
+
+      expect(guildsState.activeGuildId).toBe("g1");
+      expect(guildsState.guildUnreadCounts["g1"]).toBe(0);
+    });
+  });
+
+  describe("selectHome", () => {
+    it("clears active guild", async () => {
+      setGuildsState({ activeGuildId: "g1" });
+
+      await selectHome();
+
+      expect(guildsState.activeGuildId).toBeNull();
+    });
+  });
+});

--- a/client/src/stores/__tests__/messages.test.ts
+++ b/client/src/stores/__tests__/messages.test.ts
@@ -1,0 +1,317 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/tauri", () => ({
+  getMessages: vi.fn(),
+  sendMessageWithStatus: vi.fn(),
+  sendMessage: vi.fn(),
+  getOurCurve25519Key: vi.fn(),
+}));
+
+vi.mock("@/stores/e2ee", () => ({
+  e2eeStore: {
+    status: vi.fn(() => ({ initialized: false })),
+    decrypt: vi.fn(),
+  },
+}));
+
+vi.mock("@/stores/auth", () => ({
+  currentUser: vi.fn(() => ({ id: "me", username: "me" })),
+}));
+
+vi.mock("@/components/ui/Toast", () => ({
+  showToast: vi.fn(),
+}));
+
+import * as tauri from "@/lib/tauri";
+import { showToast } from "@/components/ui/Toast";
+import type { Message, PaginatedMessages } from "@/lib/types";
+import {
+  messagesState,
+  setMessagesState,
+  loadMessages,
+  loadInitialMessages,
+  sendMessage,
+  addMessage,
+  updateMessage,
+  removeMessage,
+  getChannelMessages,
+  isLoadingMessages,
+  hasMoreMessages,
+  clearChannelMessages,
+  clearCurve25519KeyCache,
+} from "../messages";
+
+function createMessage(id: string, channelId = "ch-1"): Message {
+  return {
+    id,
+    channel_id: channelId,
+    author: { id: "user-1", username: "alice", display_name: "Alice", avatar_url: null, status: "online" },
+    content: `content-${id}`,
+    encrypted: false,
+    attachments: [],
+    reply_to: null,
+    parent_id: null,
+    thread_reply_count: 0,
+    thread_last_reply_at: null,
+    edited_at: null,
+    created_at: new Date().toISOString(),
+    mention_type: null,
+    reactions: [],
+  };
+}
+
+describe("messages store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setMessagesState({
+      byChannel: {},
+      loadingChannels: {},
+      hasMore: {},
+      error: null,
+    });
+  });
+
+  describe("initial state", () => {
+    it("has empty message maps and no error", () => {
+      expect(messagesState.byChannel).toEqual({});
+      expect(messagesState.loadingChannels).toEqual({});
+      expect(messagesState.hasMore).toEqual({});
+      expect(messagesState.error).toBeNull();
+    });
+  });
+
+  describe("loadMessages", () => {
+    it("loads messages for a channel", async () => {
+      const msgs = [createMessage("m1"), createMessage("m2")];
+      vi.mocked(tauri.getMessages).mockResolvedValue({
+        items: msgs,
+        has_more: false,
+        next_cursor: null,
+      } as PaginatedMessages);
+
+      await loadMessages("ch-1");
+
+      // Messages are reversed (server returns newest-first)
+      expect(messagesState.byChannel["ch-1"]).toHaveLength(2);
+      expect(messagesState.byChannel["ch-1"][0].id).toBe("m2");
+      expect(messagesState.byChannel["ch-1"][1].id).toBe("m1");
+      expect(messagesState.hasMore["ch-1"]).toBe(false);
+      expect(messagesState.loadingChannels["ch-1"]).toBe(false);
+    });
+
+    it("paginates using oldest message as cursor", async () => {
+      setMessagesState("byChannel", "ch-1", [createMessage("m-old")]);
+      vi.mocked(tauri.getMessages).mockResolvedValue({
+        items: [createMessage("m-older")],
+        has_more: true,
+        next_cursor: "m-older",
+      } as PaginatedMessages);
+
+      await loadMessages("ch-1");
+
+      expect(tauri.getMessages).toHaveBeenCalledWith("ch-1", "m-old", 50);
+      expect(messagesState.hasMore["ch-1"]).toBe(true);
+    });
+
+    it("prevents concurrent loads for the same channel", async () => {
+      let resolveFirst: (v: PaginatedMessages) => void;
+      const firstCall = new Promise<PaginatedMessages>((resolve) => { resolveFirst = resolve; });
+      vi.mocked(tauri.getMessages).mockReturnValueOnce(firstCall);
+
+      const p1 = loadMessages("ch-1");
+      const p2 = loadMessages("ch-1"); // Should be no-op
+
+      resolveFirst!({ items: [createMessage("m1")], has_more: false, next_cursor: null });
+      await p1;
+      await p2;
+
+      expect(tauri.getMessages).toHaveBeenCalledTimes(1);
+    });
+
+    it("sets error on failure", async () => {
+      vi.mocked(tauri.getMessages).mockRejectedValue(new Error("Network error"));
+
+      await loadMessages("ch-1");
+
+      expect(messagesState.error).toBe("Network error");
+      expect(messagesState.loadingChannels["ch-1"]).toBe(false);
+    });
+  });
+
+  describe("loadInitialMessages", () => {
+    it("clears existing messages and loads fresh", async () => {
+      setMessagesState("byChannel", "ch-1", [createMessage("old")]);
+      vi.mocked(tauri.getMessages).mockResolvedValue({
+        items: [createMessage("new")],
+        has_more: false,
+        next_cursor: null,
+      } as PaginatedMessages);
+
+      await loadInitialMessages("ch-1");
+
+      expect(messagesState.byChannel["ch-1"]).toHaveLength(1);
+      expect(messagesState.byChannel["ch-1"][0].id).toBe("new");
+    });
+  });
+
+  describe("sendMessage", () => {
+    it("sends message and adds to store", async () => {
+      const sent = createMessage("sent-1");
+      vi.mocked(tauri.sendMessageWithStatus).mockResolvedValue({ message: sent, status: 201 });
+
+      const result = await sendMessage("ch-1", "hello");
+
+      expect(result?.id).toBe("sent-1");
+      expect(messagesState.byChannel["ch-1"]).toHaveLength(1);
+    });
+
+    it("returns null for empty/whitespace content", async () => {
+      const result = await sendMessage("ch-1", "   ");
+
+      expect(result).toBeNull();
+      expect(tauri.sendMessageWithStatus).not.toHaveBeenCalled();
+    });
+
+    it("suppresses local echo for 202 status (slash commands)", async () => {
+      const sent = createMessage("cmd-1");
+      vi.mocked(tauri.sendMessageWithStatus).mockResolvedValue({ message: sent, status: 202 });
+
+      await sendMessage("ch-1", "/roll");
+
+      expect(messagesState.byChannel["ch-1"]).toBeUndefined();
+    });
+
+    it("deduplicates by message ID", async () => {
+      const sent = createMessage("dup-1");
+      setMessagesState("byChannel", "ch-1", [sent]);
+      vi.mocked(tauri.sendMessageWithStatus).mockResolvedValue({ message: sent, status: 201 });
+
+      await sendMessage("ch-1", "hello");
+
+      expect(messagesState.byChannel["ch-1"]).toHaveLength(1);
+    });
+
+    it("shows toast on error", async () => {
+      vi.mocked(tauri.sendMessageWithStatus).mockRejectedValue(new Error("fail"));
+
+      const result = await sendMessage("ch-1", "hello");
+
+      expect(result).toBeNull();
+      expect(showToast).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "error", title: "Send Failed" }),
+      );
+      expect(messagesState.error).toBe("fail");
+    });
+  });
+
+  describe("addMessage", () => {
+    it("appends message to channel", async () => {
+      const msg = createMessage("ws-1");
+
+      await addMessage(msg);
+
+      expect(messagesState.byChannel["ch-1"]).toHaveLength(1);
+      expect(messagesState.byChannel["ch-1"][0].id).toBe("ws-1");
+    });
+
+    it("deduplicates by ID", async () => {
+      const msg = createMessage("dup-1");
+      setMessagesState("byChannel", "ch-1", [msg]);
+
+      await addMessage(msg);
+
+      expect(messagesState.byChannel["ch-1"]).toHaveLength(1);
+    });
+  });
+
+  describe("updateMessage", () => {
+    it("updates message in-place", () => {
+      const original = createMessage("m1");
+      setMessagesState("byChannel", "ch-1", [original]);
+
+      const updated = { ...original, content: "edited content", edited_at: "2025-01-01T12:00:00Z" };
+      updateMessage(updated);
+
+      expect(messagesState.byChannel["ch-1"][0].content).toBe("edited content");
+    });
+
+    it("ignores update for missing message", () => {
+      setMessagesState("byChannel", "ch-1", [createMessage("m1")]);
+
+      updateMessage({ ...createMessage("unknown"), content: "edited" });
+
+      expect(messagesState.byChannel["ch-1"][0].content).toBe("content-m1");
+    });
+  });
+
+  describe("removeMessage", () => {
+    it("removes message from channel", () => {
+      setMessagesState("byChannel", "ch-1", [createMessage("m1"), createMessage("m2")]);
+
+      removeMessage("ch-1", "m1");
+
+      expect(messagesState.byChannel["ch-1"]).toHaveLength(1);
+      expect(messagesState.byChannel["ch-1"][0].id).toBe("m2");
+    });
+
+    it("no-ops for unknown channel", () => {
+      removeMessage("unknown", "m1");
+
+      expect(messagesState.byChannel["unknown"]).toBeUndefined();
+    });
+  });
+
+  describe("getChannelMessages", () => {
+    it("returns messages for a channel", () => {
+      setMessagesState("byChannel", "ch-1", [createMessage("m1")]);
+
+      expect(getChannelMessages("ch-1")).toHaveLength(1);
+    });
+
+    it("returns empty array for unknown channel", () => {
+      expect(getChannelMessages("unknown")).toEqual([]);
+    });
+  });
+
+  describe("isLoadingMessages", () => {
+    it("returns true when loading", () => {
+      setMessagesState("loadingChannels", "ch-1", true);
+
+      expect(isLoadingMessages("ch-1")).toBe(true);
+    });
+
+    it("returns false by default", () => {
+      expect(isLoadingMessages("ch-1")).toBe(false);
+    });
+  });
+
+  describe("hasMoreMessages", () => {
+    it("returns true by default (unknown channel)", () => {
+      expect(hasMoreMessages("ch-1")).toBe(true);
+    });
+
+    it("returns stored value", () => {
+      setMessagesState("hasMore", "ch-1", false);
+
+      expect(hasMoreMessages("ch-1")).toBe(false);
+    });
+  });
+
+  describe("clearChannelMessages", () => {
+    it("removes channel messages and hasMore entry", () => {
+      setMessagesState("byChannel", "ch-1", [createMessage("m1")]);
+      setMessagesState("hasMore", "ch-1", false);
+
+      clearChannelMessages("ch-1");
+
+      expect(messagesState.byChannel["ch-1"]).toBeUndefined();
+      expect(messagesState.hasMore["ch-1"]).toBeUndefined();
+    });
+  });
+
+  describe("clearCurve25519KeyCache", () => {
+    it("does not throw", () => {
+      expect(() => clearCurve25519KeyCache()).not.toThrow();
+    });
+  });
+});

--- a/client/src/stores/__tests__/presence.test.ts
+++ b/client/src/stores/__tests__/presence.test.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/tauri", () => ({
+  updateStatus: vi.fn(),
+}));
+
+vi.mock("@/lib/idleDetector", () => ({
+  startIdleDetection: vi.fn(),
+  stopIdleDetection: vi.fn(),
+  setIdleTimeout: vi.fn(),
+}));
+
+vi.mock("@/stores/preferences", () => ({
+  preferences: vi.fn(() => ({ display: { idleTimeoutMinutes: 5 } })),
+}));
+
+vi.mock("@/stores/auth", () => ({
+  currentUser: vi.fn(() => ({ id: "me", username: "me", display_name: "Me", avatar_url: null, status: "online", email: null, mfa_enabled: false, created_at: "2025-01-01T00:00:00Z" })),
+  updateUser: vi.fn(),
+}));
+
+import { updateStatus } from "@/lib/tauri";
+import { startIdleDetection, stopIdleDetection } from "@/lib/idleDetector";
+import { currentUser } from "@/stores/auth";
+import {
+  presenceState,
+  setPresenceState,
+  updateUserPresence,
+  updateUserActivity,
+  setInitialPresence,
+  getUserStatus,
+  isUserOnline,
+  clearPresence,
+  setMyStatus,
+  patchUser,
+  initIdleDetection,
+  markManualStatusChange,
+  stopIdleDetectionCleanup,
+} from "../presence";
+
+describe("presence store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setPresenceState({ users: {} });
+  });
+
+  describe("initial state", () => {
+    it("has empty users map", () => {
+      expect(presenceState.users).toEqual({});
+    });
+  });
+
+  describe("updateUserPresence", () => {
+    it("sets status for a user", () => {
+      updateUserPresence("user-1", "online");
+
+      expect(presenceState.users["user-1"].status).toBe("online");
+    });
+
+    it("preserves existing activity when not provided", () => {
+      setPresenceState("users", "user-1", {
+        status: "online",
+        activity: { type: "game", name: "Minecraft", started_at: "2025-01-01T00:00:00Z" },
+      });
+
+      updateUserPresence("user-1", "idle");
+
+      expect(presenceState.users["user-1"].status).toBe("idle");
+      expect(presenceState.users["user-1"].activity?.name).toBe("Minecraft");
+    });
+
+    it("sets lastSeen when user goes offline", () => {
+      updateUserPresence("user-1", "offline");
+
+      expect(presenceState.users["user-1"].lastSeen).toBeDefined();
+    });
+
+    it("does not set lastSeen for non-offline statuses", () => {
+      updateUserPresence("user-1", "online");
+
+      expect(presenceState.users["user-1"].lastSeen).toBeUndefined();
+    });
+  });
+
+  describe("updateUserActivity", () => {
+    it("updates activity for existing user", () => {
+      setPresenceState("users", "user-1", { status: "online" });
+      const activity = { type: "game" as const, name: "Chess", started_at: "2025-01-01T00:00:00Z" };
+
+      updateUserActivity("user-1", activity);
+
+      expect(presenceState.users["user-1"].activity?.name).toBe("Chess");
+      expect(presenceState.users["user-1"].status).toBe("online");
+    });
+
+    it("creates user with online status if not present", () => {
+      const activity = { type: "coding" as const, name: "VS Code", started_at: "2025-01-01T00:00:00Z" };
+
+      updateUserActivity("new-user", activity);
+
+      expect(presenceState.users["new-user"].status).toBe("online");
+      expect(presenceState.users["new-user"].activity?.name).toBe("VS Code");
+    });
+
+    it("clears activity with null", () => {
+      setPresenceState("users", "user-1", {
+        status: "online",
+        activity: { type: "game", name: "Chess", started_at: "2025-01-01T00:00:00Z" },
+      });
+
+      updateUserActivity("user-1", null);
+
+      expect(presenceState.users["user-1"].activity).toBeNull();
+    });
+  });
+
+  describe("setInitialPresence", () => {
+    it("sets status for multiple users in bulk", () => {
+      setInitialPresence([
+        { id: "u1", status: "online" },
+        { id: "u2", status: "idle" },
+        { id: "u3", status: "dnd" },
+      ]);
+
+      expect(presenceState.users["u1"].status).toBe("online");
+      expect(presenceState.users["u2"].status).toBe("idle");
+      expect(presenceState.users["u3"].status).toBe("dnd");
+    });
+  });
+
+  describe("getUserStatus", () => {
+    it("returns status for known user", () => {
+      setPresenceState("users", "user-1", { status: "dnd" });
+
+      expect(getUserStatus("user-1")).toBe("dnd");
+    });
+
+    it("returns 'offline' for unknown user", () => {
+      expect(getUserStatus("unknown")).toBe("offline");
+    });
+  });
+
+  describe("isUserOnline", () => {
+    it("returns true for online/idle/dnd users", () => {
+      setPresenceState("users", "u1", { status: "online" });
+      setPresenceState("users", "u2", { status: "idle" });
+      setPresenceState("users", "u3", { status: "dnd" });
+
+      expect(isUserOnline("u1")).toBe(true);
+      expect(isUserOnline("u2")).toBe(true);
+      expect(isUserOnline("u3")).toBe(true);
+    });
+
+    it("returns false for offline users", () => {
+      setPresenceState("users", "u1", { status: "offline" });
+
+      expect(isUserOnline("u1")).toBe(false);
+    });
+
+    it("returns false for unknown users", () => {
+      expect(isUserOnline("unknown")).toBe(false);
+    });
+  });
+
+  describe("clearPresence", () => {
+    it("clears all user presence data", () => {
+      setPresenceState("users", "u1", { status: "online" });
+      setPresenceState("users", "u2", { status: "idle" });
+
+      clearPresence();
+
+      expect(presenceState.users).toEqual({});
+    });
+  });
+
+  describe("setMyStatus", () => {
+    it("updates server and local state", async () => {
+      vi.mocked(updateStatus).mockResolvedValue(undefined);
+
+      await setMyStatus("dnd");
+
+      expect(updateStatus).toHaveBeenCalledWith("dnd");
+      expect(presenceState.users["me"].status).toBe("dnd");
+    });
+
+    it("does nothing without a current user", async () => {
+      vi.mocked(currentUser).mockReturnValue(null);
+
+      await setMyStatus("online");
+
+      expect(updateStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("patchUser", () => {
+    it("updates presence fields for known user", () => {
+      setPresenceState("users", "user-1", { status: "online" });
+
+      patchUser("user-1", { status: "idle" });
+
+      expect(presenceState.users["user-1"].status).toBe("idle");
+    });
+
+    it("ignores patch for unknown presence user", () => {
+      patchUser("unknown", { status: "online" });
+
+      // Should not create a new entry via the presence path
+      expect(presenceState.users["unknown"]).toBeUndefined();
+    });
+  });
+
+  describe("initIdleDetection", () => {
+    it("starts idle detection with timeout from preferences", () => {
+      initIdleDetection();
+
+      expect(startIdleDetection).toHaveBeenCalledWith(expect.any(Function), 5);
+    });
+  });
+
+  describe("stopIdleDetectionCleanup", () => {
+    it("calls stopIdleDetection", () => {
+      stopIdleDetectionCleanup();
+
+      expect(stopIdleDetection).toHaveBeenCalled();
+    });
+  });
+
+  describe("markManualStatusChange", () => {
+    it("does not throw for valid statuses", () => {
+      expect(() => markManualStatusChange("idle")).not.toThrow();
+      expect(() => markManualStatusChange("dnd")).not.toThrow();
+      expect(() => markManualStatusChange("online")).not.toThrow();
+      expect(() => markManualStatusChange("invisible")).not.toThrow();
+    });
+  });
+});

--- a/client/src/stores/__tests__/voice.test.ts
+++ b/client/src/stores/__tests__/voice.test.ts
@@ -1,0 +1,311 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockAdapter = {
+  join: vi.fn(),
+  leave: vi.fn(),
+  setMute: vi.fn(),
+  setDeafen: vi.fn(),
+  setEventHandlers: vi.fn(),
+  getConnectionMetrics: vi.fn(),
+  getScreenShareInfo: vi.fn(),
+  startScreenShare: vi.fn(),
+  stopScreenShare: vi.fn(),
+  startWebcam: vi.fn(),
+  stopWebcam: vi.fn(),
+  handleOffer: vi.fn(),
+  handleIceCandidate: vi.fn(),
+};
+
+vi.mock("@/lib/webrtc", () => ({
+  createVoiceAdapter: vi.fn(() => mockAdapter),
+  getVoiceAdapter: vi.fn(() => mockAdapter),
+}));
+
+vi.mock("@/lib/tauri", () => ({
+  wsSend: vi.fn(),
+  wsScreenShareStart: vi.fn(),
+  wsScreenShareStop: vi.fn(),
+  wsWebcamStart: vi.fn(),
+  wsWebcamStop: vi.fn(),
+}));
+
+vi.mock("@/stores/channels", () => ({
+  channelsState: {
+    channels: [
+      { id: "ch-1", name: "voice-1", channel_type: "voice", guild_id: "g1" },
+      { id: "ch-2", name: "voice-2", channel_type: "voice", guild_id: "g1" },
+    ],
+  },
+}));
+
+vi.mock("@/components/ui/Toast", () => ({
+  showToast: vi.fn(),
+  dismissToast: vi.fn(),
+}));
+
+import {
+  voiceState,
+  setVoiceState,
+  joinVoice,
+  leaveVoice,
+  toggleMute,
+  toggleDeafen,
+  setSpeaking,
+  getParticipants,
+  isInVoice,
+  isInChannel,
+  getVoiceChannelInfo,
+  getLocalMetrics,
+  getParticipantMetrics,
+  handleVoiceUserStats,
+} from "../voice";
+
+describe("voice store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setVoiceState({
+      state: "disconnected",
+      channelId: null,
+      muted: false,
+      deafened: false,
+      speaking: false,
+      participants: {},
+      error: null,
+      screenSharing: false,
+      screenShareInfo: null,
+      screenShares: [],
+      webcamActive: false,
+      webcams: [],
+      sessionId: null,
+      connectedAt: null,
+      localMetrics: null,
+      participantMetrics: new Map(),
+    });
+  });
+
+  describe("initial state", () => {
+    it("is disconnected with defaults", () => {
+      expect(voiceState.state).toBe("disconnected");
+      expect(voiceState.channelId).toBeNull();
+      expect(voiceState.muted).toBe(false);
+      expect(voiceState.deafened).toBe(false);
+      expect(voiceState.speaking).toBe(false);
+      expect(voiceState.participants).toEqual({});
+      expect(voiceState.error).toBeNull();
+    });
+  });
+
+  describe("isInVoice", () => {
+    it("returns true when connected", () => {
+      setVoiceState({ state: "connected" });
+
+      expect(isInVoice()).toBe(true);
+    });
+
+    it("returns false when disconnected", () => {
+      expect(isInVoice()).toBe(false);
+    });
+
+    it("returns false when connecting", () => {
+      setVoiceState({ state: "connecting" });
+
+      expect(isInVoice()).toBe(false);
+    });
+  });
+
+  describe("isInChannel", () => {
+    it("returns true for matching channel", () => {
+      setVoiceState({ state: "connected", channelId: "ch-1" });
+
+      expect(isInChannel("ch-1")).toBe(true);
+    });
+
+    it("returns false for different channel", () => {
+      setVoiceState({ state: "connected", channelId: "ch-1" });
+
+      expect(isInChannel("ch-2")).toBe(false);
+    });
+
+    it("returns false when disconnected", () => {
+      expect(isInChannel("ch-1")).toBe(false);
+    });
+  });
+
+  describe("getParticipants", () => {
+    it("returns empty array when no participants", () => {
+      expect(getParticipants()).toEqual([]);
+    });
+
+    it("returns array of participants", () => {
+      setVoiceState("participants", {
+        "u1": { user_id: "u1", muted: false, speaking: false, screen_sharing: false },
+        "u2": { user_id: "u2", muted: true, speaking: false, screen_sharing: false },
+      });
+
+      expect(getParticipants()).toHaveLength(2);
+    });
+  });
+
+  describe("getVoiceChannelInfo", () => {
+    it("returns null when disconnected", () => {
+      expect(getVoiceChannelInfo()).toBeNull();
+    });
+
+    it("returns channel info when connected to known channel", () => {
+      setVoiceState({ state: "connected", channelId: "ch-1" });
+
+      const info = getVoiceChannelInfo();
+      expect(info?.id).toBe("ch-1");
+      expect(info?.name).toBe("voice-1");
+    });
+
+    it("returns 'Unknown Channel' for unknown channel", () => {
+      setVoiceState({ state: "connected", channelId: "unknown-ch" });
+
+      const info = getVoiceChannelInfo();
+      expect(info?.id).toBe("unknown-ch");
+      expect(info?.name).toBe("Unknown Channel");
+    });
+  });
+
+  describe("handleVoiceUserStats", () => {
+    it("updates participant metrics for matching channel", () => {
+      setVoiceState({ state: "connected", channelId: "ch-1" });
+
+      handleVoiceUserStats({
+        channel_id: "ch-1",
+        user_id: "u1",
+        latency: 25,
+        packet_loss: 0.5,
+        jitter: 3,
+        quality: 3,
+      });
+
+      const metrics = getParticipantMetrics("u1");
+      expect(metrics?.latency).toBe(25);
+      expect(metrics?.packetLoss).toBe(0.5);
+      expect(metrics?.quality).toBe("good");
+    });
+
+    it("ignores stats for wrong channel", () => {
+      setVoiceState({ state: "connected", channelId: "ch-1" });
+
+      handleVoiceUserStats({
+        channel_id: "ch-other",
+        user_id: "u1",
+        latency: 25,
+        packet_loss: 0,
+        jitter: 0,
+        quality: 3,
+      });
+
+      expect(getParticipantMetrics("u1")).toBeUndefined();
+    });
+  });
+
+  describe("setSpeaking", () => {
+    it("sets speaking state", () => {
+      setSpeaking(true);
+
+      expect(voiceState.speaking).toBe(true);
+
+      setSpeaking(false);
+
+      expect(voiceState.speaking).toBe(false);
+    });
+  });
+
+  describe("getLocalMetrics", () => {
+    it("returns null when not connected", () => {
+      expect(getLocalMetrics()).toBeNull();
+    });
+
+    it("returns stored metrics", () => {
+      const metrics = { latency: 20, packetLoss: 0, jitter: 1, quality: "good" as const, timestamp: Date.now() };
+      setVoiceState({ localMetrics: metrics });
+
+      expect(getLocalMetrics()).toEqual(metrics);
+    });
+  });
+
+  describe("joinVoice", () => {
+    it("joins voice channel on success", async () => {
+      mockAdapter.join.mockResolvedValue({ ok: true });
+
+      await joinVoice("ch-1");
+
+      expect(mockAdapter.setEventHandlers).toHaveBeenCalled();
+      expect(mockAdapter.join).toHaveBeenCalledWith("ch-1");
+      expect(voiceState.sessionId).not.toBeNull();
+      expect(voiceState.connectedAt).not.toBeNull();
+    });
+
+    it("resets state on join error", async () => {
+      mockAdapter.join.mockResolvedValue({
+        ok: false,
+        error: { type: "permission_denied", message: "Mic denied" },
+      });
+
+      await expect(joinVoice("ch-1")).rejects.toThrow("Mic denied");
+      expect(voiceState.state).toBe("disconnected");
+      expect(voiceState.channelId).toBeNull();
+    });
+  });
+
+  describe("leaveVoice", () => {
+    it("resets all state", async () => {
+      setVoiceState({
+        state: "connected",
+        channelId: "ch-1",
+        participants: { u1: { user_id: "u1", muted: false, speaking: false, screen_sharing: false } },
+        sessionId: "sess-1",
+        connectedAt: Date.now(),
+      });
+      mockAdapter.leave.mockResolvedValue({ ok: true });
+
+      await leaveVoice();
+
+      expect(voiceState.state).toBe("disconnected");
+      expect(voiceState.channelId).toBeNull();
+      expect(voiceState.participants).toEqual({});
+      expect(voiceState.sessionId).toBeNull();
+    });
+
+    it("no-ops when already disconnected", async () => {
+      await leaveVoice();
+
+      expect(mockAdapter.leave).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("toggleMute", () => {
+    it("toggles mute state via adapter", async () => {
+      mockAdapter.setMute.mockResolvedValue({ ok: true });
+
+      await toggleMute();
+
+      expect(mockAdapter.setMute).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe("toggleDeafen", () => {
+    it("deafening also mutes", async () => {
+      mockAdapter.setDeafen.mockResolvedValue({ ok: true });
+
+      await toggleDeafen();
+
+      expect(voiceState.deafened).toBe(true);
+      expect(voiceState.muted).toBe(true);
+    });
+
+    it("undeafening preserves previous mute state", async () => {
+      setVoiceState({ deafened: true, muted: true });
+      mockAdapter.setDeafen.mockResolvedValue({ ok: true });
+
+      await toggleDeafen();
+
+      expect(voiceState.deafened).toBe(false);
+      // muted stays true since it was the deafen-induced mute state
+    });
+  });
+});

--- a/client/src/stores/__tests__/websocket.test.ts
+++ b/client/src/stores/__tests__/websocket.test.ts
@@ -1,0 +1,255 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/tauri", () => ({
+  wsConnect: vi.fn(),
+  wsDisconnect: vi.fn(),
+  wsSubscribe: vi.fn(),
+  wsUnsubscribe: vi.fn(),
+  wsTyping: vi.fn(),
+  wsStopTyping: vi.fn(),
+  getBrowserWebSocket: vi.fn(),
+  wsStatus: vi.fn(),
+  wsSend: vi.fn(),
+}));
+
+vi.mock("@/stores/auth", () => ({
+  currentUser: vi.fn(() => ({ id: "me", username: "me" })),
+}));
+
+// Stub heavy cross-store dependencies to prevent import side effects
+vi.mock("@/stores/presence", () => ({
+  updateUserPresence: vi.fn(),
+  updateUserActivity: vi.fn(),
+}));
+
+vi.mock("@/stores/messages", () => ({
+  addMessage: vi.fn(),
+  removeMessage: vi.fn(),
+  messagesState: { byChannel: {} },
+  setMessagesState: vi.fn(),
+}));
+
+vi.mock("@/stores/threads", () => ({
+  addThreadReply: vi.fn(),
+  removeThreadReply: vi.fn(),
+  setThreadReadState: vi.fn(),
+  updateThreadInfo: vi.fn(),
+  updateParentThreadIndicator: vi.fn(),
+  markThreadUnread: vi.fn(),
+  clearThreadUnread: vi.fn(),
+  threadsState: { activeThreadId: null },
+}));
+
+vi.mock("@/stores/preferences", () => ({
+  handlePreferencesUpdated: vi.fn(),
+}));
+
+vi.mock("@/stores/call", () => ({
+  receiveIncomingCall: vi.fn(),
+  callConnected: vi.fn(),
+  callEndedExternally: vi.fn(),
+  participantJoined: vi.fn(),
+  participantLeft: vi.fn(),
+}));
+
+vi.mock("@/stores/friends", () => ({
+  loadFriends: vi.fn(),
+  loadPendingRequests: vi.fn(),
+  handleUserBlocked: vi.fn(),
+  handleUserUnblocked: vi.fn(),
+}));
+
+vi.mock("@/stores/channels", () => ({
+  getChannel: vi.fn(),
+  channelsState: { selectedChannelId: null },
+  handleChannelReadEvent: vi.fn(),
+  incrementUnreadCount: vi.fn(),
+}));
+
+vi.mock("@/stores/guilds", () => ({
+  guildsState: { activeGuildId: null },
+  getGuildIdForChannel: vi.fn(),
+  incrementGuildUnread: vi.fn(),
+}));
+
+vi.mock("@/stores/dms", () => ({
+  handleDMReadEvent: vi.fn(),
+  handleDMNameUpdated: vi.fn(),
+}));
+
+vi.mock("@/lib/sound", () => ({
+  playNotification: vi.fn(),
+}));
+
+import * as tauri from "@/lib/tauri";
+import {
+  wsState,
+  setWsState,
+  setTypingState,
+  connect,
+  disconnect,
+  subscribeChannel,
+  unsubscribeChannel,
+  sendTyping,
+  stopTyping,
+  getTypingUsers,
+  isConnected,
+  cleanupWebSocket,
+} from "../websocket";
+
+describe("websocket store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setWsState({
+      status: "disconnected",
+      reconnectAttempt: 0,
+      subscribedChannels: new Set(),
+      error: null,
+    });
+    setTypingState({ byChannel: {} });
+  });
+
+  describe("connect", () => {
+    it("connects successfully", async () => {
+      vi.mocked(tauri.wsConnect).mockResolvedValue(undefined);
+
+      await connect();
+
+      expect(tauri.wsConnect).toHaveBeenCalled();
+      // Status is set to "connecting" before await
+    });
+
+    it("sets error on failure", async () => {
+      vi.mocked(tauri.wsConnect).mockRejectedValue(new Error("Connection failed"));
+
+      await expect(connect()).rejects.toThrow("Connection failed");
+      expect(wsState.status).toBe("disconnected");
+      expect(wsState.error).toBe("Connection failed");
+    });
+  });
+
+  describe("disconnect", () => {
+    it("disconnects and clears subscriptions", async () => {
+      setWsState({ status: "connected", subscribedChannels: new Set(["ch-1"]) });
+      vi.mocked(tauri.wsDisconnect).mockResolvedValue(undefined);
+
+      await disconnect();
+
+      expect(wsState.status).toBe("disconnected");
+      expect(wsState.subscribedChannels.size).toBe(0);
+    });
+  });
+
+  describe("subscribeChannel", () => {
+    it("subscribes to a channel", async () => {
+      vi.mocked(tauri.wsSubscribe).mockResolvedValue(undefined);
+
+      await subscribeChannel("ch-1");
+
+      expect(tauri.wsSubscribe).toHaveBeenCalledWith("ch-1");
+      expect(wsState.subscribedChannels.has("ch-1")).toBe(true);
+    });
+
+    it("no-ops if already subscribed", async () => {
+      setWsState({ subscribedChannels: new Set(["ch-1"]) });
+
+      await subscribeChannel("ch-1");
+
+      expect(tauri.wsSubscribe).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("unsubscribeChannel", () => {
+    it("unsubscribes from a channel", async () => {
+      setWsState({ subscribedChannels: new Set(["ch-1"]) });
+      vi.mocked(tauri.wsUnsubscribe).mockResolvedValue(undefined);
+
+      await unsubscribeChannel("ch-1");
+
+      expect(tauri.wsUnsubscribe).toHaveBeenCalledWith("ch-1");
+      expect(wsState.subscribedChannels.has("ch-1")).toBe(false);
+    });
+
+    it("no-ops if not subscribed", async () => {
+      await unsubscribeChannel("ch-1");
+
+      expect(tauri.wsUnsubscribe).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("sendTyping", () => {
+    it("sends typing indicator", async () => {
+      vi.useFakeTimers();
+      try {
+        // Advance far enough to clear any prior debounce
+        vi.advanceTimersByTime(5000);
+        vi.mocked(tauri.wsTyping).mockResolvedValue(undefined);
+
+        await sendTyping("ch-1");
+
+        expect(tauri.wsTyping).toHaveBeenCalledWith("ch-1");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("debounces within 3 seconds", async () => {
+      vi.useFakeTimers();
+      try {
+        // Advance well past any prior debounce window (module-level lastTypingSent persists)
+        vi.setSystemTime(Date.now() + 10000);
+        vi.mocked(tauri.wsTyping).mockResolvedValue(undefined);
+
+        await sendTyping("ch-1"); // First call succeeds
+        await sendTyping("ch-1"); // Should be debounced (< 3s since first)
+
+        expect(tauri.wsTyping).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe("stopTyping", () => {
+    it("sends stop typing", async () => {
+      vi.mocked(tauri.wsStopTyping).mockResolvedValue(undefined);
+
+      await stopTyping("ch-1");
+
+      expect(tauri.wsStopTyping).toHaveBeenCalledWith("ch-1");
+    });
+  });
+
+  describe("getTypingUsers", () => {
+    it("returns empty array for unknown channel", () => {
+      expect(getTypingUsers("ch-1")).toEqual([]);
+    });
+
+    it("returns users from typing state", () => {
+      setTypingState("byChannel", "ch-1", new Set(["user-1", "user-2"]));
+
+      const users = getTypingUsers("ch-1");
+      expect(users).toHaveLength(2);
+      expect(users).toContain("user-1");
+      expect(users).toContain("user-2");
+    });
+  });
+
+  describe("isConnected", () => {
+    it("returns true when connected", () => {
+      setWsState({ status: "connected" });
+
+      expect(isConnected()).toBe(true);
+    });
+
+    it("returns false when not connected", () => {
+      expect(isConnected()).toBe(false);
+    });
+  });
+
+  describe("cleanupWebSocket", () => {
+    it("does not throw", async () => {
+      await expect(cleanupWebSocket()).resolves.not.toThrow();
+    });
+  });
+});

--- a/client/src/stores/auth.ts
+++ b/client/src/stores/auth.ts
@@ -344,4 +344,4 @@ export function clearSetupRequired(): void {
 
 // Export the store for reading only
 // Use the exported functions (login, register, logout, etc.) to modify state
-export { authState };
+export { authState, setAuthState };

--- a/client/src/stores/channels.ts
+++ b/client/src/stores/channels.ts
@@ -450,4 +450,4 @@ export async function moveChannelToCategory(
 }
 
 // Export the store for reading
-export { channelsState };
+export { channelsState, setChannelsState };

--- a/client/src/stores/dms.ts
+++ b/client/src/stores/dms.ts
@@ -216,4 +216,4 @@ export function getTotalUnreadCount(): number {
   return dmsState.dms.reduce((sum, dm) => sum + dm.unread_count, 0);
 }
 
-export { dmsState };
+export { dmsState, setDmsState };

--- a/client/src/stores/friends.ts
+++ b/client/src/stores/friends.ts
@@ -211,4 +211,4 @@ export function getOnlineFriends(): Friend[] {
 }
 
 // Export the store state
-export { friendsState };
+export { friendsState, setFriendsState };

--- a/client/src/stores/presence.ts
+++ b/client/src/stores/presence.ts
@@ -302,4 +302,4 @@ export function patchUser(userId: string, diff: Record<string, unknown>): void {
 }
 
 // Export the store for reading
-export { presenceState };
+export { presenceState, setPresenceState };

--- a/client/src/stores/websocket.ts
+++ b/client/src/stores/websocket.ts
@@ -1650,4 +1650,4 @@ async function handleAdminReportResolved(reportId: string): Promise<void> {
 }
 
 // Export stores for reading
-export { wsState, typingState };
+export { wsState, setWsState, typingState, setTypingState };


### PR DESCRIPTION
## Summary

- Add 200 unit tests across 9 new test files covering all critical client stores: auth, channels, dms, friends, guilds, messages, presence, voice, and websocket
- Export state setters from 6 stores (`auth`, `channels`, `dms`, `friends`, `presence`, `websocket`) to enable test state reset in `beforeEach`
- Tests cover initial state, mutations, async operations (success + error paths), optimistic updates, WS event handlers, and derived state helpers

## Test plan

- [x] `bun run test:run` — all 373 tests pass (200 new + 173 existing)
- [x] `bun run build` — no TypeScript errors from setter exports
- [ ] CI passes on this branch

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)