### PR TITLE
style(server): apply rustfmt formatting

### DIFF
--- a/server/src/auth/handlers.rs
+++ b/server/src/auth/handlers.rs
@@ -24,9 +24,8 @@ use super::oidc::{append_collision_suffix, generate_username_from_claims, OidcFl
 use super::password::{hash_password, verify_password};
 use crate::api::AppState;
 use crate::db::{
-    self, count_all_mfa_backup_codes, count_unused_mfa_backup_codes,
-    create_password_reset_token, create_session, delete_mfa_backup_codes,
-    delete_session_by_token_hash, email_exists,
+    self, count_all_mfa_backup_codes, count_unused_mfa_backup_codes, create_password_reset_token,
+    create_session, delete_mfa_backup_codes, delete_session_by_token_hash, email_exists,
     find_session_by_token_hash, find_user_by_email, find_user_by_external_id, find_user_by_id,
     find_user_by_username, find_valid_reset_token, get_auth_methods_allowed,
     get_unused_mfa_backup_codes, invalidate_user_reset_tokens, is_setup_complete,
@@ -1078,9 +1077,10 @@ pub async fn mfa_verify(
     } else {
         // Check for pending MFA secret in Redis (from mfa_setup)
         let redis_key = format!("mfa:pending:{}", auth_user.id);
-        let pending: Option<String> = state.redis.get(&redis_key).await.map_err(|e| {
-            AuthError::Internal(format!("Failed to check pending MFA secret: {e}"))
-        })?;
+        let pending: Option<String> =
+            state.redis.get(&redis_key).await.map_err(|e| {
+                AuthError::Internal(format!("Failed to check pending MFA secret: {e}"))
+            })?;
         match pending {
             Some(secret) => (secret, true),
             None => return Err(AuthError::Validation("MFA not enabled".to_string())),

--- a/server/src/crypto/handlers.rs
+++ b/server/src/crypto/handlers.rs
@@ -163,13 +163,12 @@ pub async fn upload_keys(
     .map_err(AuthError::Database)?;
 
     if existing_device.is_none() {
-        let device_count: i64 = sqlx::query_scalar(
-            "SELECT COUNT(*) FROM user_devices WHERE user_id = $1",
-        )
-        .bind(user_id)
-        .fetch_one(&state.db)
-        .await
-        .map_err(AuthError::Database)?;
+        let device_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM user_devices WHERE user_id = $1")
+                .bind(user_id)
+                .fetch_one(&state.db)
+                .await
+                .map_err(AuthError::Database)?;
 
         if device_count >= MAX_DEVICES_PER_USER {
             return Err(AuthError::Validation(format!(
@@ -482,13 +481,12 @@ pub async fn upload_backup(
     if result.rows_affected() == 0 {
         // Either version is not greater than existing, or the insert conflicted
         // Check if a backup already exists with a higher or equal version
-        let existing_version: Option<i32> = sqlx::query_scalar(
-            "SELECT version FROM key_backups WHERE user_id = $1",
-        )
-        .bind(user_id)
-        .fetch_optional(&state.db)
-        .await
-        .map_err(AuthError::Database)?;
+        let existing_version: Option<i32> =
+            sqlx::query_scalar("SELECT version FROM key_backups WHERE user_id = $1")
+                .bind(user_id)
+                .fetch_optional(&state.db)
+                .await
+                .map_err(AuthError::Database)?;
 
         if let Some(v) = existing_version {
             if req.version <= v {

--- a/server/src/db/queries.rs
+++ b/server/src/db/queries.rs
@@ -472,13 +472,12 @@ pub async fn count_unused_mfa_backup_codes(pool: &PgPool, user_id: Uuid) -> sqlx
 /// Count all MFA backup codes for a user (used and unused).
 /// Used to detect whether backup codes were ever generated (first-time setup detection).
 pub async fn count_all_mfa_backup_codes(pool: &PgPool, user_id: Uuid) -> sqlx::Result<i64> {
-    let (count,): (i64,) = sqlx::query_as(
-        "SELECT COUNT(*) FROM mfa_backup_codes WHERE user_id = $1",
-    )
-    .bind(user_id)
-    .fetch_one(pool)
-    .await
-    .map_err(db_error!("count_all_mfa_backup_codes", user_id = %user_id))?;
+    let (count,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM mfa_backup_codes WHERE user_id = $1")
+            .bind(user_id)
+            .fetch_one(pool)
+            .await
+            .map_err(db_error!("count_all_mfa_backup_codes", user_id = %user_id))?;
     Ok(count)
 }
 

--- a/server/src/webhooks/handlers.rs
+++ b/server/src/webhooks/handlers.rs
@@ -45,9 +45,8 @@ fn get_encryption_key(state: &AppState) -> Result<Vec<u8>, WebhookError> {
             "Server encryption key not configured (MFA_ENCRYPTION_KEY)".to_string(),
         )
     })?;
-    let key = hex::decode(key_hex).map_err(|_| {
-        WebhookError::Validation("Server encryption key misconfigured".to_string())
-    })?;
+    let key = hex::decode(key_hex)
+        .map_err(|_| WebhookError::Validation("Server encryption key misconfigured".to_string()))?;
     if key.len() != 32 {
         tracing::error!(
             actual_len = key.len(),

--- a/server/src/ws/mod.rs
+++ b/server/src/ws/mod.rs
@@ -1474,16 +1474,12 @@ async fn handle_pubsub(redis: Client, params: HandlePubsubParams) {
                             // Filter events from blocked users
                             let blocked = params.blocked_users.read().await;
                             let should_filter = match &event {
-                                ServerEvent::MessageNew { message, .. } => {
-                                    message
-                                        .get("author")
-                                        .and_then(|a| a.get("id"))
-                                        .and_then(|id| id.as_str())
-                                        .and_then(|id| Uuid::parse_str(id).ok())
-                                        .is_some_and(|author_id| {
-                                            blocked.contains(&author_id)
-                                        })
-                                }
+                                ServerEvent::MessageNew { message, .. } => message
+                                    .get("author")
+                                    .and_then(|a| a.get("id"))
+                                    .and_then(|id| id.as_str())
+                                    .and_then(|id| Uuid::parse_str(id).ok())
+                                    .is_some_and(|author_id| blocked.contains(&author_id)),
                                 ServerEvent::TypingStart { user_id: uid, .. }
                                 | ServerEvent::TypingStop { user_id: uid, .. }
                                 | ServerEvent::VoiceUserJoined { user_id: uid, .. }


### PR DESCRIPTION
## Summary
- Apply `rustfmt` formatting across 5 server source files
- Whitespace/line-wrapping changes only — no logic or behavior modifications

## Test plan
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` passes (no behavioral changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)