### PR TITLE
docs(agents): add module guidance for server domains

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,40 +1,137 @@
 # PROJECT KNOWLEDGE BASE
 
-**Lifecycle:** Active
-**Last Updated:** 2026-02-27
+**Generated:** 2026-02-27 · **Commit:** a5cfe9f · **Branch:** main
 
-## Mandatory Start Policy
+## OVERVIEW
 
-Before starting any non-trivial work, create and use a dedicated git worktree.
+Self-hosted voice/text-chat platform for gaming communities. Rust monorepo: Axum server, Tauri 2.0 desktop client, Solid.js frontend. PostgreSQL + Valkey. MIT OR Apache-2.0.
 
-1. Ensure you are on an up-to-date base branch (`main` unless instructed otherwise).
-2. Create a feature/docs/fix branch in a new worktree.
-3. Perform all edits, tests, and commits from that worktree path.
-4. Keep the primary checkout clean for parallel work and emergency fixes.
+## STRUCTURE
 
-Recommended command pattern:
-
-```bash
-git worktree add -b "<branch-name>" "../canis-worktrees/<worktree-name>" main
+```
+./
+├── server/             # Rust backend (axum, sqlx, webrtc-rs) → see server/AGENTS.md
+├── client/             # Desktop app → see client/AGENTS.md
+│   ├── src/            # Solid.js frontend (UnoCSS, Solid Router)
+│   └── src-tauri/      # Rust backend (audio, crypto, WebRTC)
+├── shared/             # Shared Rust crates → see shared/AGENTS.md
+│   ├── vc-common/      # Types, WebSocket protocol (ClientEvent/ServerEvent)
+│   └── vc-crypto/      # E2EE (vodozemac Olm/Megolm)
+├── infra/              # Docker, Compose, Traefik → see infra/AGENTS.md
+├── docs/               # Architecture, security, plans, roadmap
+├── scripts/            # Dev setup, test runners → see scripts/AGENTS.md
+└── .sqlx/              # Offline query cache — COMMIT when queries change
 ```
 
-## Critical Documentation Map
+## WHERE TO LOOK
 
-Read these first to avoid redundant searching and to stay aligned with project direction:
+| Task | Location | Notes |
+|------|----------|-------|
+| Add REST endpoint | `server/src/api/` | Router in `mod.rs`, feature in own file |
+| Add WebSocket event | `shared/vc-common/src/protocol/` + `server/src/ws/` | Protocol change = BREAKING |
+| Add Tauri command | `client/src-tauri/src/commands/` + register in `lib.rs` | Thin adapter pattern |
+| Add UI component | `client/src/components/{domain}/` | Domain-organized |
+| Add reactive store | `client/src/stores/` | `createStore` pattern, see existing |
+| Add shared type | `shared/vc-common/src/types/` + re-export in `lib.rs` | Both server + client consume |
+| Add migration | `server/migrations/` | `sqlx migrate add -r <name> --source server/migrations` |
+| Change permissions | `server/src/permissions/` | Bitflags u64, deny wins over allow |
+| Voice/WebRTC | `server/src/voice/` + `client/src-tauri/src/webrtc/` | <50ms latency target |
+| Auth changes | `server/src/auth/` | Security review required |
+| E2EE crypto | `shared/vc-crypto/` + `client/src-tauri/src/crypto/` | vodozemac only, NEVER custom crypto |
+| Admin features | `server/src/admin/` + `client/src/components/admin/` | Elevated session required |
+| Styling/themes | `client/src/styles/` + `client/uno.config.ts` | CSS variables, `data-theme` attribute |
 
-- Roadmap and phase status: `docs/project/roadmap.md`
-- Active plan lifecycle rules: `docs/plans/PLAN_LIFECYCLE.md`
-- Phase 7 observability design: `docs/plans/2026-02-15-phase-7-a11y-observability-design.md`
-- Phase 7 observability implementation baseline: `docs/plans/2026-02-15-phase-7-a11y-observability-implementation.md`
-- OTel and Grafana reference architecture: `docs/plans/2026-02-15-opentelemetry-grafana-reference-design.md`
-- Operational safety implementation plan: `docs/plans/2026-02-15-operational-safety-implementation-plan.md`
+## WORKSPACE
 
-## Quick Execution Checklist
+4-crate Rust workspace + Solid.js frontend:
 
-Use this checklist at task start:
+| Crate | Type | Binary | Purpose |
+|-------|------|--------|---------|
+| `server/` | lib+bin | `vc-server` | REST API, WebSocket, SFU |
+| `client/src-tauri/` | lib+bin | `vc-client` | Audio, crypto, WebRTC |
+| `shared/vc-common/` | lib | — | Types, protocol |
+| `shared/vc-crypto/` | lib | — | E2EE primitives |
 
-- [ ] Worktree created and branch named per convention
-- [ ] Roadmap phase and target item confirmed
-- [ ] Relevant design + implementation docs opened
-- [ ] Standards profile considered (OTel, W3C Trace Context, WCAG where applicable)
-- [ ] Verification commands identified before first code change
+Dependency graph (acyclic): server/client → vc-common, vc-crypto. Shared crates have NO internal deps.
+
+## CONVENTIONS
+
+**Rust:**
+- `unsafe_code = "forbid"` — no unsafe anywhere
+- Clippy: pedantic + nursery warnings (`[workspace.lints]` in Cargo.toml)
+- rustfmt: 100-char lines, module-granularity imports, `StdExternalCrate` grouping
+- Errors: `thiserror` for library, `anyhow` for application
+- Observability: `#[tracing::instrument(skip(pool))]` on all public fns
+- Modules: `mod.rs` + feature files per service
+
+**TypeScript/Solid.js:**
+- Strict mode, no unused locals/params
+- Path alias: `@/*` → `./src/*`
+- UnoCSS utility classes + CSS variable themes
+- Props: NEVER destructure (breaks Solid.js reactivity)
+- Lists: `<For>` not `.map()`
+
+**Git:**
+- NEVER commit to main — always feature branch + squash merge PR
+- Branch: `feature/`, `fix/`, `refactor/`, `docs/`
+- Commit: `type(scope): subject` (max 72 chars, imperative)
+- Changelog: user-facing changes in `CHANGELOG.md` under `[Unreleased]`
+
+**Builds:**
+- SQLx offline: `SQLX_OFFLINE=true` in CI, commit `.sqlx/` on query changes
+- Frontend package manager: **Bun** (not npm/yarn)
+- License compliance: `cargo deny check licenses` — no GPL/AGPL/LGPL
+
+## ANTI-PATTERNS (THIS PROJECT)
+
+- **No `as any` / `@ts-ignore` / `@ts-expect-error`** — strict TS enforced
+- **No unsafe Rust** — `forbid(unsafe_code)` workspace-wide
+- **No GPL/AGPL dependencies** — `cargo deny` enforces
+- **No tokens in localStorage** — Tauri secure storage (browser dev mode excepted)
+- **No logging private keys / decrypted content** — vc-crypto constraint
+- **No mocking crypto ops** — use real vodozemac in tests
+- **No direct main commits** — feature branches only
+- **No console.log in prod** — stripped by Vite build config
+- **Protocol changes are BREAKING** — ClientEvent/ServerEvent in vc-common
+
+## COMMANDS
+
+```bash
+# Development
+make setup                # Full dev environment setup
+make dev                  # Server with auto-reload (cargo watch)
+make client               # Tauri dev (Solid.js + Rust)
+
+# Testing
+cargo test -p vc-server   # Server tests (uses cargo-nextest in CI)
+bun run test:run          # Frontend tests (vitest, single run)
+npx playwright test       # E2E tests
+
+# Quality Gates (run before PR)
+SQLX_OFFLINE=true cargo clippy -- -D warnings
+cargo fmt --check
+cargo deny check licenses
+bun run lint && bun run format
+
+# Database
+sqlx migrate run --source server/migrations
+sqlx migrate add -r <name> --source server/migrations
+
+# Docker
+make docker-up            # Start PostgreSQL 16, Valkey, RustFS
+make docker-down          # Stop services
+```
+
+## NOTES
+
+- **Dual-mode client**: `window.__TAURI__` detection in `lib/tauri.ts` branches native vs browser
+- **SQLx offline cache**: CI uses `SQLX_OFFLINE=true` — regenerate `.sqlx/` when changing queries
+- **Optional services**: S3 and rate limiting degrade gracefully if unavailable
+- **WebRTC ports**: Server exposes 10000-10100/udp for voice RTP
+- **Stack**: PostgreSQL 16 + Valkey (Redis-compatible) + optional RustFS (S3)
+- **MSRV**: Rust 1.82, Edition 2021
+- **Voice**: SFU architecture (not MCU) — server forwards RTP, clients mix audio
+- **E2EE**: Text via Olm/Megolm (vodozemac), voice via DTLS-SRTP (server-trusted, MLS planned)
+- **Permissions**: Bitflags u64, role stacking with channel overrides, deny > allow
+- **Tauri 2.0**: 100+ commands in `client/src-tauri/src/lib.rs`
+- **Tech debt**: Tracked in `docs/project/tech-debt.md` (14 open items)

