### PR TITLE
fix(test): serialize channel permissions tests

### DIFF
--- a/server/tests/channel_permissions_test.rs
+++ b/server/tests/channel_permissions_test.rs
@@ -6,6 +6,7 @@
 use axum::body::Body;
 use axum::http::{Method, Request, StatusCode};
 use serde_json::json;
+use serial_test::serial;
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -143,6 +144,7 @@ const SEND_MESSAGES: i64 = 1 << 3;
 // ============================================================================
 
 #[tokio::test]
+#[serial]
 async fn test_guild_owner_can_view_any_channel() {
     let app = TestApp::new().await;
     let (owner_id, _) = create_test_user(&app.pool).await;
@@ -162,6 +164,7 @@ async fn test_guild_owner_can_view_any_channel() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_guild_owner_bypasses_channel_overrides() {
     let app = TestApp::new().await;
     let (owner_id, _) = create_test_user(&app.pool).await;
@@ -191,6 +194,7 @@ async fn test_guild_owner_bypasses_channel_overrides() {
 // ============================================================================
 
 #[tokio::test]
+#[serial]
 async fn test_user_with_view_channel_can_access() {
     let app = TestApp::new().await;
     let (owner_id, _) = create_test_user(&app.pool).await;
@@ -216,6 +220,7 @@ async fn test_user_with_view_channel_can_access() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_user_without_view_channel_cannot_access() {
     let app = TestApp::new().await;
     let (owner_id, _) = create_test_user(&app.pool).await;
@@ -241,6 +246,7 @@ async fn test_user_without_view_channel_cannot_access() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_non_guild_member_cannot_access_channel() {
     let app = TestApp::new().await;
     let (owner_id, _) = create_test_user(&app.pool).await;
@@ -265,6 +271,7 @@ async fn test_non_guild_member_cannot_access_channel() {
 // ============================================================================
 
 #[tokio::test]
+#[serial]
 async fn test_channel_override_deny_blocks_access() {
     let app = TestApp::new().await;
     let (owner_id, _) = create_test_user(&app.pool).await;
@@ -293,6 +300,7 @@ async fn test_channel_override_deny_blocks_access() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_channel_override_allow_grants_access() {
     let app = TestApp::new().await;
     let (owner_id, _) = create_test_user(&app.pool).await;
@@ -321,6 +329,7 @@ async fn test_channel_override_allow_grants_access() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_channel_override_deny_wins_over_allow() {
     let app = TestApp::new().await;
     let (owner_id, _) = create_test_user(&app.pool).await;
@@ -361,6 +370,7 @@ async fn test_channel_override_deny_wins_over_allow() {
 // ============================================================================
 
 #[tokio::test]
+#[serial]
 async fn test_dm_participant_can_access() {
     let app = TestApp::new().await;
     let (user1_id, _) = create_test_user(&app.pool).await;
@@ -392,6 +402,7 @@ async fn test_dm_participant_can_access() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_non_dm_participant_cannot_access() {
     let app = TestApp::new().await;
     let (user1_id, _) = create_test_user(&app.pool).await;
@@ -416,6 +427,7 @@ async fn test_non_dm_participant_cannot_access() {
 // ============================================================================
 
 #[tokio::test]
+#[serial]
 async fn test_cannot_send_message_without_view_channel() {
     let app = TestApp::new().await;
     let (owner_id, _) = create_test_user(&app.pool).await;
@@ -448,6 +460,7 @@ async fn test_cannot_send_message_without_view_channel() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_cannot_read_messages_without_view_channel() {
     let app = TestApp::new().await;
     let (owner_id, _) = create_test_user(&app.pool).await;
@@ -478,6 +491,7 @@ async fn test_cannot_read_messages_without_view_channel() {
 // ============================================================================
 
 #[tokio::test]
+#[serial]
 async fn test_cannot_favorite_channel_without_view_permission() {
     let app = TestApp::new().await;
     let (owner_id, _) = create_test_user(&app.pool).await;
@@ -503,6 +517,7 @@ async fn test_cannot_favorite_channel_without_view_permission() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_can_favorite_channel_with_view_permission() {
     let app = TestApp::new().await;
     let (owner_id, _) = create_test_user(&app.pool).await;


### PR DESCRIPTION
## Summary
- Add `#[serial]` to all 14 tests in `channel_permissions_test.rs` to prevent shared state contamination
- Without serialization, concurrent tests cause "Tokio context being shutdown" errors and stale permission data (403/404 instead of expected 200)
- All 14 tests pass individually, confirming the root cause is purely concurrency

## Test plan
- [x] `cargo test --test channel_permissions_test` — all 14 tests pass (85s, serial execution)
- [x] Each failing test passes in isolation, confirming concurrency as root cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)