### PR TITLE
fix(test): standardize fresh fixtures across HTTP tests

### DIFF
--- a/server/tests/channels_http_test.rs
+++ b/server/tests/channels_http_test.rs
@@ -21,7 +21,7 @@ use vc_server::permissions::GuildPermissions;
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_create_channel_success() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
     let perms = GuildPermissions::VIEW_CHANNEL | GuildPermissions::SEND_MESSAGES;
@@ -55,7 +55,7 @@ async fn test_create_channel_success() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_create_channel_validation_errors() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
     let perms = GuildPermissions::VIEW_CHANNEL | GuildPermissions::SEND_MESSAGES;
@@ -116,7 +116,7 @@ async fn test_create_channel_validation_errors() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_update_channel_requires_manage_channels() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (owner_id, _) = create_test_user(&app.pool).await;
     let (member_id, _) = create_test_user(&app.pool).await;
     let token_owner = generate_access_token(&app.config, owner_id);
@@ -165,7 +165,7 @@ async fn test_update_channel_requires_manage_channels() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_delete_channel_requires_manage_channels() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (owner_id, _) = create_test_user(&app.pool).await;
     let (member_id, _) = create_test_user(&app.pool).await;
     let token_owner = generate_access_token(&app.config, owner_id);
@@ -206,7 +206,7 @@ async fn test_delete_channel_requires_manage_channels() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_get_channel_not_found() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 

