### PR TITLE
feat(api): guild resource limits and usage stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Production client builds now selectively strip `console.log` and `console.debug` while preserving `console.error` and `console.warn` for diagnostics (TD-09)
 
 ### Added
+- Guild resource limits — configurable per-instance limits for guilds per user, members, channels, roles, emojis, bots per guild, and webhooks per app; enforced server-side with `LIMIT_EXCEEDED` (403) errors; limits configurable via environment variables (`MAX_GUILDS_PER_USER`, `MAX_MEMBERS_PER_GUILD`, etc.) with sensible defaults
+- Guild usage stats endpoint (`GET /api/guilds/{id}/usage`) — shows current resource counts vs limits for members, channels, roles, emojis, and bots; requires guild membership
+- Instance limits endpoint (`GET /api/config/limits`) — public endpoint returning all configured resource limits for client display
+- Guild plan column — `plan` field on guilds (default: "free") preparing for future tier/boost system
+- Usage tab in guild settings — visual progress bars showing resource usage with color-coded thresholds (green/yellow/red) and plan badge
 - Guild discovery — public browsing of discoverable guilds with full-text search, tag filtering, and sort by popularity or newest; guilds opt in via a new "Discoverable" toggle in Server Settings with up to 5 tags and an optional banner URL; unauthenticated users can browse, authenticated users can join directly without an invite code; controlled by `ENABLE_GUILD_DISCOVERY` server config
 - Onboarding wizard — 5-step first-time experience for new users: display name, theme selection with live preview, microphone/speaker setup, server discovery or invite code join, and welcome summary; skippable at any step; re-triggerable from Appearance Settings
 - Interactive API documentation (Swagger UI) at `/api/docs` — covers all REST endpoints with schemas, auth requirements, and tag grouping. Controlled via `ENABLE_API_DOCS` env var.

--- a/client/src/components/guilds/GuildSettingsModal.tsx
+++ b/client/src/components/guilds/GuildSettingsModal.tsx
@@ -6,7 +6,7 @@
 
 import { Component, createSignal, Show } from "solid-js";
 import { Portal } from "solid-js/web";
-import { X, Link, Users, Shield, ShieldAlert, Smile, Bot, Settings } from "lucide-solid";
+import { X, Link, Users, Shield, ShieldAlert, Smile, Bot, Settings, BarChart3 } from "lucide-solid";
 import { guildsState, isGuildOwner } from "@/stores/guilds";
 import { authState } from "@/stores/auth";
 import GeneralTab from "./GeneralTab";
@@ -16,6 +16,7 @@ import RolesTab from "./RolesTab";
 import EmojisTab from "./EmojisTab";
 import BotsTab from "./BotsTab";
 import SafetyTab from "./SafetyTab";
+import UsageTab from "./UsageTab";
 import RoleEditor from "./RoleEditor";
 import { memberHasPermission } from "@/stores/permissions";
 import { PermissionBits } from "@/lib/permissionConstants";
@@ -26,7 +27,7 @@ interface GuildSettingsModalProps {
   onClose: () => void;
 }
 