--- a/server/src/moderation/AGENTS.md
+++ b/server/src/moderation/AGENTS.md
@@ -1,0 +1,67 @@
+<!-- Parent: ../AGENTS.md -->
+# Moderation Module
+
+## Purpose
+User reporting queue (submit, claim, resolve) and per-guild content filtering (keyword + regex engine, caching, audit log). Security-critical: all filter mutations write to the audit log.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `types.rs` | Report enums (`ReportCategory`, `ReportStatus`, `ReportTargetType`) and `ReportError` with `IntoResponse` |
+| `handlers.rs` | `POST /api/reports` — user-facing only; enforces 5-reports/hour Redis rate limit and duplicate detection via DB unique index |
+| `admin_handlers.rs` | Report queue management (`list`, `get`, `claim`, `resolve`, `stats`); requires `ElevatedAdmin` extension on claim |
+| `filter_types.rs` | `FilterCategory` (Slurs/HateSpeech/Spam/AbusiveLanguage/Custom), `FilterAction` (Block/Log/Warn), DB models, request/response types, `FilterError` |
+| `filter_engine.rs` | Hybrid Aho-Corasick (keywords, fast path) + `regex::Regex` (patterns); `FilterEngine::build()` compiles once, `check()` runs both passes |
+| `filter_cache.rs` | `DashMap`-backed per-guild engine cache; generation counters prevent TOCTOU races on concurrent invalidation |
+| `filter_handlers.rs` | CRUD for filter configs and custom patterns under `/api/guilds/{id}/filters`; `test_filter` uses `build_ephemeral` to avoid cache churn |
+| `filter_queries.rs` | All DB ops for `guild_filter_configs`, `guild_filter_patterns`, `moderation_actions`; truncates logged content to 200 chars |
+| `defaults.rs` | Embeds wordlists via `include_str!` at compile time; `parse_wordlist()` splits lines into keywords vs `regex:`-prefixed patterns |
+| `wordlists/` | Four `.txt` files (`slurs.txt`, `hate_speech.txt`, `spam_patterns.txt`, `abusive.txt`) — see TD-26 below |
+
+## For AI Agents
+
+### Two Separate Subsystems
+Reports and filters are independent. Reports live in `user_reports` table with their own error type (`ReportError`). Filters live in `guild_filter_configs` / `guild_filter_patterns` / `moderation_actions` with `FilterError`. Don't mix them.
+
+### Filter Architecture Flow
+```
+message arrives → FilterCache::get_or_build(guild_id)
+                → FilterEngine::check(content)
+                → if blocked: filter_queries::log_moderation_action()
+```
+`FilterCache` is stored in `AppState` as `filter_cache: Arc<FilterCache>`. Call `state.filter_cache.invalidate(guild_id)` after every mutation to filter configs or patterns — all three mutating handlers already do this.
+
+### Cache Invalidation Pattern
+Every handler that mutates filter state must:
+1. Write to DB
+2. Call `state.filter_cache.invalidate(guild_id)`
+3. Write audit log via `permissions::queries::write_audit_log()`
+
+Missing any step is a bug. The audit log call uses `.ok()` — failures are non-fatal.
+
+### Test Endpoint Uses Ephemeral Engine
+`POST /api/guilds/{id}/filters/test` calls `build_ephemeral` instead of `get_or_build`. This builds a fresh engine from DB without inserting into the shared cache, so test runs don't pollute production cache state.
+
+### ReDoS Protection
+`validate_regex()` in `filter_handlers.rs` compiles the regex then runs it against 1000 `'a'` chars. If that takes >10ms, the pattern is rejected. Apply this check whenever accepting user-supplied regex.
+
+### Custom Patterns: Hard Limits
+- Max 100 patterns per guild (`MAX_CUSTOM_PATTERNS`)
+- Max 500 chars per pattern (`MAX_PATTERN_LENGTH`)
+- Max 4000 chars for test input (`MAX_TEST_INPUT_LENGTH`)
+
+### Double-Option Deserialization
+`UpdatePatternRequest.description` uses `Option<Option<String>>` with a custom deserializer. Absent field = don't change. `null` = clear to NULL. String value = update. The DB query uses a boolean sentinel (`$5`) to distinguish "set null" from "leave unchanged".
+
+### Permission Gate
+All filter endpoints require `GuildPermissions::MANAGE_GUILD`. The check is `require_guild_permission(...).map_err(|_| FilterError::Forbidden)`. Admin report endpoints require `ElevatedAdmin` (elevated session, not just guild permission).
+
+### TD-26: Wordlists Are Placeholders
+`wordlists/slurs.txt`, `hate_speech.txt`, and `abusive.txt` contain only comment headers — no actual entries. `spam_patterns.txt` has 4 regex patterns. The built-in filter categories (`Slurs`, `HateSpeech`, `AbusiveLanguage`) will match nothing until these files are populated. Custom guild patterns work correctly regardless.
+
+### Report Duplicate Detection
+The unique index `idx_reports_no_duplicate_active` on `user_reports` prevents duplicate active reports. The handler catches `sqlx::Error::Database` and checks `db_err.constraint()` to return `ReportError::Duplicate` (409) instead of a generic 500.
+
+### Moderation Log Content Truncation
+`log_moderation_action` truncates `original_content` to 200 chars on a valid UTF-8 char boundary before storing. This is intentional data minimization — don't remove it.

