### PR TITLE
fix(api): resolve CI compilation errors and clippy warnings

### DIFF
--- a/server/src/api/bots.rs
+++ b/server/src/api/bots.rs
@@ -31,7 +31,7 @@ struct ApplicationRow {
 
 impl From<ApplicationRow> for ApplicationResponse {
     fn from(r: ApplicationRow) -> Self {
-        ApplicationResponse {
+        Self {
             id: r.id,
             name: r.name,
             description: r.description,

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 use axum::extract::{DefaultBodyLimit, FromRef, State};
 use axum::middleware::{from_fn, from_fn_with_state};
-use axum::routing::{delete, get, patch, post, put};
+use axum::routing::{delete, get, post, put};
 use axum::{Json, Router};
 use fred::interfaces::ClientLike;
 use serde::Serialize;

--- a/server/src/chat/s3.rs
+++ b/server/src/chat/s3.rs
@@ -1,7 +1,7 @@
 //! S3 Storage Client
 //!
 //! Handles S3-compatible storage for file uploads.
-//! Supports any S3-compatible backend: AWS S3, RustFS, Backblaze B2, Cloudflare R2.
+//! Supports any S3-compatible backend: AWS S3, `RustFS`, Backblaze B2, Cloudflare R2.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -54,7 +54,7 @@ pub enum S3Error {
 impl S3Client {
     /// Create a new S3 client from configuration.
     ///
-    /// Supports custom endpoints for S3-compatible backends (RustFS, R2, B2).
+    /// Supports custom endpoints for S3-compatible backends (`RustFS`, R2, B2).
     /// Uses path-style addressing when a custom endpoint is configured.
     pub async fn new(config: &Config) -> Result<Self, S3Error> {
         let region =

--- a/server/src/chat/uploads.rs
+++ b/server/src/chat/uploads.rs
@@ -217,19 +217,18 @@ fn validate_file_content(data: &[u8], claimed_mime: &str) -> Result<String, Uplo
     }
 
     // Use magic byte detection for all other types
-    let detected = match infer::get(data) {
-        Some(kind) => kind.mime_type().to_string(),
-        None => {
-            // No magic bytes recognized — reject the file
-            tracing::warn!(
-                claimed_mime = %claimed_mime,
-                size = data.len(),
-                "File content does not match any known magic byte signature"
-            );
-            return Err(UploadError::InvalidMimeType {
-                mime_type: format!("{claimed_mime} (content unrecognizable)"),
-            });
-        }
+    let detected = if let Some(kind) = infer::get(data) {
+        kind.mime_type().to_string()
+    } else {
+        // No magic bytes recognized — reject the file
+        tracing::warn!(
+            claimed_mime = %claimed_mime,
+            size = data.len(),
+            "File content does not match any known magic byte signature"
+        );
+        return Err(UploadError::InvalidMimeType {
+            mime_type: format!("{claimed_mime} (content unrecognizable)"),
+        });
     };
 
     // Allow if detected type matches claimed type

--- a/server/src/guild/handlers.rs
+++ b/server/src/guild/handlers.rs
@@ -991,7 +991,7 @@ pub async fn get_guild_settings(
     }))
 }
 
-/// Update guild settings (requires MANAGE_GUILD).
+/// Update guild settings (requires `MANAGE_GUILD`).
 /// PATCH /api/guilds/{id}/settings
 #[tracing::instrument(skip(state))]
 pub async fn update_guild_settings(

--- a/server/src/moderation/filter_cache.rs
+++ b/server/src/moderation/filter_cache.rs
@@ -21,7 +21,7 @@ use super::filter_queries;
 /// Cached engine paired with the generation it was built at.
 struct CachedEngine {
     engine: Arc<FilterEngine>,
-    generation: u64,
+    _generation: u64,
 }
 
 /// Thread-safe cache of per-guild filter engines.
@@ -89,7 +89,7 @@ impl FilterCache {
                 guild_id,
                 CachedEngine {
                     engine: Arc::clone(&engine),
-                    generation: gen_before,
+                    _generation: gen_before,
                 },
             );
         }

--- a/server/src/moderation/filter_handlers.rs
+++ b/server/src/moderation/filter_handlers.rs
@@ -427,7 +427,7 @@ async fn test_filter(
 // Helpers
 // ============================================================================
 
-/// Validate a regex pattern for compilation and ReDoS protection.
+/// Validate a regex pattern for compilation and `ReDoS` protection.
 fn validate_regex(pattern: &str) -> Result<(), FilterError> {
     // Try to compile
     let regex = regex::Regex::new(pattern)

--- a/server/src/moderation/filter_types.rs
+++ b/server/src/moderation/filter_types.rs
@@ -150,6 +150,7 @@ pub struct UpdatePatternRequest {
 /// - Field absent in JSON → `#[serde(default)]` yields `None` (skip calling this)
 /// - `"field": null` → `Some(None)` (clear the value)
 /// - `"field": "text"` → `Some(Some("text"))` (set value)
+#[allow(clippy::option_option)]
 fn deserialize_double_option<'de, D>(deserializer: D) -> Result<Option<Option<String>>, D::Error>
 where
     D: Deserializer<'de>,
@@ -172,7 +173,7 @@ pub struct PaginationQuery {
     pub offset: i64,
 }
 
-fn default_limit() -> i64 {
+const fn default_limit() -> i64 {
     50
 }
 

--- a/server/src/webhooks/delivery.rs
+++ b/server/src/webhooks/delivery.rs
@@ -281,10 +281,10 @@ async fn process_delivery(
             let success = resp.status().is_success();
 
             // Log delivery result
-            let error_msg = if !success {
-                Some(format!("HTTP {status}"))
-            } else {
+            let error_msg = if success {
                 None
+            } else {
+                Some(format!("HTTP {status}"))
             };
             if let Err(e) = queries::log_delivery(
                 db,

--- a/server/src/webhooks/dispatch.rs
+++ b/server/src/webhooks/dispatch.rs
@@ -13,7 +13,7 @@ use super::{delivery, queries};
 
 /// Dispatch an event to all webhook subscribers for bots installed in a guild.
 ///
-/// Queries webhooks joined with guild_bot_installations where the webhook
+/// Queries webhooks joined with `guild_bot_installations` where the webhook
 /// subscribes to the given event type. Enqueues one delivery item per webhook.
 pub async fn dispatch_guild_event(
     db: &PgPool,

--- a/server/src/webhooks/events.rs
+++ b/server/src/webhooks/events.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Bot event types matching the `webhook_event_type` PostgreSQL enum.
+/// Bot event types matching the `webhook_event_type` `PostgreSQL` enum.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, sqlx::Type)]
 #[sqlx(type_name = "webhook_event_type", rename_all = "snake_case")]
 pub enum BotEventType {
@@ -28,7 +28,7 @@ pub enum BotEventType {
 
 impl BotEventType {
     /// Parse from a string (e.g., `"message.created"`).
-    pub fn from_str(s: &str) -> Option<Self> {
+    pub fn parse_str(s: &str) -> Option<Self> {
         match s {
             "message.created" => Some(Self::MessageCreated),
             "member.joined" => Some(Self::MemberJoined),
@@ -39,7 +39,7 @@ impl BotEventType {
     }
 
     /// Convert to the dot-separated string form.
-    pub fn as_str(&self) -> &'static str {
+    pub const fn as_str(&self) -> &'static str {
         match self {
             Self::MessageCreated => "message.created",
             Self::MemberJoined => "member.joined",
@@ -72,7 +72,7 @@ pub enum GatewayIntent {
 
 impl GatewayIntent {
     /// Parse from a string (e.g., `"messages"`).
-    pub fn from_str(s: &str) -> Option<Self> {
+    pub fn parse_str(s: &str) -> Option<Self> {
         match s {
             "messages" => Some(Self::Messages),
             "members" => Some(Self::Members),
@@ -82,7 +82,7 @@ impl GatewayIntent {
     }
 
     /// Convert to string form.
-    pub fn as_str(&self) -> &'static str {
+    pub const fn as_str(&self) -> &'static str {
         match self {
             Self::Messages => "messages",
             Self::Members => "members",
@@ -91,7 +91,7 @@ impl GatewayIntent {
     }
 
     /// Returns the event types covered by this intent.
-    pub fn event_types(&self) -> &'static [BotEventType] {
+    pub const fn event_types(&self) -> &'static [BotEventType] {
         match self {
             Self::Messages => &[BotEventType::MessageCreated],
             Self::Members => &[BotEventType::MemberJoined, BotEventType::MemberLeft],

--- a/server/src/webhooks/handlers.rs
+++ b/server/src/webhooks/handlers.rs
@@ -9,7 +9,10 @@ use sqlx::PgPool;
 use tracing::{info, instrument};
 use uuid::Uuid;
 
-use super::types::*;
+use super::types::{
+    CreateWebhookRequest, DeliveryLogEntry, TestDeliveryResult, UpdateWebhookRequest,
+    WebhookCreatedResponse, WebhookError, WebhookResponse,
+};
 use super::{queries, signing};
 use crate::auth::AuthUser;
 
@@ -60,7 +63,7 @@ fn validate_url(url: &str) -> Result<(), WebhookError> {
     Ok(())
 }
 
-/// POST /api/applications/{app_id}/webhooks
+/// POST /`api/applications/{app_id}/webhooks`
 #[instrument(skip(pool, claims))]
 pub async fn create_webhook(
     State(pool): State<PgPool>,
@@ -126,7 +129,7 @@ pub async fn create_webhook(
     ))
 }
 
-/// GET /api/applications/{app_id}/webhooks
+/// GET /`api/applications/{app_id}/webhooks`
 #[instrument(skip(pool, claims))]
 pub async fn list_webhooks(
     State(pool): State<PgPool>,
@@ -142,7 +145,7 @@ pub async fn list_webhooks(
     Ok(Json(webhooks))
 }
 
-/// GET /api/applications/{app_id}/webhooks/{wh_id}
+/// GET /`api/applications/{app_id}/webhooks/{wh_id}`
 #[instrument(skip(pool, claims))]
 pub async fn get_webhook(
     State(pool): State<PgPool>,
@@ -159,7 +162,7 @@ pub async fn get_webhook(
     Ok(Json(webhook))
 }
 
-/// PATCH /api/applications/{app_id}/webhooks/{wh_id}
+/// PATCH /`api/applications/{app_id}/webhooks/{wh_id}`
 #[instrument(skip(pool, claims))]
 pub async fn update_webhook(
     State(pool): State<PgPool>,
@@ -221,7 +224,7 @@ pub async fn update_webhook(
     Ok(Json(webhook))
 }
 
-/// DELETE /api/applications/{app_id}/webhooks/{wh_id}
+/// DELETE /`api/applications/{app_id}/webhooks/{wh_id}`
 #[instrument(skip(pool, claims))]
 pub async fn delete_webhook(
     State(pool): State<PgPool>,
@@ -241,7 +244,7 @@ pub async fn delete_webhook(
     Ok(StatusCode::NO_CONTENT)
 }
 
-/// POST /api/applications/{app_id}/webhooks/{wh_id}/test
+/// POST /`api/applications/{app_id}/webhooks/{wh_id}/test`
 #[instrument(skip(pool, claims))]
 pub async fn test_webhook(
     State(pool): State<PgPool>,
@@ -320,10 +323,10 @@ pub async fn test_webhook(
                 success,
                 response_status: Some(status),
                 latency_ms: latency,
-                error_message: if !success {
-                    Some(format!("HTTP {status}"))
-                } else {
+                error_message: if success {
                     None
+                } else {
+                    Some(format!("HTTP {status}"))
                 },
             }))
         }
@@ -336,7 +339,7 @@ pub async fn test_webhook(
     }
 }
 
-/// GET /api/applications/{app_id}/webhooks/{wh_id}/deliveries
+/// GET /`api/applications/{app_id}/webhooks/{wh_id}/deliveries`
 #[instrument(skip(pool, claims))]
 pub async fn list_deliveries(
     State(pool): State<PgPool>,

--- a/server/src/webhooks/queries.rs
+++ b/server/src/webhooks/queries.rs
@@ -105,6 +105,7 @@ pub async fn get_webhook_full(pool: &PgPool, webhook_id: Uuid) -> sqlx::Result<O
 }
 
 /// Update a webhook.
+#[allow(clippy::option_option)]
 pub async fn update_webhook(
     pool: &PgPool,
     webhook_id: Uuid,
@@ -191,6 +192,7 @@ pub async fn list_deliveries(
 }
 
 /// Log a delivery attempt.
+#[allow(clippy::too_many_arguments)]
 pub async fn log_delivery(
     pool: &PgPool,
     webhook_id: Uuid,
@@ -224,6 +226,7 @@ pub async fn log_delivery(
 }
 
 /// Insert a dead letter entry.
+#[allow(clippy::too_many_arguments)]
 pub async fn insert_dead_letter(
     pool: &PgPool,
     webhook_id: Uuid,


### PR DESCRIPTION
## Summary

- Convert two `sqlx::query!` macros in `messages.rs` to runtime queries (`sqlx::query_as` / `sqlx::query_scalar`) since the `.sqlx` offline cache was missing entries, breaking CI builds (`SQLX_OFFLINE=true`)
- Fix all clippy warnings treated as errors under pedantic+nursery lints across 14 files
- Remove unused `patch` import in `api/mod.rs`

## Clippy lints resolved

`dead_code`, `items_after_statements`, `if_not_else`, `should_implement_trait`, `missing_const_for_fn`, `use_self`, `wildcard_imports`, `option_option`, `too_many_arguments`, `single_match_else`, `doc_markdown`

## Test plan

- [x] `cargo build` compiles without errors
- [x] `rustup run nightly cargo fmt -- --check` passes
- [x] `cargo clippy -p vc-server -- -D warnings` passes (0 warnings)
- [x] `cargo test -p vc-server` — 338 lib tests pass; bot_ecosystem_test failures are pre-existing on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)