### PR TITLE
fix(auth): add missing authorization checks on channel, upload, and guild endpoints

### DIFF
--- a/client/src/lib/tauri.ts
+++ b/client/src/lib/tauri.ts
@@ -1185,15 +1185,9 @@ export async function deleteGuild(guildId: string): Promise<void> {
   await httpRequest<void>("DELETE", `/api/guilds/${guildId}`);
 }
 
-export async function joinGuild(guildId: string, inviteCode: string): Promise<void> {
-  if (isTauri) {
-    const { invoke } = await import("@tauri-apps/api/core");
-    return invoke("join_guild", { guildId, inviteCode });
-  }
-
-  await httpRequest<void>("POST", `/api/guilds/${guildId}/join`, {
-    invite_code: inviteCode,
-  });
+export async function joinGuild(_guildId: string, inviteCode: string): Promise<void> {
+  // Guild join always requires a valid invite code — route through the invite endpoint
+  await joinViaInvite(inviteCode);
 }
 
 export async function leaveGuild(guildId: string): Promise<void> {

--- a/server/src/guild/mod.rs
+++ b/server/src/guild/mod.rs
@@ -26,7 +26,6 @@ pub fn router() -> Router<AppState> {
                 .patch(handlers::update_guild)
                 .delete(handlers::delete_guild),
         )
-        .route("/{id}/join", post(handlers::join_guild))
         .route("/{id}/leave", post(handlers::leave_guild))
         .route("/{id}/members", get(handlers::list_members))
         .route("/{id}/members/{user_id}", delete(handlers::kick_member))


### PR DESCRIPTION
## Summary

Fixes four **P0 security vulnerabilities** identified during a full codebase security audit. All four are authorization bypasses exploitable by any authenticated user.

- **Channel member operations (#216):** `list_members` had no `AuthUser` at all; `add_member` and `remove_member` accepted but ignored `_auth_user`. Any authenticated user could enumerate private channel members, add themselves to any channel, or remove any user from any channel. Now all three require `require_channel_access` and `MANAGE_CHANNELS` permission.

- **Channel creation (#217):** `create` accepted `_auth_user` (unused) and a client-supplied `guild_id` with no guild membership or permission check. Any authenticated user could create channels in any guild. Now requires `require_guild_permission(MANAGE_CHANNELS)` when `guild_id` is provided.

- **File upload with message (#218):** `upload_message_with_file` deliberately skipped `require_channel_access` with a misleading comment claiming consistency with `messages::create` — but `messages::create` **does** check permissions. Any authenticated user could post messages with file attachments to any channel. Now matches `messages::create` with `require_channel_access` + `SEND_MESSAGES` check.

- **Guild join without invite (#219):** `POST /api/guilds/{id}/join` allowed any authenticated user to join any guild by ID without an invite code. The handler was a placeholder that entirely ignored the request body. Removed the endpoint and handler; all guild joins now go through the existing `join_via_invite` endpoint which properly validates invite codes.

## Test plan

- [x] All 404 client unit tests pass (`bun run test:run`)
- [x] `cargo check` passes (no compilation errors from changes; pre-existing sqlx macro errors from missing DB connection are unrelated)
- [x] `cargo clippy` clean on modified files
- [ ] Verify channel member list returns 403 for non-members
- [ ] Verify channel add/remove member returns 403 without MANAGE_CHANNELS
- [ ] Verify channel creation returns 403 for non-guild-members
- [ ] Verify file upload returns 403 for non-channel-members
- [ ] Verify `POST /api/guilds/{id}/join` returns 404 (route removed)
- [ ] Verify `POST /api/invites/{code}/join` still works correctly

Fixes #216, #217, #218, #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)