--- a/server/src/pages/AGENTS.md
+++ b/server/src/pages/AGENTS.md
@@ -1,0 +1,47 @@
+<!-- Parent: ../AGENTS.md -->
+# Pages Module
+
+## Purpose
+Static information pages for the platform and guilds. Two scopes: platform-level (Terms of Service, Privacy Policy) and guild-level (rules, FAQ, welcome). Not chat channels.
+
+## Key Files
+
+- `types.rs` - Core structs: `Page` (full content), `PageListItem` (no content, for listings), `PageRevision`, `PageAcceptance`, `PageCategory`. Contains `deserialize_double_option` for `Option<Option<Uuid>>` on `category_id` — handles absent/null/value distinction.
+- `queries.rs` - All DB access. `hash_content()` computes SHA-256 of content stored as `content_hash`. `slugify()` lowercases + replaces non-alphanumeric with `-`. Position assigned atomically via inline `COUNT(*)` subquery on insert.
+- `handlers.rs` - 1888 lines. Platform handlers require `is_system_admin`. Guild handlers require `GuildPermissions::MANAGE_PAGES`. Read endpoints (list, get-by-slug) require auth but no special permission. `get_pending_acceptance` returns pages the calling user hasn't accepted yet.
+- `constants.rs` - Hard limits: 100KB content, 100-char title/slug, 50-char category name, 10 pages/scope (configurable via `config.max_pages_per_guild`), 25 revisions/page, 20 categories/guild, 7-day slug cooldown after deletion.
+- `router.rs` - Three routers: `platform_pages_router` (`/api/pages`), `guild_pages_router` (`/api/guilds/{guild_id}/pages`), `guild_page_categories_router` (`/api/guilds/{guild_id}/page-categories`).
+
+## For AI Agents
+
+### Scope Distinction
+`guild_id: Option<Uuid>` is the scope discriminator throughout. `None` = platform page, `Some(id)` = guild page. All queries branch on this. Platform pages don't support categories.
+
+### Permission Model
+- **Read** (list, get-by-slug): any authenticated user, no permission check beyond `require_auth` middleware.
+- **Write** (create, update, delete, reorder, restore): platform pages require `is_system_admin`; guild pages require `GuildPermissions::MANAGE_PAGES`.
+- **Accept**: any authenticated user can accept any page (`POST /{id}/accept`).
+
+### Revision System
+Every create and update snapshots a `PageRevision`. Revisions are numbered sequentially per page. Restore (`POST /{page_id}/revisions/{n}/restore`) creates a new revision rather than mutating history. Max revisions enforced at create time; oldest revision is pruned when limit is hit.
+
+### Slug Rules
+- Auto-generated from title via `slugify()` if not provided.
+- Must not match `RESERVED_SLUGS` (includes `admin`, `api`, `new`, `edit`, `settings`, etc.).
+- 7-day cooldown after deletion — slug can't be reused immediately.
+- Slug uniqueness is scoped: same slug can exist in different guilds or on platform.
+
+### Content Format
+Markdown with Mermaid diagram support (rendering is client-side). Stored as raw text. `content_hash` (SHA-256 hex) tracks versions for acceptance records — if content changes, prior acceptances are stale.
+
+### Acceptance Tracking
+`PageAcceptance` records `(user_id, page_id, content_hash)`. `get_pending_acceptance` returns pages with `requires_acceptance = true` where the user has no acceptance record matching the current `content_hash`.
+
+### Error Handling
+Handlers use `type PageResult<T> = Result<T, (StatusCode, String)>`. Permission check DB errors fail-fast (500, not 403) to avoid security ambiguity. Slug/limit checks default to "assume at limit" on DB error.
+
+### Adding a New Page Endpoint
+1. Add query function in `queries.rs`.
+2. Add handler in `handlers.rs` — check scope, check permission, validate, call query.
+3. Register route in the appropriate router in `router.rs`.
+4. Annotate with `#[utoipa::path(...)]` matching existing handler patterns.

