### PR TITLE
docs(infra): add CachyOS dev environment planning docs

### DIFF
--- a/docs/plans/2026-02-15-cachyos-dev-setup-manual-implementation-plan.md
+++ b/docs/plans/2026-02-15-cachyos-dev-setup-manual-implementation-plan.md
@@ -1,0 +1,208 @@
+# CachyOS Dev Setup Manual Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a reusable Markdown manual and a consistent Makefile target contract for per-project isolated development environments on CachyOS.
+
+**Architecture:** Keep host tooling minimal and run project work inside per-project Distrobox containers. Document the pattern in a portable manual and align this repository's Makefile with the standard target names so the workflow is consistent across repos.
+
+**Tech Stack:** GNU Make, Bash, Distrobox, Podman/Docker Compose, Rust, Bun, Node.js, sqlx
+
+---
+
+### Task 1: Add reusable manual document
+
+**Files:**
+- Create: `docs/development/cachyos-dev-environment-manual.md`
+- Reference: `docs/plans/2026-02-15-cachyos-multi-project-dev-environment-design.md`
+
+**Step 1: Write the failing test**
+
+Use a content check command that fails if required manual sections are missing.
+
+```bash
+rg -n "^# |^## " docs/development/cachyos-dev-environment-manual.md
+```
+
+Expected missing sections before file exists:
+- Host baseline setup
+- Container naming convention
+- Standard Makefile target contract
+- New-project onboarding checklist
+- Troubleshooting and reset playbook
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+test -f docs/development/cachyos-dev-environment-manual.md
+```
+
+Expected: FAIL (exit code non-zero, file does not exist).
+
+**Step 3: Write minimal implementation**
+
+Create `docs/development/cachyos-dev-environment-manual.md` with:
+- purpose and non-goals
+- host package install instructions for CachyOS/Arch (`pacman`)
+- Distrobox workflow (`create`, `enter`, `export`)
+- repo-scoped env and service isolation rules
+- canonical Make targets and expected behavior
+- copy/paste starter Makefile snippet for cross-project reuse
+- verification checklist and troubleshooting
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+test -f docs/development/cachyos-dev-environment-manual.md && rg -n "Host baseline|Distrobox|Makefile|Troubleshooting" docs/development/cachyos-dev-environment-manual.md
+```
+
+Expected: PASS with matching section lines.
+
+**Step 5: Commit**
+
+```bash
+git add docs/development/cachyos-dev-environment-manual.md
+git commit -m "docs(infra): add reusable CachyOS dev environment manual"
+```
+
+### Task 2: Align Makefile with standard target contract
+
+**Files:**
+- Modify: `Makefile`
+- Test: `Makefile`
+
+**Step 1: Write the failing test**
+
+Check for required targets that should exist for cross-repo consistency.
+
+```bash
+rg -n "^(init|bootstrap|doctor|services-up|services-down|migrate|lint|fmt):" Makefile
+```
+
+Expected: FAIL for missing aliases (`init`, `bootstrap`, `doctor`, `services-up`, `services-down`, `migrate`).
+
+**Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+make init
+```
+
+Expected: FAIL with "No rule to make target 'init'".
+
+**Step 3: Write minimal implementation**
+
+Update `Makefile` by adding non-breaking aliases/wrappers:
+- `init` -> current setup entrypoint
+- `bootstrap` -> existing install/setup flow
+- `services-up`/`services-down` -> existing docker targets
+- `migrate` -> existing `db-migrate`
+- `doctor` -> lightweight dependency and service checks
+
+Do not remove existing targets; keep backward compatibility.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+make -n init bootstrap services-up services-down migrate doctor lint fmt
+```
+
+Expected: PASS with command previews for all targets.
+
+**Step 5: Commit**
+
+```bash
+git add Makefile
+git commit -m "chore(infra): add standard dev workflow make targets"
+```
+
+### Task 3: Link manual from existing setup docs
+
+**Files:**
+- Modify: `docs/development/setup.md`
+- Test: `docs/development/setup.md`
+
+**Step 1: Write the failing test**
+
+Search for a link/reference to the new manual.
+
+```bash
+rg -n "cachyos-dev-environment-manual" docs/development/setup.md
+```
+
+Expected: FAIL (no reference yet).
+
+**Step 2: Run test to verify it fails**
+
+Run the command above and confirm no matches.
+
+**Step 3: Write minimal implementation**
+
+Add a short "Standardized Multi-Project Setup" section in `docs/development/setup.md` linking to:
+- `docs/development/cachyos-dev-environment-manual.md`
+
+Keep quick-start instructions intact.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+rg -n "cachyos-dev-environment-manual" docs/development/setup.md
+```
+
+Expected: PASS with one matching line.
+
+**Step 5: Commit**
+
+```bash
+git add docs/development/setup.md
+git commit -m "docs(infra): link standardized CachyOS setup manual"
+```
+
+### Task 4: Validate final workflow end-to-end
+
+**Files:**
+- Modify if needed: `Makefile`, `docs/development/cachyos-dev-environment-manual.md`
+
+**Step 1: Write the failing test**
+
+Dry-run required make targets and ensure no missing rules.
+
+```bash
+make -n init bootstrap doctor services-up services-down migrate dev test lint fmt
+```
+
+Expected before fixes: any missing-target failure.
+
+**Step 2: Run test to verify it fails**
+
+Run the command and capture first failure.
+
+**Step 3: Write minimal implementation**
+
+Fix target wiring or docs mismatches discovered during dry run.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+make -n init bootstrap doctor services-up services-down migrate dev test lint fmt
+```
+
+Expected: PASS with full command preview.
+
+**Step 5: Commit**
+
+```bash
+git add Makefile docs/development/cachyos-dev-environment-manual.md docs/development/setup.md
+git commit -m "docs(infra): standardize multi-project dev environment workflow"
+```