-type TabId = "general" | "invites" | "members" | "roles" | "emojis" | "bots" | "safety";
+type TabId = "general" | "invites" | "members" | "roles" | "emojis" | "bots" | "safety" | "usage";
 
 const GuildSettingsModal: Component<GuildSettingsModalProps> = (props) => {
   const guild = () => guildsState.guilds.find((g) => g.id === props.guildId);
@@ -155,6 +156,17 @@ const GuildSettingsModal: Component<GuildSettingsModalProps> = (props) => {
               <Users class="w-4 h-4" />
               Members
             </button>
+            <button
+              onClick={() => setActiveTab("usage")}
+              class="flex items-center gap-2 px-6 py-3 font-medium transition-colors"
+              classList={{
+                "text-accent-primary border-b-2 border-accent-primary": activeTab() === "usage",
+                "text-text-secondary hover:text-text-primary": activeTab() !== "usage",
+              }}
+            >
+              <BarChart3 class="w-4 h-4" />
+              Usage
+            </button>
             <Show when={canManageEmojis()}>
               <button
                 onClick={() => setActiveTab("emojis")}
@@ -219,6 +231,9 @@ const GuildSettingsModal: Component<GuildSettingsModalProps> = (props) => {
             </Show>
             <Show when={activeTab() === "members"}>
               <MembersTab guildId={props.guildId} isOwner={isOwner()} />
+            </Show>
+            <Show when={activeTab() === "usage"}>
+              <UsageTab guildId={props.guildId} />
             </Show>
             <Show when={activeTab() === "emojis" && canManageEmojis()}>
               <EmojisTab guildId={props.guildId} />

--- a/client/src/components/guilds/UsageTab.tsx
+++ b/client/src/components/guilds/UsageTab.tsx
@@ -1,0 +1,109 @@
+/**
+ * UsageTab - Guild resource usage display
+ *
+ * Shows current usage vs limits for members, channels, roles, emojis, and bots.
+ */
+
+import { Component, createSignal, onMount, For } from "solid-js";
+import { getGuildUsage } from "@/lib/tauri";
+import type { GuildUsageStats } from "@/lib/types";
+
+interface UsageTabProps {
+  guildId: string;
+}
+
+interface UsageRow {
+  label: string;
+  current: number;
+  limit: number;
+}
+
+function percentage(current: number, limit: number): number {
+  if (limit <= 0) return 0;
+  return Math.min(100, Math.round((current / limit) * 100));
+}
+
+function barColor(pct: number): string {
+  if (pct >= 90) return "bg-red-500";
+  if (pct >= 70) return "bg-yellow-500";
+  return "bg-emerald-500";
+}
+
+const UsageTab: Component<UsageTabProps> = (props) => {
+  const [loading, setLoading] = createSignal(true);
+  const [error, setError] = createSignal<string | null>(null);
+  const [stats, setStats] = createSignal<GuildUsageStats | null>(null);
+
+  onMount(async () => {
+    try {
+      const data = await getGuildUsage(props.guildId);
+      setStats(data);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load usage stats");
+    } finally {
+      setLoading(false);
+    }
+  });
+
+  const rows = (): UsageRow[] => {
+    const s = stats();
+    if (!s) return [];
+    return [
+      { label: "Members", current: s.members.current, limit: s.members.limit },
+      { label: "Channels", current: s.channels.current, limit: s.channels.limit },
+      { label: "Roles", current: s.roles.current, limit: s.roles.limit },
+      { label: "Emojis", current: s.emojis.current, limit: s.emojis.limit },
+      { label: "Bots", current: s.bots.current, limit: s.bots.limit },
+    ];
+  };
+
+  return (
+    <div class="p-6 space-y-6">
+      {/* Plan Badge */}
+      <div class="flex items-center gap-3">
+        <span class="px-3 py-1 rounded-full text-sm font-medium bg-white/10 text-text-secondary capitalize">
+          {stats()?.plan ?? "—"} Plan
+        </span>
+      </div>
+
+      {loading() && (
+        <div class="flex items-center justify-center py-12 text-text-secondary">
+          Loading usage stats...
+        </div>
+      )}
+
+      {error() && (
+        <div class="text-red-400 text-sm">{error()}</div>
+      )}
+
+      {!loading() && !error() && (
+        <div class="space-y-4">
+          <For each={rows()}>
+            {(row) => {
+              const pct = () => percentage(row.current, row.limit);
+              return (
+                <div class="space-y-1.5">
+                  <div class="flex items-center justify-between text-sm">
+                    <span class="text-text-primary font-medium">{row.label}</span>
+                    <span class="text-text-secondary">
+                      {row.current} / {row.limit}
+                      <span class="ml-1.5 text-xs">({pct()}%)</span>
+                    </span>
+                  </div>
+                  <div class="h-2 rounded-full bg-white/10 overflow-hidden">
+                    <div
+                      class={`h-full rounded-full transition-all ${barColor(pct())}`}
+                      style={{ width: `${pct()}%` }}
+                    />
+                  </div>
+                </div>
+              );
+            }}
+          </For>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default UsageTab;

--- a/client/src/lib/tauri.ts
+++ b/client/src/lib/tauri.ts
@@ -66,12 +66,13 @@ import type {
   AdminOidcProvider,
   UiState,
   GuildSettings,
+  GuildUsageStats,
   DiscoverResponse,
   JoinDiscoverableResponse,
 } from "./types";
 
 // Re-export types for convenience
-export type { User, Channel, ChannelCategory, ChannelWithUnread, Message, AppSettings, Guild, GuildMember, GuildInvite, InviteResponse, InviteExpiry, Friend, Friendship, DMChannel, DMListItem, Page, PageListItem, GuildRole, GuildEmoji, ChannelOverride, CreateRoleRequest, UpdateRoleRequest, SetChannelOverrideRequest, AssignRoleResponse, RemoveRoleResponse, DeleteRoleResponse, AdminStats, AdminStatus, UserSummary, GuildSummary, AuditLogEntry, PaginatedResponse, ElevateResponse, UserDetailsResponse, GuildDetailsResponse, BulkBanResponse, BulkSuspendResponse, CallEndReason, CallStateResponse, E2EEStatus, InitE2EEResponse, PrekeyData, E2EEContent, ClaimedPrekeyInput, UserKeysResponse, ClaimedPrekeyResponse, SearchResponse, SearchFilters, GlobalSearchResponse, Pin, CreatePinRequest, UpdatePinRequest, ServerSettings, OidcProvider, OidcLoginResult, AuthSettingsResponse, AuthMethodsConfig, AdminOidcProvider, GuildSettings, DiscoverResponse, JoinDiscoverableResponse };
+export type { User, Channel, ChannelCategory, ChannelWithUnread, Message, AppSettings, Guild, GuildMember, GuildInvite, InviteResponse, InviteExpiry, Friend, Friendship, DMChannel, DMListItem, Page, PageListItem, GuildRole, GuildEmoji, ChannelOverride, CreateRoleRequest, UpdateRoleRequest, SetChannelOverrideRequest, AssignRoleResponse, RemoveRoleResponse, DeleteRoleResponse, AdminStats, AdminStatus, UserSummary, GuildSummary, AuditLogEntry, PaginatedResponse, ElevateResponse, UserDetailsResponse, GuildDetailsResponse, BulkBanResponse, BulkSuspendResponse, CallEndReason, CallStateResponse, E2EEStatus, InitE2EEResponse, PrekeyData, E2EEContent, ClaimedPrekeyInput, UserKeysResponse, ClaimedPrekeyResponse, SearchResponse, SearchFilters, GlobalSearchResponse, Pin, CreatePinRequest, UpdatePinRequest, ServerSettings, OidcProvider, OidcLoginResult, AuthSettingsResponse, AuthMethodsConfig, AdminOidcProvider, GuildSettings, GuildUsageStats, DiscoverResponse, JoinDiscoverableResponse };
 
 /**
  * Unread aggregation types
@@ -1225,6 +1226,13 @@ export async function getGuildChannels(guildId: string): Promise<ChannelWithUnre
  */
 export async function getGuildSettings(guildId: string): Promise<GuildSettings> {
   return fetchApi<GuildSettings>(`/api/guilds/${guildId}/settings`);
+}
+
+/**
+ * Get guild resource usage stats (members, channels, roles, emojis, bots).
+ */
+export async function getGuildUsage(guildId: string): Promise<GuildUsageStats> {
+  return fetchApi<GuildUsageStats>(`/api/guilds/${guildId}/usage`);
 }
 
 /**

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -105,7 +105,23 @@ export interface Guild {
   discoverable: boolean;
   tags: string[];
   banner_url: string | null;
+  plan: string;
   created_at: string;
+}
+
+export interface UsageStat {
+  current: number;
+  limit: number;
+}
+
+export interface GuildUsageStats {
+  guild_id: string;
+  plan: string;
+  members: UsageStat;
+  channels: UsageStat;
+  roles: UsageStat;
+  emojis: UsageStat;
+  bots: UsageStat;
 }
 
 export interface GuildSettings {

--- a/server/migrations/20260225000000_guild_plan.sql
+++ b/server/migrations/20260225000000_guild_plan.sql
@@ -1,0 +1,3 @@
+-- Add plan column to guilds for future tier/boost system
+ALTER TABLE guilds ADD COLUMN plan VARCHAR(32) NOT NULL DEFAULT 'free';
+CREATE INDEX idx_guilds_plan ON guilds (plan);

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -313,6 +313,7 @@ pub fn create_router(state: AppState) -> Router {
             "/api/config/upload-limits",
             get(settings::get_upload_limits),
         )
+        .route("/api/config/limits", get(settings::get_instance_limits))
         // Setup routes (status and config are public, complete requires auth)
         .route("/api/setup/status", get(setup::status))
         .route("/api/setup/config", get(setup::get_config))

--- a/server/src/api/settings.rs
+++ b/server/src/api/settings.rs
@@ -65,6 +65,45 @@ pub async fn get_server_settings(State(state): State<AppState>) -> Json<ServerSe
     })
 }
 
+/// Instance resource limits response (public).
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct InstanceLimitsResponse {
+    pub max_guilds_per_user: i64,
+    pub max_members_per_guild: i64,
+    pub max_channels_per_guild: i64,
+    pub max_roles_per_guild: i64,
+    pub max_emojis_per_guild: i64,
+    pub max_bots_per_guild: i64,
+    pub max_webhooks_per_app: i64,
+    pub max_upload_size: usize,
+}
+
+/// Get instance resource limits (public endpoint).
+///
+/// Returns the configured resource limits so clients can display them.
+///
+/// GET /api/config/limits
+#[utoipa::path(
+    get,
+    path = "/api/config/limits",
+    tag = "settings",
+    responses(
+        (status = 200, body = InstanceLimitsResponse),
+    ),
+)]
+pub async fn get_instance_limits(State(state): State<AppState>) -> Json<InstanceLimitsResponse> {
+    Json(InstanceLimitsResponse {
+        max_guilds_per_user: state.config.max_guilds_per_user,
+        max_members_per_guild: state.config.max_members_per_guild,
+        max_channels_per_guild: state.config.max_channels_per_guild,
+        max_roles_per_guild: state.config.max_roles_per_guild,
+        max_emojis_per_guild: state.config.max_emojis_per_guild,
+        max_bots_per_guild: state.config.max_bots_per_guild,
+        max_webhooks_per_app: state.config.max_webhooks_per_app,
+        max_upload_size: state.config.max_upload_size,
+    })
+}
+
 /// File upload size limits response.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct UploadLimitsResponse {

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -127,6 +127,31 @@ pub struct Config {
     ///
     /// Defaults to `true`. Override via `ENABLE_GUILD_DISCOVERY` env var.
     pub enable_guild_discovery: bool,
+
+    // ========================================================================
+    // Resource Limits
+    // ========================================================================
+
+    /// Maximum number of guilds a single user can own (default: 100)
+    pub max_guilds_per_user: i64,
+
+    /// Maximum number of members per guild (default: 1000)
+    pub max_members_per_guild: i64,
+
+    /// Maximum number of channels per guild (default: 200)
+    pub max_channels_per_guild: i64,
+
+    /// Maximum number of roles per guild (default: 50)
+    pub max_roles_per_guild: i64,
+
+    /// Maximum number of custom emojis per guild (default: 50)
+    pub max_emojis_per_guild: i64,
+
+    /// Maximum number of bot installations per guild (default: 10)
+    pub max_bots_per_guild: i64,
+
+    /// Maximum number of webhooks per bot application (default: 5)
+    pub max_webhooks_per_app: i64,
 }
 
 impl Config {
@@ -215,6 +240,41 @@ impl Config {
                 .ok()
                 .map(|v| v.to_lowercase() == "true" || v == "1")
                 .unwrap_or(true),
+            max_guilds_per_user: env::var("MAX_GUILDS_PER_USER")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(100)
+                .max(1),
+            max_members_per_guild: env::var("MAX_MEMBERS_PER_GUILD")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(1000)
+                .max(1),
+            max_channels_per_guild: env::var("MAX_CHANNELS_PER_GUILD")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(200)
+                .max(1),
+            max_roles_per_guild: env::var("MAX_ROLES_PER_GUILD")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(50)
+                .max(1),
+            max_emojis_per_guild: env::var("MAX_EMOJIS_PER_GUILD")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(50)
+                .max(1),
+            max_bots_per_guild: env::var("MAX_BOTS_PER_GUILD")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(10)
+                .max(1),
+            max_webhooks_per_app: env::var("MAX_WEBHOOKS_PER_APP")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(5)
+                .max(1),
         })
     }
 
@@ -288,6 +348,13 @@ impl Config {
             smtp_tls: "starttls".into(),
             enable_api_docs: true,
             enable_guild_discovery: true,
+            max_guilds_per_user: 100,
+            max_members_per_guild: 1000,
+            max_channels_per_guild: 200,
+            max_roles_per_guild: 50,
+            max_emojis_per_guild: 50,
+            max_bots_per_guild: 10,
+            max_webhooks_per_app: 5,
         }
     }
 }

--- a/server/src/guild/limits.rs
+++ b/server/src/guild/limits.rs
@@ -1,0 +1,66 @@
+//! Guild Resource Limit Helpers
+//!
+//! Reusable count queries used by enforcement checks and the usage stats endpoint.
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Count guilds owned by a user.
+pub async fn count_user_owned_guilds(pool: &PgPool, user_id: Uuid) -> Result<i64, sqlx::Error> {
+    let (count,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM guilds WHERE owner_id = $1")
+            .bind(user_id)
+            .fetch_one(pool)
+            .await?;
+    Ok(count)
+}
+
+/// Get the member count for a guild (uses denormalized `member_count` column).
+pub async fn get_member_count(pool: &PgPool, guild_id: Uuid) -> Result<i64, sqlx::Error> {
+    let (count,): (i64,) =
+        sqlx::query_as("SELECT member_count::bigint FROM guilds WHERE id = $1")
+            .bind(guild_id)
+            .fetch_one(pool)
+            .await?;
+    Ok(count)
+}
+
+/// Count channels in a guild.
+pub async fn count_guild_channels(pool: &PgPool, guild_id: Uuid) -> Result<i64, sqlx::Error> {
+    let (count,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM channels WHERE guild_id = $1")
+            .bind(guild_id)
+            .fetch_one(pool)
+            .await?;
+    Ok(count)
+}
+
+/// Count roles in a guild (includes `@everyone`).
+pub async fn count_guild_roles(pool: &PgPool, guild_id: Uuid) -> Result<i64, sqlx::Error> {
+    let (count,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM guild_roles WHERE guild_id = $1")
+            .bind(guild_id)
+            .fetch_one(pool)
+            .await?;
+    Ok(count)
+}
+
+/// Count custom emojis in a guild.
+pub async fn count_guild_emojis(pool: &PgPool, guild_id: Uuid) -> Result<i64, sqlx::Error> {
+    let (count,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM guild_emojis WHERE guild_id = $1")
+            .bind(guild_id)
+            .fetch_one(pool)
+            .await?;
+    Ok(count)
+}
+
+/// Count bot installations in a guild.
+pub async fn count_guild_bots(pool: &PgPool, guild_id: Uuid) -> Result<i64, sqlx::Error> {
+    let (count,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM guild_bot_installations WHERE guild_id = $1")
+            .bind(guild_id)
+            .fetch_one(pool)
+            .await?;
+    Ok(count)
+}

--- a/server/src/guild/mod.rs
+++ b/server/src/guild/mod.rs
@@ -6,6 +6,7 @@ pub mod categories;
 pub mod emojis;
 pub mod handlers;
 pub mod invites;
+pub mod limits;
 pub mod roles;
 pub mod search;
 pub mod types;
@@ -35,6 +36,7 @@ pub fn router() -> Router<AppState> {
             "/{id}/bots/{bot_id}",
             delete(handlers::remove_bot_from_guild),
         )
+        .route("/{id}/usage", get(handlers::get_guild_usage))
         .route("/{id}/channels", get(handlers::list_channels))
         .route("/{id}/channels/reorder", post(handlers::reorder_channels))
         .route("/{id}/read-all", post(handlers::mark_all_channels_read))

--- a/server/src/guild/types.rs
+++ b/server/src/guild/types.rs
@@ -20,6 +20,7 @@ pub struct Guild {
     pub discoverable: bool,
     pub tags: Vec<String>,
     pub banner_url: Option<String>,
+    pub plan: String,
     pub created_at: chrono::DateTime<chrono::Utc>,
 }
 

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -131,6 +131,7 @@ use utoipa::{Modify, OpenApi};
         crate::guild::handlers::list_guild_commands,
         crate::guild::handlers::get_guild_settings,
         crate::guild::handlers::update_guild_settings,
+        crate::guild::handlers::get_guild_usage,
         // Roles
         crate::guild::roles::list_roles,
         crate::guild::roles::create_role,
@@ -298,6 +299,7 @@ use utoipa::{Modify, OpenApi};
         // Settings
         crate::api::settings::get_server_settings,
         crate::api::settings::get_upload_limits,
+        crate::api::settings::get_instance_limits,
         // Setup
         crate::api::setup::status,
         crate::api::setup::get_config,
@@ -397,6 +399,8 @@ use utoipa::{Modify, OpenApi};
         crate::guild::types::GuildSettings,
         crate::guild::types::UpdateGuildSettingsRequest,
         crate::guild::types::GuildCommandInfo,
+        crate::guild::handlers::UsageStat,
+        crate::guild::handlers::GuildUsageStats,
         crate::guild::handlers::ChannelWithUnread,
         crate::guild::handlers::InstalledBot,
         crate::guild::handlers::ChannelPosition,
@@ -484,6 +488,8 @@ use utoipa::{Modify, OpenApi};
         crate::api::bots::CreateApplicationRequest,
         crate::api::bots::ApplicationResponse,
         crate::api::bots::BotTokenResponse,
+        // Settings
+        crate::api::settings::InstanceLimitsResponse,
     ))
 )]
 pub struct ApiDoc;

--- a/server/src/webhooks/handlers.rs
+++ b/server/src/webhooks/handlers.rs
@@ -133,7 +133,7 @@ pub async fn create_webhook(
     let count = queries::count_webhooks(&state.db, app_id)
         .await
         .map_err(WebhookError::Database)?;
-    if count >= 5 {
+    if count >= state.config.max_webhooks_per_app {
         return Err(WebhookError::MaxWebhooksReached.into());
     }
 

--- a/server/tests/guild_limits_test.rs
+++ b/server/tests/guild_limits_test.rs
@@ -1,0 +1,503 @@
+//! Integration tests for guild resource limits.
+
+mod helpers;
+
+use axum::body::Body;
+use axum::http::{Method, StatusCode};
+use helpers::{
+    add_guild_member, body_to_json, create_bot_application, create_channel, create_guild,
+    create_test_user, delete_bot_application, delete_guild, delete_user, generate_access_token,
+    TestApp,
+};
+use vc_server::config::Config;
+
+/// Helper: create a Config with low limits for testing.
+fn low_limit_config() -> Config {
+    let mut config = Config::default_for_test();
+    config.max_guilds_per_user = 2;
+    config.max_members_per_guild = 2;
+    config.max_channels_per_guild = 2;
+    config.max_roles_per_guild = 2;
+    config.max_emojis_per_guild = 1;
+    config.max_bots_per_guild = 1;
+    config
+}
+
+// ============================================================================
+// Guild creation limit
+// ============================================================================
+
+#[tokio::test]
+async fn test_guild_creation_limit() {
+    let app = TestApp::with_config(low_limit_config()).await;
+    let (user_id, _) = create_test_user(&app.pool).await;
+    let token = generate_access_token(&app.config, user_id);
+    let mut guard = app.cleanup_guard();
+    guard.delete_user(user_id);
+
+    // Create 2 guilds (at limit)
+    let mut guild_ids = Vec::new();
+    for i in 0..2 {
+        let resp = app
+            .oneshot(
+                TestApp::request(Method::POST, "/api/guilds")
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(format!(
+                        r#"{{"name": "LimitGuild{i}"}}"#
+                    )))
+                    .unwrap(),
+            )
+            .await;
+        assert_eq!(resp.status(), StatusCode::OK, "Guild {i} should succeed");
+        let body = body_to_json(resp).await;
+        guild_ids.push(body["id"].as_str().unwrap().to_string());
+    }
+
+    // 3rd guild should fail
+    let resp = app
+        .oneshot(
+            TestApp::request(Method::POST, "/api/guilds")
+                .header("authorization", format!("Bearer {token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"name": "LimitGuild3"}"#))
+                .unwrap(),
+        )
+        .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let body = body_to_json(resp).await;
+    assert_eq!(body["error"], "LIMIT_EXCEEDED");
+
+    // Cleanup
+    for gid in &guild_ids {
+        let uuid = uuid::Uuid::parse_str(gid).unwrap();
+        delete_guild(&app.pool, uuid).await;
+    }
+}
+
+// ============================================================================
+// Member limit on invite join
+// ============================================================================
+
+#[tokio::test]
+async fn test_member_limit_on_invite_join() {
+    let app = TestApp::with_config(low_limit_config()).await;
+    let (owner_id, _) = create_test_user(&app.pool).await;
+    let (user2_id, _) = create_test_user(&app.pool).await;
+    let (user3_id, _) = create_test_user(&app.pool).await;
+    let owner_token = generate_access_token(&app.config, owner_id);
+    let user3_token = generate_access_token(&app.config, user3_id);
+    let guild_id = create_guild(&app.pool, owner_id).await;
+    let mut guard = app.cleanup_guard();
+    guard.add(move |pool| async move {
+        delete_guild(&pool, guild_id).await;
+        delete_user(&pool, owner_id).await;
+        delete_user(&pool, user2_id).await;
+        delete_user(&pool, user3_id).await;
+    });
+
+    // Owner is already member (1/2). Add user2 (2/2).
+    add_guild_member(&app.pool, guild_id, user2_id).await;
+
+    // Create invite
+    let resp = app
+        .oneshot(
+            TestApp::request(Method::POST, &format!("/api/guilds/{guild_id}/invites"))
+                .header("authorization", format!("Bearer {owner_token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"expires_in": "7d"}"#))
+                .unwrap(),
+        )
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let invite_body = body_to_json(resp).await;
+    let code = invite_body["code"].as_str().unwrap();
+
+    // user3 tries to join via invite — should fail (2/2)
+    let resp = app
+        .oneshot(
+            TestApp::request(Method::POST, &format!("/api/invites/{code}/join"))
+                .header("authorization", format!("Bearer {user3_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let body = body_to_json(resp).await;
+    assert_eq!(body["error"], "LIMIT_EXCEEDED");
+}
+
+// ============================================================================
+// Channel limit
+// ============================================================================
+
+#[tokio::test]
+async fn test_channel_limit() {
+    let app = TestApp::with_config(low_limit_config()).await;
+    let (owner_id, _) = create_test_user(&app.pool).await;
+    let token = generate_access_token(&app.config, owner_id);
+    let guild_id = create_guild(&app.pool, owner_id).await;
+    let mut guard = app.cleanup_guard();
+    guard.add(move |pool| async move {
+        delete_guild(&pool, guild_id).await;
+        delete_user(&pool, owner_id).await;
+    });
+
+    // Create @everyone role with MANAGE_CHANNELS
+    sqlx::query(
+        "INSERT INTO guild_roles (id, guild_id, name, permissions, position, is_default) VALUES ($1, $2, 'everyone', $3, 0, true)",
+    )
+    .bind(uuid::Uuid::now_v7())
+    .bind(guild_id)
+    .bind(vc_server::permissions::GuildPermissions::MANAGE_CHANNELS.to_db())
+    .execute(&app.pool)
+    .await
+    .unwrap();
+
+    // Create 2 channels (at limit)
+    for i in 0..2 {
+        let resp = app
+            .oneshot(
+                TestApp::request(Method::POST, "/api/channels")
+                    .header("authorization", format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(format!(
+                        r#"{{"name": "ch{i}", "channel_type": "text", "guild_id": "{guild_id}"}}"#
+                    )))
+                    .unwrap(),
+            )
+            .await;
+        assert_eq!(resp.status(), StatusCode::CREATED, "Channel {i} should succeed");
+    }
+
+    // 3rd channel should fail
+    let resp = app
+        .oneshot(
+            TestApp::request(Method::POST, "/api/channels")
+                .header("authorization", format!("Bearer {token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(format!(
+                    r#"{{"name": "ch_over", "channel_type": "text", "guild_id": "{guild_id}"}}"#
+                )))
+                .unwrap(),
+        )
+        .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let body = body_to_json(resp).await;
+    assert_eq!(body["error"], "LIMIT_EXCEEDED");
+}
+
+// ============================================================================
+// Role limit
+// ============================================================================
+
+#[tokio::test]
+async fn test_role_limit() {
+    let app = TestApp::with_config(low_limit_config()).await;
+    let (owner_id, _) = create_test_user(&app.pool).await;
+    let token = generate_access_token(&app.config, owner_id);
+    let guild_id = create_guild(&app.pool, owner_id).await;
+    let mut guard = app.cleanup_guard();
+    guard.add(move |pool| async move {
+        delete_guild(&pool, guild_id).await;
+        delete_user(&pool, owner_id).await;
+    });
+
+    // Create @everyone role with MANAGE_ROLES (counts as 1 of limit 2)
+    sqlx::query(
+        "INSERT INTO guild_roles (id, guild_id, name, permissions, position, is_default) VALUES ($1, $2, 'everyone', $3, 0, true)",
+    )
+    .bind(uuid::Uuid::now_v7())
+    .bind(guild_id)
+    .bind(vc_server::permissions::GuildPermissions::MANAGE_ROLES.to_db())
+    .execute(&app.pool)
+    .await
+    .unwrap();
+
+    // Create 1 more role (2/2)
+    let resp = app
+        .oneshot(
+            TestApp::request(Method::POST, &format!("/api/guilds/{guild_id}/roles"))
+                .header("authorization", format!("Bearer {token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"name": "Mod"}"#))
+                .unwrap(),
+        )
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK, "First extra role should succeed");
+
+    // Next role should fail (3/2)
+    let resp = app
+        .oneshot(
+            TestApp::request(Method::POST, &format!("/api/guilds/{guild_id}/roles"))
+                .header("authorization", format!("Bearer {token}"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"name": "Admin"}"#))
+                .unwrap(),
+        )
+        .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let body = body_to_json(resp).await;
+    assert_eq!(body["error"], "LIMIT_EXCEEDED");
+}
+
+// ============================================================================
+// Bot limit
+// ============================================================================
+
+#[tokio::test]
+async fn test_bot_limit() {
+    let app = TestApp::with_config(low_limit_config()).await;
+    let (owner_id, _) = create_test_user(&app.pool).await;
+    let token = generate_access_token(&app.config, owner_id);
+    let guild_id = create_guild(&app.pool, owner_id).await;
+    let mut guard = app.cleanup_guard();
+
+    // Create @everyone with MANAGE_GUILD
+    sqlx::query(
+        "INSERT INTO guild_roles (id, guild_id, name, permissions, position, is_default) VALUES ($1, $2, 'everyone', $3, 0, true)",
+    )
+    .bind(uuid::Uuid::now_v7())
+    .bind(guild_id)
+    .bind(vc_server::permissions::GuildPermissions::MANAGE_GUILD.to_db())
+    .execute(&app.pool)
+    .await
+    .unwrap();
+
+    // Create 2 bots
+    let (app1_id, bot1_id, _) = create_bot_application(&app.pool, owner_id).await;
+    let (app2_id, bot2_id, _) = create_bot_application(&app.pool, owner_id).await;
+
+    guard.add(move |pool| async move {
+        delete_bot_application(&pool, app1_id).await;
+        delete_bot_application(&pool, app2_id).await;
+        delete_guild(&pool, guild_id).await;
+        delete_user(&pool, owner_id).await;
+    });
+
+    // Install first bot (1/1)
+    let resp = app
+        .oneshot(
+            TestApp::request(
+                Method::POST,
+                &format!("/api/guilds/{guild_id}/bots/{bot1_id}/add"),
+            )
+            .header("authorization", format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap(),
+        )
+        .await;
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT, "First bot should succeed");
+
+    // Install second bot (2/1) — should fail
+    let resp = app
+        .oneshot(
+            TestApp::request(
+                Method::POST,
+                &format!("/api/guilds/{guild_id}/bots/{bot2_id}/add"),
+            )
+            .header("authorization", format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap(),
+        )
+        .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let body = body_to_json(resp).await;
+    assert_eq!(body["error"], "LIMIT_EXCEEDED");
+}
+
+// ============================================================================
+// Emoji limit
+// ============================================================================
+
+#[tokio::test]
+async fn test_emoji_limit() {
+    let app = TestApp::with_config(low_limit_config()).await;
+    let (owner_id, _) = create_test_user(&app.pool).await;
+    let token = generate_access_token(&app.config, owner_id);
+    let guild_id = create_guild(&app.pool, owner_id).await;
+    let mut guard = app.cleanup_guard();
+    guard.add(move |pool| async move {
+        delete_guild(&pool, guild_id).await;
+        delete_user(&pool, owner_id).await;
+    });
+
+    // Insert 1 emoji directly (at limit of 1)
+    sqlx::query(
+        "INSERT INTO guild_emojis (guild_id, name, image_url, uploaded_by) VALUES ($1, $2, $3, $4)",
+    )
+    .bind(guild_id)
+    .bind("existing_emoji")
+    .bind("https://example.com/emoji.png")
+    .bind(owner_id)
+    .execute(&app.pool)
+    .await
+    .unwrap();
+
+    // Next emoji upload should fail (2/1) — limit check runs before multipart parsing
+    let boundary = "----TestBoundary";
+    let body = format!(
+        "--{boundary}\r\nContent-Disposition: form-data; name=\"name\"\r\n\r\nover_limit\r\n\
+         --{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"test.png\"\r\n\
+         Content-Type: image/png\r\n\r\nfake-png-data\r\n\
+         --{boundary}--\r\n"
+    );
+
+    let resp = app
+        .oneshot(
+            TestApp::request(Method::POST, &format!("/api/guilds/{guild_id}/emojis"))
+                .header("authorization", format!("Bearer {token}"))
+                .header(
+                    "content-type",
+                    format!("multipart/form-data; boundary={boundary}"),
+                )
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let body = body_to_json(resp).await;
+    assert_eq!(body["error"], "LIMIT_EXCEEDED");
+}
+
+// ============================================================================
+// Member limit on discovery join
+// ============================================================================
+
+#[tokio::test]
+async fn test_member_limit_on_discovery_join() {
+    let mut config = low_limit_config();
+    config.enable_guild_discovery = true;
+    let app = TestApp::with_config(config).await;
+    let (owner_id, _) = create_test_user(&app.pool).await;
+    let (user2_id, _) = create_test_user(&app.pool).await;
+    let (user3_id, _) = create_test_user(&app.pool).await;
+    let user3_token = generate_access_token(&app.config, user3_id);
+    let guild_id = create_guild(&app.pool, owner_id).await;
+    let mut guard = app.cleanup_guard();
+    guard.add(move |pool| async move {
+        delete_guild(&pool, guild_id).await;
+        delete_user(&pool, owner_id).await;
+        delete_user(&pool, user2_id).await;
+        delete_user(&pool, user3_id).await;
+    });
+
+    // Make guild discoverable
+    sqlx::query("UPDATE guilds SET discoverable = true WHERE id = $1")
+        .bind(guild_id)
+        .execute(&app.pool)
+        .await
+        .unwrap();
+
+    // Owner is member (1/2). Add user2 (2/2).
+    add_guild_member(&app.pool, guild_id, user2_id).await;
+
+    // user3 tries to join via discovery — should fail (2/2)
+    let resp = app
+        .oneshot(
+            TestApp::request(
+                Method::POST,
+                &format!("/api/discover/guilds/{guild_id}/join"),
+            )
+            .header("authorization", format!("Bearer {user3_token}"))
+            .body(Body::empty())
+            .unwrap(),
+        )
+        .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let body = body_to_json(resp).await;
+    assert_eq!(body["error"], "LIMIT_EXCEEDED");
+}
+
+// ============================================================================
+// Usage endpoint
+// ============================================================================
+
+#[tokio::test]
+async fn test_usage_endpoint() {
+    let app = TestApp::new().await;
+    let (owner_id, _) = create_test_user(&app.pool).await;
+    let token = generate_access_token(&app.config, owner_id);
+    let guild_id = create_guild(&app.pool, owner_id).await;
+    let mut guard = app.cleanup_guard();
+    guard.add(move |pool| async move {
+        delete_guild(&pool, guild_id).await;
+        delete_user(&pool, owner_id).await;
+    });
+
+    // Create some channels
+    create_channel(&app.pool, guild_id, "general").await;
+    create_channel(&app.pool, guild_id, "random").await;
+
+    let resp = app
+        .oneshot(
+            TestApp::request(Method::GET, &format!("/api/guilds/{guild_id}/usage"))
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_to_json(resp).await;
+
+    assert_eq!(body["guild_id"], guild_id.to_string());
+    assert_eq!(body["plan"], "free");
+    assert_eq!(body["members"]["current"], 1); // owner
+    assert_eq!(body["channels"]["current"], 2);
+    assert!(body["members"]["limit"].as_i64().unwrap() > 0);
+    assert!(body["channels"]["limit"].as_i64().unwrap() > 0);
+}
+
+#[tokio::test]
+async fn test_usage_requires_membership() {
+    let app = TestApp::new().await;
+    let (owner_id, _) = create_test_user(&app.pool).await;
+    let (outsider_id, _) = create_test_user(&app.pool).await;
+    let outsider_token = generate_access_token(&app.config, outsider_id);
+    let guild_id = create_guild(&app.pool, owner_id).await;
+    let mut guard = app.cleanup_guard();
+    guard.add(move |pool| async move {
+        delete_guild(&pool, guild_id).await;
+        delete_user(&pool, owner_id).await;
+        delete_user(&pool, outsider_id).await;
+    });
+
+    let resp = app
+        .oneshot(
+            TestApp::request(Method::GET, &format!("/api/guilds/{guild_id}/usage"))
+                .header("authorization", format!("Bearer {outsider_token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+// ============================================================================
+// Instance limits endpoint
+// ============================================================================
+
+#[tokio::test]
+async fn test_instance_limits_endpoint() {
+    let app = TestApp::new().await;
+
+    let resp = app
+        .oneshot(
+            TestApp::request(Method::GET, "/api/config/limits")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_to_json(resp).await;
+
+    // Verify shape
+    assert!(body["max_guilds_per_user"].is_number());
+    assert!(body["max_members_per_guild"].is_number());
+    assert!(body["max_channels_per_guild"].is_number());
+    assert!(body["max_roles_per_guild"].is_number());
+    assert!(body["max_emojis_per_guild"].is_number());
+    assert!(body["max_bots_per_guild"].is_number());
+    assert!(body["max_webhooks_per_app"].is_number());
+    assert!(body["max_upload_size"].is_number());
+}


### PR DESCRIPTION
## Summary
- Add configurable per-guild resource limits enforced server-side at 8 code points (guild creation, member join via invite/discovery, channel/role/emoji/bot/webhook creation) with `LIMIT_EXCEEDED` (403) errors
- New `GET /api/guilds/{id}/usage` endpoint returns resource counts vs limits with parallel queries; `GET /api/config/limits` returns instance-wide limits (public)
- Database migration adds `plan` column to guilds (default: `free`) for future tier/boost system
- Frontend Usage tab in guild settings with progress bars and color-coded thresholds
- 10 integration tests covering all enforcement points, usage stats, and instance limits

## Details

**Config (env vars):** `MAX_GUILDS_PER_USER` (100), `MAX_MEMBERS_PER_GUILD` (1000), `MAX_CHANNELS_PER_GUILD` (200), `MAX_ROLES_PER_GUILD` (50), `MAX_EMOJIS_PER_GUILD` (50), `MAX_BOTS_PER_GUILD` (10), `MAX_WEBHOOKS_PER_APP` (5). All clamped to >= 1.

**Files:** 22 changed (18 modified, 4 new) — `server/src/guild/limits.rs`, `server/migrations/20260225000000_guild_plan.sql`, `server/tests/guild_limits_test.rs`, `client/src/components/guilds/UsageTab.tsx`

## Test plan
- [ ] `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings` passes (verified)
- [ ] `cargo test -p vc-server --test guild_limits_test` — 10 integration tests (requires DB)
- [ ] Manual: set `MAX_CHANNELS_PER_GUILD=3`, create 3 channels, verify 4th returns 403
- [ ] Manual: `GET /api/guilds/{id}/usage` returns correct counts and limits
- [ ] Manual: Usage tab in guild settings shows progress bars with correct data

🤖 Generated with [Claude Code](https://claude.com/claude-code)