--- a/server/src/webhooks/AGENTS.md
+++ b/server/src/webhooks/AGENTS.md
@@ -1,0 +1,48 @@
+<!-- Parent: ../AGENTS.md -->
+# Webhooks Module
+
+## Purpose
+HTTP POST delivery of platform events to bot endpoints. Covers the full lifecycle: CRUD management, event dispatch, HMAC-signed delivery with exponential backoff, and dead-letter handling.
+
+## Key Files
+
+- `types.rs` — Core structs. `Webhook` includes `signing_secret` (encrypted at rest). `WebhookResponse` omits it. `WebhookCreatedResponse` returns it once at creation. `WebhookDeliveryItem` is the Redis queue payload — signing secret is intentionally absent (fetched from DB at delivery time).
+- `events.rs` — `BotEventType` enum (`message.created`, `member.joined`, `member.left`, `command.invoked`). Maps to the `webhook_event_type` PostgreSQL enum via `#[sqlx(type_name = "webhook_event_type")]`. `GatewayIntent` groups event types; `CommandInvoked` is always permitted regardless of declared intents.
+- `handlers.rs` — REST CRUD (`POST/GET/PATCH/DELETE` under `/api/applications/{app_id}/webhooks`). All handlers call `verify_ownership` first. URL validation runs `ssrf::is_blocked_host` at registration time. Signing secrets are encrypted with `MFA_ENCRYPTION_KEY` (AES-256-GCM via `auth::mfa_crypto`) before DB insert; plaintext is returned once at creation only.
+- `queries.rs` — Uses runtime `sqlx::query` / `sqlx::query_as` (not compile-time macros) to avoid requiring a live DB at compile time. `get_webhook_full` returns the signing secret; `get_webhook` does not. `find_guild_webhooks_for_event` joins `guild_bot_installations` to scope delivery to installed bots.
+- `dispatch.rs` — Non-blocking entry points called from other modules. `dispatch_guild_event` fans out to all matching webhooks for a guild. `dispatch_command_event` targets a specific application. Both enqueue to Redis and swallow errors with `warn!` (never block the caller).
+- `delivery.rs` — Background worker (`spawn_delivery_worker`). Pulls from `webhook:delivery:queue` (Redis list, BRPOP). Retries go into `webhook:delivery:retry` (sorted set, score = Unix timestamp). A Lua script atomically promotes due retries to avoid double-delivery. Max 5 attempts; delays: 5s, 30s, 120s, 600s, 1800s. SSRF-blocked deliveries are NOT retried.
+- `signing.rs` — HMAC-SHA256. `sign_payload` returns hex. `verify_signature` uses constant-time comparison (manual XOR fold, not `==`). `generate_signing_secret` produces 32 random bytes as 64-char hex.
+- `ssrf.rs` — Two-layer protection. `is_blocked_host` checks at registration (static: hostname blocklist + IP parse). `verify_resolved_ip` checks at delivery (dynamic: DNS resolution + IP validation). Returns `VerifiedUrl` with a pinned `SocketAddr`; the delivery worker builds a per-request `reqwest::Client` with `.resolve()` to pin the IP and prevent DNS rebinding between check and send.
+
+## For AI Agents
+
+### Webhook Lifecycle
+```
+Create → validate URL (ssrf::is_blocked_host) → encrypt secret → store
+Dispatch → find matching webhooks → enqueue WebhookDeliveryItem to Redis
+Deliver → BRPOP → ssrf::verify_resolved_ip → fetch+decrypt secret → sign → POST
+Retry → schedule_retry into sorted set → promote_due_retries (Lua) → re-enqueue
+Dead-letter → after 5 attempts → insert_dead_letter
+```
+
+### Security Rules
+- **Signing secret never in Redis.** `WebhookDeliveryItem` has no `signing_secret` field. The worker fetches it from DB at delivery time via `queries::get_signing_secret`.
+- **Signing secret encrypted at rest.** Uses `auth::mfa_crypto::{encrypt_mfa_secret, decrypt_mfa_secret}` (AES-256-GCM). Legacy plaintext secrets are handled with a `warn!` fallback, not an error.
+- **SSRF is two-phase.** Registration blocks known-bad hostnames/IPs. Delivery resolves DNS and pins the IP. Both checks must pass. SSRF failures at delivery skip retry entirely.
+- **Constant-time signature comparison.** `verify_signature` uses XOR fold, not string equality. Don't replace with `==`.
+- **Limit: 5 webhooks per application.** Enforced in `create_webhook` handler via `config.max_webhooks_per_app`.
+
+### Adding a New Event Type
+1. Add variant to `BotEventType` in `events.rs` with matching `#[serde(rename)]` and `#[sqlx(rename)]`.
+2. Add a migration to extend the `webhook_event_type` PostgreSQL enum.
+3. Wire up a `dispatch_guild_event` or `dispatch_command_event` call at the relevant site.
+4. Update `GatewayIntent::event_types()` if the event belongs to an existing intent group.
+
+### Anti-Patterns
+- Don't call `queries::get_webhook_full` in list/read handlers — it exposes the signing secret.
+- Don't store `signing_secret` in `WebhookDeliveryItem` or any Redis payload.
+- Don't use `==` for signature comparison — always use `verify_signature`.
+- Don't retry SSRF-blocked deliveries — the URL is the problem, not a transient failure.
+- Don't block the caller in `dispatch_*` functions — they must remain fire-and-forget.
+- Don't use compile-time `sqlx::query!` macros here — this module intentionally uses runtime queries.


### PR DESCRIPTION
## Summary
- restore the root `AGENTS.md` knowledge-base content snapshot
- add module-specific AGENTS guidance for `server/src/moderation`, `server/src/pages`, and `server/src/webhooks`
- capture security-critical and architectural notes so future edits follow existing module constraints

## Verification
- verified branch is clean after commit
- confirmed commit is pushed to `origin/docs/agent-submodule-guides`