--- a/docs/plans/2026-02-15-cachyos-multi-project-dev-environment-design.md
+++ b/docs/plans/2026-02-15-cachyos-multi-project-dev-environment-design.md
@@ -1,0 +1,160 @@
+# CachyOS Multi-Project Dev Environment Design
+
+**Date:** 2026-02-15
+**Status:** Approved
+**Target platform:** CachyOS (Arch Linux based)
+
+## Goal
+
+Create a repeatable development environment pattern that prevents cross-project contamination by default, while remaining fast for daily Rust/Bun/Tauri development.
+
+## Scope
+
+This design defines:
+- host-level baseline setup on CachyOS
+- per-project isolation model
+- standard Makefile target contract used in every repository
+- service and port isolation strategy
+- operational rules and troubleshooting expectations
+
+This design does not define project-specific application architecture.
+
+## Recommended Approach
+
+Use one containerized dev environment per project (Distrobox), with a shared host runtime (Podman or Docker), and enforce a standard Makefile interface for all repos.
+
+### Why this approach
+
+- strongest isolation without heavy VM overhead
+- deterministic onboarding for new devices
+- easy project reset/rebuild without affecting others
+- single command surface (`make ...`) across repositories
+
+## Alternatives Considered
+
+### 1) Host tools + direnv only
+
+Pros:
+- lowest setup complexity
+- fast local execution
+
+Cons:
+- higher risk of toolchain drift and version conflicts
+- greater chance of accidental cross-project cache/env leakage
+
+### 2) Hybrid (host language toolchains, containerized services)
+
+Pros:
+- good performance
+- less container management
+
+Cons:
+- still allows host-level contamination between projects
+- harder to guarantee reproducibility
+
+### 3) Per-project containers (selected)
+
+Pros:
+- clean project boundaries
+- reproducible across machines
+- explicit lifecycle per repository
+
+Cons:
+- slightly higher initial setup time
+
+## Architecture
+
+### Layer 1: Host (shared and minimal)
+
+Install only:
+- container runtime (`podman` preferred on Arch/CachyOS, `docker` acceptable)
+- `distrobox`
+- `git`
+- editor/IDE
+- optional `direnv`
+
+Do not rely on global Rust/Bun/Node/sqlx for day-to-day project work.
+
+### Layer 2: Project container (isolated)
+
+Each repo gets a dedicated container, naming convention:
+- `dev-<org>-<repo>`
+- example: `dev-detair-canis`
+
+Inside container:
+- Rust toolchain (stable)
+- Bun
+- Node.js (Playwright compatibility)
+- `sqlx-cli`
+- native build dependencies required by project (GTK/WebKit/libsoup/clang/audio libs for Tauri projects)
+
+### Layer 3: Project services (isolated)
+
+Every repository starts services via compose with a unique project name:
+- `COMPOSE_PROJECT_NAME=<repo>`
+
+Where required, use repo-specific port overrides to avoid collisions when multiple projects are running simultaneously.
+
+## Standard Repository Contract (Makefile-first)
+
+Every repository should expose the same baseline targets:
+
+- `make init` - create or refresh the project Distrobox container
+- `make bootstrap` - install project dependencies inside the container
+- `make doctor` - verify toolchain, env, services, and port availability
+- `make services-up` - start project-local compose services
+- `make services-down` - stop project-local compose services
+- `make migrate` - run database migrations inside container
+- `make dev` - run project in development mode
+- `make test` - execute test suite inside container
+- `make lint` - run lints/static checks inside container
+- `make fmt` - run formatters inside container
+- `make clean` - remove project-local artifacts only
+
+Optional targets (recommended when applicable):
+- `make logs`
+- `make shell`
+- `make rebuild`
+
+## Data and State Isolation Rules
+
+- one repo = one container
+- one repo = one `.env`
+- never share `.venv`, `node_modules`, `target`, caches, or DB volumes across repositories
+- always execute build/test/migration commands from inside the project container
+- avoid global scripts that mutate sibling repositories
+
+## Operational Workflow
+
+1. Clone repository to standard workspace path (for example `~/dev/<org>/<repo>`).
+2. Run `make init`.
+3. Run `make bootstrap`.
+4. Run `make services-up`.
+5. Run `make doctor`.
+6. Start development with `make dev`.
+
+## Error Handling and Recovery
+
+- If container dependency drift occurs, run `make rebuild` or remove/recreate that project's container only.
+- If service conflicts occur, confirm unique compose project names and port overrides.
+- If migrations fail, rerun from container shell and verify `.env` for current repo.
+- If tool checks fail, `make doctor` must report exact missing component and remediation hint.
+
+## Testing and Verification Expectations
+
+For each project, `make test`, `make lint`, and `make fmt` should be deterministic in a fresh container.
+
+For this repository specifically, the setup must support existing quality gates:
+- `cargo test`
+- `bun run test:run`
+- `cargo fmt --check && cargo clippy -- -D warnings`
+
+## Security and Compliance Notes
+
+- Keep secrets in repo-local `.env` only; never in global shell profiles.
+- Prefer least-privilege container execution and avoid privileged containers.
+- Keep dependency and storage choices license-compliant with project constraints.
+
+## Deliverable Plan
+
+Create a reusable Markdown manual that can be copied to other repositories and used as the standard onboarding and operations guide for this setup pattern.


### PR DESCRIPTION
## Summary
- add a design doc for a multi-project CachyOS development environment workflow
- add a manual implementation plan for the CachyOS development setup
- document the proposed setup path in `docs/plans` for review and iteration

## Test Plan
- [x] verify both docs are committed on a dedicated docs branch
- [x] confirm branch is pushed and ready for review