--- a/server/tests/connectivity_http_test.rs
+++ b/server/tests/connectivity_http_test.rs
@@ -78,7 +78,7 @@ async fn insert_test_session(
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_summary_empty() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -107,7 +107,7 @@ async fn test_summary_empty() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_summary_with_data() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
     let channel_id = helpers::create_channel(
@@ -153,7 +153,7 @@ async fn test_summary_with_data() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_summary_unauthenticated() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
 
     let req = TestApp::request(Method::GET, "/api/me/connection/summary")
         .body(Body::empty())
@@ -170,7 +170,7 @@ async fn test_summary_unauthenticated() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_sessions_empty() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -193,7 +193,7 @@ async fn test_sessions_empty() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_sessions_with_data() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
     let guild_id = helpers::create_guild(&app.pool, user_id).await;
@@ -231,7 +231,7 @@ async fn test_sessions_with_data() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_sessions_pagination() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
     let guild_id = helpers::create_guild(&app.pool, user_id).await;
@@ -275,7 +275,7 @@ async fn test_sessions_pagination() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_sessions_unauthenticated() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
 
     let req = TestApp::request(Method::GET, "/api/me/connection/sessions")
         .body(Body::empty())
@@ -292,7 +292,7 @@ async fn test_sessions_unauthenticated() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_session_detail() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
     let guild_id = helpers::create_guild(&app.pool, user_id).await;
@@ -337,7 +337,7 @@ async fn test_session_detail() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_session_detail_not_found() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -362,7 +362,7 @@ async fn test_session_detail_not_found() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_session_rls_isolation() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
 
     // Create two users
     let (user_a, _) = create_test_user(&app.pool).await;

--- a/server/tests/global_search_http_test.rs
+++ b/server/tests/global_search_http_test.rs
@@ -36,7 +36,7 @@ fn global_search_request(query_string: &str, token: &str) -> axum::http::Request
 #[tokio::test]
 #[serial]
 async fn test_global_search_requires_auth() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
 
     let req = TestApp::request(Method::GET, "/api/search?q=test")
         .body(Body::empty())
@@ -53,7 +53,7 @@ async fn test_global_search_requires_auth() {
 #[tokio::test]
 #[serial]
 async fn test_global_search_basic() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -120,7 +120,7 @@ async fn test_global_search_basic() {
 #[tokio::test]
 #[serial]
 async fn test_global_search_multi_guild() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -165,7 +165,7 @@ async fn test_global_search_multi_guild() {
 #[tokio::test]
 #[serial]
 async fn test_global_search_includes_dms() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_a, _) = create_test_user(&app.pool).await;
     let (user_b, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_a);
@@ -208,7 +208,7 @@ async fn test_global_search_includes_dms() {
 #[tokio::test]
 #[serial]
 async fn test_global_search_source_guild() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -248,7 +248,7 @@ async fn test_global_search_source_guild() {
 #[tokio::test]
 #[serial]
 async fn test_global_search_source_dm() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_a, _) = create_test_user(&app.pool).await;
     let (user_b, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_a);
@@ -286,7 +286,7 @@ async fn test_global_search_source_dm() {
 #[tokio::test]
 #[serial]
 async fn test_global_search_excludes_inaccessible() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_a, _) = create_test_user(&app.pool).await;
     let (user_b, _) = create_test_user(&app.pool).await;
 
@@ -326,7 +326,7 @@ async fn test_global_search_excludes_inaccessible() {
 #[tokio::test]
 #[serial]
 async fn test_global_search_excludes_deleted() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -356,7 +356,7 @@ async fn test_global_search_excludes_deleted() {
 #[tokio::test]
 #[serial]
 async fn test_global_search_excludes_encrypted() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -392,7 +392,7 @@ async fn test_global_search_excludes_encrypted() {
 #[tokio::test]
 #[serial]
 async fn test_global_search_date_filter() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -429,7 +429,7 @@ async fn test_global_search_date_filter() {
 #[tokio::test]
 #[serial]
 async fn test_global_search_author_filter() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_a, _) = create_test_user(&app.pool).await;
     let (user_b, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_a).await;
@@ -461,7 +461,7 @@ async fn test_global_search_author_filter() {
 #[tokio::test]
 #[serial]
 async fn test_global_search_has_link() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -497,7 +497,7 @@ async fn test_global_search_has_link() {
 #[tokio::test]
 #[serial]
 async fn test_global_search_has_file() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -535,7 +535,7 @@ async fn test_global_search_has_file() {
 #[tokio::test]
 #[serial]
 async fn test_global_search_sort_relevance() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -576,7 +576,7 @@ async fn test_global_search_sort_relevance() {
 #[tokio::test]
 #[serial]
 async fn test_global_search_sort_date() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -618,7 +618,7 @@ async fn test_global_search_sort_date() {
 #[tokio::test]
 #[serial]
 async fn test_global_search_validation() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -649,7 +649,7 @@ async fn test_global_search_validation() {
 #[tokio::test]
 #[serial]
 async fn test_global_search_pagination() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -731,7 +731,7 @@ async fn test_global_search_pagination() {
 #[tokio::test]
 #[serial]
 async fn test_global_search_limit_clamping() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;

--- a/server/tests/messages_http_test.rs
+++ b/server/tests/messages_http_test.rs
@@ -66,7 +66,7 @@ async fn list_messages(
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_create_message_success() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
     let perms = GuildPermissions::VIEW_CHANNEL | GuildPermissions::SEND_MESSAGES;
@@ -93,7 +93,7 @@ async fn test_create_message_success() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_create_message_validation_errors() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
     let perms = GuildPermissions::VIEW_CHANNEL | GuildPermissions::SEND_MESSAGES;
@@ -143,7 +143,7 @@ async fn test_create_message_validation_errors() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_list_messages_pagination() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
     let perms = GuildPermissions::VIEW_CHANNEL | GuildPermissions::SEND_MESSAGES;
@@ -199,7 +199,7 @@ async fn test_list_messages_pagination() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_edit_message_owner_only() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_a, _) = create_test_user(&app.pool).await;
     let (user_b, _) = create_test_user(&app.pool).await;
     let token_a = generate_access_token(&app.config, user_a);
@@ -253,7 +253,7 @@ async fn test_edit_message_owner_only() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_delete_message_owner_only() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_a, _) = create_test_user(&app.pool).await;
     let (user_b, _) = create_test_user(&app.pool).await;
     let token_a = generate_access_token(&app.config, user_a);
@@ -299,7 +299,7 @@ async fn test_delete_message_owner_only() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_create_message_nonexistent_channel() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 

--- a/server/tests/search_http_test.rs
+++ b/server/tests/search_http_test.rs
@@ -51,7 +51,7 @@ fn dm_search_request(query_string: &str, token: &str) -> axum::http::Request<Bod
 #[tokio::test]
 #[serial]
 async fn test_guild_search_requires_auth() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
 
@@ -76,7 +76,7 @@ async fn test_guild_search_requires_auth() {
 #[tokio::test]
 #[serial]
 async fn test_guild_search_non_member_forbidden() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (owner_id, _) = create_test_user(&app.pool).await;
     let (outsider_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, owner_id).await;
@@ -102,7 +102,7 @@ async fn test_guild_search_non_member_forbidden() {
 #[tokio::test]
 #[serial]
 async fn test_guild_search_nonexistent_guild() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -121,7 +121,7 @@ async fn test_guild_search_nonexistent_guild() {
 #[tokio::test]
 #[serial]
 async fn test_guild_search_basic() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -150,7 +150,7 @@ async fn test_guild_search_basic() {
 #[tokio::test]
 #[serial]
 async fn test_guild_search_excludes_encrypted() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -177,7 +177,7 @@ async fn test_guild_search_excludes_encrypted() {
 #[tokio::test]
 #[serial]
 async fn test_guild_search_date_filter() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -212,7 +212,7 @@ async fn test_guild_search_date_filter() {
 #[tokio::test]
 #[serial]
 async fn test_guild_search_author_filter() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_a, _) = create_test_user(&app.pool).await;
     let (user_b, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_a).await;
@@ -245,7 +245,7 @@ async fn test_guild_search_author_filter() {
 #[tokio::test]
 #[serial]
 async fn test_guild_search_channel_filter() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let ch_a = create_channel(&app.pool, guild_id, "channel-a").await;
@@ -275,7 +275,7 @@ async fn test_guild_search_channel_filter() {
 #[tokio::test]
 #[serial]
 async fn test_guild_search_has_link() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -311,7 +311,7 @@ async fn test_guild_search_has_link() {
 #[tokio::test]
 #[serial]
 async fn test_guild_search_has_file() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -343,7 +343,7 @@ async fn test_guild_search_has_file() {
 #[tokio::test]
 #[serial]
 async fn test_guild_search_validation() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     create_channel(&app.pool, guild_id, "general").await;
@@ -375,7 +375,7 @@ async fn test_guild_search_validation() {
 #[tokio::test]
 #[serial]
 async fn test_dm_search_requires_auth() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
 
     let req = TestApp::request(Method::GET, "/api/dm/search?q=test")
         .body(Body::empty())
@@ -392,7 +392,7 @@ async fn test_dm_search_requires_auth() {
 #[tokio::test]
 #[serial]
 async fn test_dm_search_basic() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_a, _) = create_test_user(&app.pool).await;
     let (user_b, _) = create_test_user(&app.pool).await;
     let dm_id = create_dm_channel(&app.pool, user_a, user_b).await;
@@ -422,7 +422,7 @@ async fn test_dm_search_basic() {
 #[tokio::test]
 #[serial]
 async fn test_dm_search_only_own_dms() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_a, _) = create_test_user(&app.pool).await;
     let (user_b, _) = create_test_user(&app.pool).await;
     let (user_c, _) = create_test_user(&app.pool).await;
@@ -462,7 +462,7 @@ async fn test_dm_search_only_own_dms() {
 #[tokio::test]
 #[serial]
 async fn test_dm_search_channel_filter() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_a, _) = create_test_user(&app.pool).await;
     let (user_b, _) = create_test_user(&app.pool).await;
     let (user_c, _) = create_test_user(&app.pool).await;
@@ -498,7 +498,7 @@ async fn test_dm_search_channel_filter() {
 #[tokio::test]
 #[serial]
 async fn test_dm_search_excludes_encrypted() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_a, _) = create_test_user(&app.pool).await;
     let (user_b, _) = create_test_user(&app.pool).await;
     let dm_id = create_dm_channel(&app.pool, user_a, user_b).await;
@@ -529,7 +529,7 @@ async fn test_dm_search_excludes_encrypted() {
 #[tokio::test]
 #[serial]
 async fn test_guild_search_headline_contains_mark() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -571,7 +571,7 @@ async fn test_guild_search_headline_contains_mark() {
 #[tokio::test]
 #[serial]
 async fn test_guild_search_rank_present() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -610,7 +610,7 @@ async fn test_guild_search_rank_present() {
 #[tokio::test]
 #[serial]
 async fn test_guild_search_sort_relevance() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -660,7 +660,7 @@ async fn test_guild_search_sort_relevance() {
 #[tokio::test]
 #[serial]
 async fn test_guild_search_sort_date() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;

--- a/server/tests/setup_http_test.rs
+++ b/server/tests/setup_http_test.rs
@@ -19,50 +19,7 @@ use axum::body::Body;
 use axum::http::Method;
 use helpers::{body_to_json, create_test_user, generate_access_token, make_admin, TestApp};
 use serial_test::serial;
-use std::sync::Arc;
 use tokio::time::{timeout, Duration};
-use vc_server::api::{create_router, AppState};
-use vc_server::voice::sfu::SfuServer;
-
-// ============================================================================
-// Test Helpers
-// ============================================================================
-
-/// Create a TestApp with a fresh pool (not shared via OnceCell).
-///
-/// The shared `OnceCell<PgPool>` connections become stale when their originating
-/// tokio runtime drops between `#[tokio::test]` runs. The setup `complete`
-/// handler's transaction exacerbates this by creating connections that are
-/// returned to the pool and then go stale. A fresh pool per test avoids this.
-async fn setup_test_app() -> TestApp {
-    let config = helpers::shared_config().await.clone();
-    let pool = vc_server::db::create_pool(&config.database_url)
-        .await
-        .expect("Failed to connect to test DB");
-    let redis = vc_server::db::create_redis_client(&config.redis_url)
-        .await
-        .expect("Failed to connect to test Redis");
-    let sfu = SfuServer::new(Arc::new(config.clone()), None).expect("Failed to create SfuServer");
-
-    let state = AppState::new(
-        pool.clone(),
-        redis,
-        config.clone(),
-        None,
-        sfu,
-        None,
-        None,
-        None,
-    );
-    let router = create_router(state);
-    let config = Arc::new(config);
-
-    TestApp {
-        router,
-        pool,
-        config,
-    }
-}
 
 // ============================================================================
 // Database state helpers
@@ -94,7 +51,7 @@ async fn set_setup_complete(pool: &sqlx::PgPool, complete: bool) -> bool {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_status_returns_setup_state() {
-    let app = setup_test_app().await;
+    let app = helpers::fresh_test_app().await;
 
     let req = TestApp::request(Method::GET, "/api/setup/status")
         .body(Body::empty())
@@ -114,7 +71,7 @@ async fn test_status_returns_setup_state() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_config_returns_values_when_setup_incomplete() {
-    let app = setup_test_app().await;
+    let app = helpers::fresh_test_app().await;
     let prev = set_setup_complete(&app.pool, false).await;
 
     // Guard restores setup_complete even if assertions below panic
@@ -150,7 +107,7 @@ async fn test_config_returns_values_when_setup_incomplete() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_config_returns_403_when_setup_complete() {
-    let app = setup_test_app().await;
+    let app = helpers::fresh_test_app().await;
     let prev = set_setup_complete(&app.pool, true).await;
 
     let mut guard = app.cleanup_guard();
@@ -170,7 +127,7 @@ async fn test_config_returns_403_when_setup_complete() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_complete_requires_auth() {
-    let app = setup_test_app().await;
+    let app = helpers::fresh_test_app().await;
 
     let req = TestApp::request(Method::POST, "/api/setup/complete")
         .header("Content-Type", "application/json")
@@ -193,7 +150,7 @@ async fn test_complete_requires_auth() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_complete_requires_admin() {
-    let app = setup_test_app().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _username) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -225,7 +182,7 @@ async fn test_complete_requires_admin() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_complete_succeeds_for_admin() {
-    let app = setup_test_app().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _username) = create_test_user(&app.pool).await;
     make_admin(&app.pool, user_id).await;
     let token = generate_access_token(&app.config, user_id);
@@ -270,7 +227,7 @@ async fn test_complete_succeeds_for_admin() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_complete_rejects_invalid_body() {
-    let app = setup_test_app().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _username) = create_test_user(&app.pool).await;
     make_admin(&app.pool, user_id).await;
     let token = generate_access_token(&app.config, user_id);
@@ -303,7 +260,7 @@ async fn test_complete_rejects_invalid_body() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_complete_already_done() {
-    let app = setup_test_app().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _username) = create_test_user(&app.pool).await;
     make_admin(&app.pool, user_id).await;
     let token = generate_access_token(&app.config, user_id);

--- a/server/tests/uploads_http_test.rs
+++ b/server/tests/uploads_http_test.rs
@@ -21,7 +21,7 @@ use vc_server::permissions::GuildPermissions;
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_upload_returns_503_without_s3() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
     let perms = GuildPermissions::VIEW_CHANNEL | GuildPermissions::SEND_MESSAGES;
@@ -61,7 +61,7 @@ async fn test_upload_returns_503_without_s3() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_upload_requires_auth() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let channel_id = Uuid::now_v7();
 
     let boundary = "----TestBoundary";
@@ -87,7 +87,7 @@ async fn test_upload_requires_auth() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial]
 async fn test_get_attachment_not_found() {
-    let app = TestApp::new().await;
+    let app = helpers::fresh_test_app().await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 


### PR DESCRIPTION
## Summary
- add a shared `fresh_test_app()` helper in `server/tests/helpers/mod.rs` that builds per-test DB/Redis resources
- migrate HTTP integration tests to use `helpers::fresh_test_app().await` instead of shared `TestApp::new()` pool usage
- remove duplicated local `setup_test_app()` implementations from setup HTTP test modules

## Why
- follow-up to #200: mixed fixture strategies allowed stale shared pool behavior and intermittent `PoolTimedOut` flakes
- this unifies HTTP test setup on a deterministic per-test resource model

## Verification
- invariant check: no `TestApp::new().await` / `setup_test_app()` remain in `server/tests/*http_test.rs`
- targeted tests pass:
  - `cargo test -p vc-server --test setup_http_test --test setup_concurrent_http_test --test channels_http_test -q`
- full suite passes:
  - `make test`

Closes #200