### PR TITLE
docs(roadmap): add phase 7 admin command center planning docs

### DIFF
--- a/docs/plans/2026-02-27-phase-7-admin-command-center-design.md
+++ b/docs/plans/2026-02-27-phase-7-admin-command-center-design.md
@@ -1,0 +1,236 @@
+# Phase 7 Admin Command Center - Design
+
+**Date:** 2026-02-27
+**Status:** Draft
+**Roadmap Scope:** Phase 7 `[Ops] Admin Command Center (Native Observability Lite)`
+**Related:**
+- `docs/project/roadmap.md`
+- `docs/ops/observability-contract.md`
+- `docs/ops/observability-runbook.md`
+- `docs/plans/2026-02-15-phase-7-a11y-observability-design.md`
+- `docs/plans/2026-02-15-opentelemetry-grafana-reference-design.md`
+
+## Problem
+
+Phase 7 observability foundations are in place (OTel + collector + Grafana stack reference), but operators currently need external tooling for most runtime visibility. This creates two gaps:
+
+1. Self-hosted operators without full Grafana setup lack practical day-to-day insight.
+2. Admin workflows are split between in-app moderation/admin actions and external telemetry tools.
+
+We need a native admin Command Center that gives immediate operational awareness while preserving external observability as the deep-analysis path.
+
+## Goals
+
+- Provide a cluster-wide command center in the existing admin panel for all system admins.
+- Deliver useful native observability with strict 30-day retention.
+- Show high-signal health, reliability, and incident context without requiring external Grafana stack.
+- Preserve compatibility with OTel/Grafana stack and deep-link into external tools when available.
+- Keep runtime and storage overhead bounded for self-hosted installations.
+
+## Non-Goals
+
+- Replacing Grafana, Tempo, Loki, or Prometheus.
+- Building an in-app trace waterfall viewer or full log query language.
+- Providing retention beyond 30 days in native storage.
+- Multi-tenant observability segmentation in v1.
+- Per-node access restrictions in v1 (view is cluster-wide for all system admins).
+
+## Product Decision Summary
+
+- **Access model:** cluster-wide, visible to all system admins.
+- **Retention model:** native telemetry retained for 30 days max.
+- **Escalation path:** users requiring deeper history or advanced queries must use external stack.
+- **UX boundary:** native panel is for fast triage and operational awareness, not full forensic analysis.
+
+## User Experience
+
+### Command Center Panels
+
+1. **System Health (always visible):**
+   - API request rate (1m)
+   - API error rate (5m)
+   - API p95/p99 latency (5m)
+   - Active WebSocket connections
+   - Active voice sessions
+   - Telemetry pipeline status (collector/export path)
+
+2. **Reliability Trends (30-day charts):**
+   - Daily API error rate
+   - Daily p95/p99 latency
+   - Daily voice join success rate
+   - Daily auth failure rate
+   - Daily WebSocket reconnect rate
+
+3. **Top Offenders:**
+   - Top failing routes
+   - Top slow routes
+   - Top error categories (`auth`, `db`, `ws`, `voice`, `ratelimit`)
+
+4. **Logs (curated native view):**
+   - ERROR/WARN focused list
+   - Filter by domain and time range
+   - Display trace id if present
+
+5. **Trace Index (not full traces):**
+   - Recent failed trace records
+   - Recent slow trace records
+   - Filters by route/domain/status/time
+   - `Open in Grafana/Tempo` actions when external stack is configured
+
+## Information Architecture
+
+### Signal Split
+
+- **Metrics:** first-class native signal, stored in Postgres/Timescale for 30 days.
+- **Logs:** native curated event stream with compact schema and 30-day TTL.
+- **Traces:** native index metadata only (trace id, route/span, duration, status, timestamp), 30-day TTL.
+- **Full traces/log corpus:** external stack only.
+
+This split gives strong native value while avoiding high cardinality and storage blowups from raw spans/logs.
+
+## Data Model (Native Retention)
+
+### 1) `telemetry_metric_samples` (Timescale hypertable)
+
+- `ts timestamptz not null`
+- `metric_name text not null`
+- `scope text not null` (cluster/domain)
+- `labels jsonb not null` (allowlisted dimensions only)
+- `value_double double precision null`
+- `value_int bigint null`
+
+Policies:
+- Retention: 30 days hard delete.
+- Downsample: rollups after day 7 to reduce storage/query cost.
+
+### 2) `telemetry_log_events`
+
+- `id uuid pk`
+- `ts timestamptz not null`
+- `level text not null` (`ERROR`, `WARN`, selected `INFO`)
+- `service text not null`
+- `domain text not null`
+- `event text not null`
+- `message text not null`
+- `trace_id text null`
+- `span_id text null`
+- `attrs jsonb not null default '{}'::jsonb`
+
+Policies:
+- Retention: 30 days hard delete.
+- Store only sanitized/allowlisted attributes.
+
+### 3) `telemetry_trace_index`
+
+- `trace_id text not null`
+- `span_name text not null`
+- `domain text not null`
+- `route text null`
+- `status_code text null`
+- `duration_ms integer not null`
+- `ts timestamptz not null`
+- `service text not null`
+
+Policies:
+- Retention: 30 days hard delete.
+- No span payload/body storage.
+
+## API Design (Admin)
+
+All endpoints are under `/api/admin/observability/*` and require `SystemAdminUser`.
+
+### Health and Overview
+
+- `GET /api/admin/observability/summary`
+  - Returns top-card KPIs and pipeline status.
+
+### Trends
+
+- `GET /api/admin/observability/trends?range=24h|7d|30d`
+  - Returns pre-aggregated chart series.
+
+### Top Offenders
+
+- `GET /api/admin/observability/top-routes?range=...`
+- `GET /api/admin/observability/top-errors?range=...`
+
+### Logs
+
+- `GET /api/admin/observability/logs?level=&domain=&from=&to=&limit=&offset=`
+
+### Trace Index
+
+- `GET /api/admin/observability/traces?status=&domain=&route=&from=&to=&limit=&offset=`
+
+### External Deep Links Config
+
+- `GET /api/admin/observability/links`
+  - Returns enabled external URLs/actions (Grafana/Tempo/Loki/Prometheus) if configured.
+
+## Security and Privacy
+
+- Reuse `observability-contract.md` redaction rules.
+- Enforce strict attribute allowlist for persisted logs and metric labels.
+- Never persist secrets, auth tokens, private message content, key material, or raw request bodies.
+- Keep admin-only access behind existing system admin middleware.
+- Record access to observability endpoints in audit log (`admin.observability.view`).
+
+## Cardinality and Cost Controls
+
+- Ban high-cardinality labels (`user_id`, `session_id`, arbitrary ids) in native metric labels.
+- Restrict route labels to parameterized templates.
+- Enforce per-query limits and bounded time ranges.
+- Pre-aggregate trend queries; avoid on-demand expensive scans of raw rows.
+
+## Operational Behavior
+
+- **Degraded mode:** if collector/external stack is unavailable, native panel remains functional using native storage.
+- **Freshness indicators:** each panel shows last successful ingest/update time.
+- **Backfill behavior:** no historical backfill beyond native retention boundaries.
+
+## Performance Constraints
+
+- Dashboard API p95 target: <= 200 ms for summary/top endpoints.
+- Trend endpoint p95 target: <= 500 ms for 30-day range.
+- UI refresh cadence: 10-30 seconds depending on panel.
+- Ingestion jobs must be async and bounded; no hot-path blocking.
+
+## Rollout Plan
+
+### Phase 1 - Foundations
+
+1. Add `command-center` panel in admin UI.
+2. Define backend observability admin route group.
+3. Add native telemetry tables and retention jobs.
+
+### Phase 2 - MVP Data and Views
+
+1. Implement summary/trends/top-routes/top-errors endpoints.
+2. Implement logs and trace-index list endpoints.
+3. Build native command center cards, charts, and tables.
+
+### Phase 3 - External Hand-off
+
+1. Add optional external deep-link configuration.
+2. Add `Open in Grafana/Tempo/Loki` actions.
+3. Add empty/degraded states and setup guidance.
+
+### Phase 4 - Hardening
+
+1. Add tests for redaction and label allowlist enforcement.
+2. Add retention/downsampling verification checks.
+3. Add CI checks for schema and contract conformance.
+
+## Success Criteria
+
+- All system admins can open cluster-wide command center and see current health signals.
+- Native logs/trace-index/metrics data is queryable for last 30 days only.
+- Degraded mode works without external stack.
+- External links appear when stack is configured.
+- No forbidden fields leak into persisted native telemetry.
+
+## Open Questions
+
+- Do we expose `INFO` logs in v1 or keep native logs strictly `WARN/ERROR`?
+- Should trend aggregation run synchronous-on-read or precomputed materialized views?
+- Do we add an export endpoint (CSV/JSON) for native command center datasets in v1?

--- a/docs/plans/2026-02-27-phase-7-admin-command-center-implementation.md
+++ b/docs/plans/2026-02-27-phase-7-admin-command-center-implementation.md
@@ -1,0 +1,254 @@
+# Phase 7 Admin Command Center - Implementation Plan
+
+**Date:** 2026-02-27
+**Status:** Draft
+**Design Doc:** `docs/plans/2026-02-27-phase-7-admin-command-center-design.md`
+**Task Plan:** `docs/plans/2026-02-27-phase-7-admin-command-center-task-plan.md`
+**Roadmap Item:** Phase 7 `[Ops] Admin Command Center (Native Observability Lite)`
+
+## Objective
+
+Implement a cluster-wide native admin Command Center that provides 30-day operational visibility for all system admins while preserving external observability (Grafana/Tempo/Loki/Prometheus) for deep analysis.
+
+## Open-Source and Maintenance Policy
+
+This feature must use actively maintained open-source tooling only.
+
+### Required policy gates
+
+1. **Open source license only**
+   - Allowed: permissive licenses compatible with project policy (MIT, Apache-2.0, BSD).
+   - Disallowed: GPL/AGPL/LGPL dependencies in runtime path (already aligned with `cargo deny`).
+
+2. **Maintenance recency**
+   - Any new dependency must show active maintenance (recent releases and non-stale issue/PR activity).
+   - Avoid deprecated or archived projects.
+
+3. **No abandoned observability components**
+   - Prefer OpenTelemetry ecosystem defaults and Grafana stack components with active support.
+   - Do not introduce legacy/deprecated telemetry SDKs or exporters.
+
+4. **Version pinning and upgrade discipline**
+   - Pin Docker images and dependency ranges to known-good versions.
+   - Track upgrade cadence in roadmap/runbook notes.
+
+5. **Standards adherence**
+   - Keep OTel semantic conventions, OTLP transport, and redaction contract alignment.
+   - Preserve vendor-neutral architecture boundaries.
+
+## Scope
+
+### In scope (native)
+
+- Admin UI panel `command-center`
+- Summary health cards and 30-day trends
+- Top offenders (slow/failing routes, error categories)
+- Curated log list (WARN/ERROR, redacted)
+- Trace index list (metadata only, no span payload storage)
+- Native retention enforcement (30 days max)
+- Optional deep-links to external Grafana stack when configured
+
+### Out of scope (v1)
+
+- In-app full trace waterfall renderer
+- In-app advanced log query language
+- Native retention beyond 30 days
+- Alert-rule authoring UI
+- Per-node or per-role observability segmentation
+
+## Implementation Phases
+
+## Phase 1 - Data Foundation
+
+1. **Add telemetry storage schema (30-day native model)**
+   - Files:
+     - `server/migrations/<new>_telemetry_native_command_center.sql`
+   - Tasks:
+     - Create `telemetry_metric_samples` (Timescale hypertable)
+     - Create `telemetry_log_events`
+     - Create `telemetry_trace_index`
+     - Add indexes for `ts`, domain, severity/status, route/span
+
+2. **Add retention/downsampling jobs**
+   - Files:
+     - `server/migrations/<same or follow-up>_telemetry_retention_policies.sql`
+   - Tasks:
+     - Enforce strict 30-day deletion policies
+     - Add metric downsampling after day 7
+
+3. **Add storage/query modules**
+   - Files:
+     - `server/src/observability/storage.rs` (new)
+     - `server/src/observability/mod.rs`
+   - Tasks:
+     - Insert/query helpers for metrics/logs/trace index
+     - Add bounded query defaults and max limits
+
+## Phase 2 - Ingestion and Contracts
+
+4. **Wire curated native telemetry ingestion**
+   - Files:
+     - `server/src/observability/tracing.rs`
+     - `server/src/observability/metrics.rs`
+     - `server/src/main.rs`
+   - Tasks:
+     - Persist only allowlisted fields for logs and trace index
+     - Persist selected metric aggregates for command center views
+     - Preserve existing OTLP export path
+
+5. **Implement cardinality guardrails**
+   - Files:
+     - `server/src/observability/metrics.rs`
+     - `docs/ops/observability-contract.md`
+   - Tasks:
+     - Explicit label allowlist for native metric storage
+     - Reject/drop forbidden high-cardinality labels
+
+6. **Audit and security hooks**
+   - Files:
+     - `server/src/admin/handlers.rs`
+     - `server/src/permissions/queries.rs`
+   - Tasks:
+     - Add `admin.observability.view` audit event on access
+     - Ensure redaction and no sensitive field persistence
+
+## Phase 3 - Admin API Surface
+
+7. **Add command center admin endpoints**
+   - Files:
+     - `server/src/admin/mod.rs`
+     - `server/src/admin/handlers.rs`
+     - `server/src/admin/types.rs`
+   - Endpoints:
+     - `GET /api/admin/observability/summary`
+     - `GET /api/admin/observability/trends`
+     - `GET /api/admin/observability/top-routes`
+     - `GET /api/admin/observability/top-errors`
+     - `GET /api/admin/observability/logs`
+     - `GET /api/admin/observability/traces`
+     - `GET /api/admin/observability/links`
+
+8. **Bounded query protections**
+   - Files:
+     - `server/src/admin/handlers.rs`
+   - Tasks:
+     - Max page size and strict range validation
+     - Default sort order and stable pagination keys
+
+## Phase 4 - Client Admin Panel
+
+9. **Add sidebar and panel wiring**
+   - Files:
+     - `client/src/components/admin/AdminSidebar.tsx`
+     - `client/src/views/AdminDashboard.tsx`
+   - Tasks:
+     - Add `command-center` panel id and nav entry
+     - Route panel rendering in admin dashboard
+
+10. **Create Command Center UI components**
+    - Files:
+      - `client/src/components/admin/CommandCenterPanel.tsx` (new)
+      - `client/src/components/admin/index.ts`
+    - Tasks:
+      - Health cards, trend charts, offender tables, logs table, trace index table
+      - Degraded-state and empty-state handling
+
+11. **Add store and API client methods**
+    - Files:
+      - `client/src/stores/admin.ts`
+      - `client/src/lib/tauri.ts`
+    - Tasks:
+      - Add state/actions for summary/trends/logs/traces/top offenders
+      - Add polling cadence and freshness timestamps
+      - Add optional external deep-link actions
+
+## Phase 5 - External Stack Hand-off
+
+12. **Config-gated deep links**
+    - Files:
+      - `server/src/config.rs`
+      - `server/src/admin/handlers.rs`
+      - `docs/ops/observability-runbook.md`
+    - Tasks:
+      - Add optional config for Grafana/Tempo/Loki/Prometheus URLs
+      - Return links via `/links` endpoint only when configured
+
+13. **UI integration for deep analysis**
+    - Files:
+      - `client/src/components/admin/CommandCenterPanel.tsx`
+    - Tasks:
+      - `Open in Grafana/Tempo/Loki` actions from relevant rows/cards
+
+## Phase 6 - Quality Gates
+
+14. **Tests: backend**
+    - Files:
+      - `server/tests/*` (new coverage files)
+    - Tasks:
+      - Endpoint auth/access tests (system admin required)
+      - Retention and query-bound checks
+      - Redaction/allowlist persistence tests
+
+15. **Tests: frontend**
+    - Files:
+      - `client/src/components/admin/*.test.tsx`
+      - `client/e2e/*admin*.spec.ts`
+    - Tasks:
+      - Panel rendering and degraded-state tests
+      - Data table/filter interactions
+
+16. **Governance + CI checks**
+    - Files:
+      - `.github/workflows/ci.yml`
+      - `scripts/check_docs_governance.py`
+    - Tasks:
+      - Check retention policy constants (30-day max)
+      - Check forbidden telemetry fields in native schemas
+      - Ensure roadmap links to active design + implementation docs
+
+## Verification Strategy
+
+### Functional
+
+- Summary/trends/top/logs/traces endpoints return expected bounded results.
+- Admin UI shows cluster-wide telemetry for all system admins.
+- Degraded mode works when external stack is unavailable.
+
+### Privacy/Security
+
+- No forbidden fields stored in `telemetry_log_events` or `telemetry_trace_index`.
+- Access is restricted to system admins only.
+- Observability view actions are audit-logged.
+
+### Performance
+
+- Summary endpoints p95 <= 200ms under expected load.
+- Trend endpoint p95 <= 500ms for 30-day range.
+- Polling does not regress server CPU/memory targets.
+
+### Operability
+
+- Retention purge/downsample jobs run successfully.
+- Data freshness indicators remain accurate.
+
+## Done Criteria
+
+- Command center is available in admin panel and usable without external stack.
+- Native telemetry retention is strictly capped at 30 days.
+- External deep links work when configured.
+- CI/governance checks enforce retention and redaction constraints.
+- Documentation updated (roadmap, runbook, contract references).
+
+## Risk Register
+
+1. **Cardinality growth risk**
+   - Mitigation: strict label allowlist, bounded dimensions, query limits.
+
+2. **Storage growth risk**
+   - Mitigation: 30-day hard TTL, downsampling, daily size checks.
+
+3. **Scope creep into full observability platform**
+   - Mitigation: enforce non-goals; route deep analysis to external stack.
+
+4. **Dependency drift to stale tooling**
+   - Mitigation: maintenance policy gate and pinned versions.

--- a/docs/plans/2026-02-27-phase-7-admin-command-center-task-plan.md
+++ b/docs/plans/2026-02-27-phase-7-admin-command-center-task-plan.md
@@ -1,0 +1,186 @@
+# Phase 7 Admin Command Center - Task-by-Task Plan
+
+**Date:** 2026-02-27
+**Status:** Not Started
+**Lifecycle:** Active
+**Roadmap Reference:** `docs/project/roadmap.md` (Phase 7, `[Ops] Admin Command Center (Native Observability Lite)`)
+**Design Reference:** `docs/plans/2026-02-27-phase-7-admin-command-center-design.md`
+**Implementation Reference:** `docs/plans/2026-02-27-phase-7-admin-command-center-implementation.md`
+
+## Objective
+
+Deliver a cluster-wide native Command Center for system admins with strict 30-day telemetry retention, while delegating deep forensic analysis to external Grafana/Tempo/Loki/Prometheus when configured.
+
+## Delivery Constraints
+
+- Native retention hard cap: 30 days.
+- Cluster-wide visibility for all system admins.
+- Open-source, actively maintained tooling only.
+- Preserve OTel standards and current observability contract.
+- No full in-app trace waterfall or advanced log query DSL in v1.
+
+## Task Breakdown (Atomic)
+
+### Phase 0 - Project Guardrails
+
+1. [ ] **Confirm contract and roadmap alignment** (0.5d)
+   - Files:
+     - `docs/ops/observability-contract.md`
+     - `docs/project/roadmap.md`
+   - Done when: retention/access/scope decisions are explicitly represented and consistent.
+
+2. [ ] **Define dependency policy checklist in docs** (0.5d)
+   - Files:
+     - `docs/plans/2026-02-27-phase-7-admin-command-center-implementation.md`
+   - Done when: maintenance/licensing/version policy is enforceable and reviewable.
+
+### Phase 1 - Data Foundation
+
+3. [ ] **Create native telemetry schema migration** (1.0d)
+   - Files:
+     - `server/migrations/<new>_command_center_telemetry.sql`
+   - Includes:
+     - `telemetry_metric_samples`
+     - `telemetry_log_events`
+     - `telemetry_trace_index`
+   - Done when: schema applies cleanly and supports target query patterns.
+
+4. [ ] **Add retention + downsampling policies** (0.75d)
+   - Files:
+     - `server/migrations/<new>_command_center_retention.sql`
+   - Done when:
+     - hard delete beyond 30 days
+     - downsampling policy after day 7 for metrics
+
+5. [ ] **Add storage/query module** (1.0d)
+   - Files:
+     - `server/src/observability/storage.rs` (new)
+     - `server/src/observability/mod.rs`
+   - Done when: bounded read/write helpers exist for summary, trends, logs, trace index.
+
+### Phase 2 - Ingestion and Safety
+
+6. [ ] **Wire native log ingestion with redaction** (1.0d)
+   - Files:
+     - `server/src/observability/tracing.rs`
+   - Done when: persisted log events are allowlisted and sanitized.
+
+7. [ ] **Wire native trace index ingestion** (0.75d)
+   - Files:
+     - `server/src/observability/tracing.rs`
+     - `server/src/observability/storage.rs`
+   - Done when: failed/slow trace metadata is persisted without payload content.
+
+8. [ ] **Wire metric sample ingestion and label guardrails** (1.0d)
+   - Files:
+     - `server/src/observability/metrics.rs`
+     - `server/src/observability/storage.rs`
+   - Done when: only allowlisted dimensions are persisted and high-cardinality labels are dropped/rejected.
+
+9. [ ] **Add observability access audit events** (0.5d)
+   - Files:
+     - `server/src/admin/handlers.rs`
+     - `server/src/permissions/queries.rs`
+   - Done when: command center data access emits `admin.observability.view` style audit events.
+
+### Phase 3 - Admin API Surface
+
+10. [ ] **Add summary/trends endpoints** (1.0d)
+    - Files:
+      - `server/src/admin/mod.rs`
+      - `server/src/admin/handlers.rs`
+      - `server/src/admin/types.rs`
+    - Endpoints:
+      - `GET /api/admin/observability/summary`
+      - `GET /api/admin/observability/trends`
+
+11. [ ] **Add top-offenders endpoints** (0.75d)
+    - Endpoints:
+      - `GET /api/admin/observability/top-routes`
+      - `GET /api/admin/observability/top-errors`
+
+12. [ ] **Add logs/trace-index list endpoints** (1.0d)
+    - Endpoints:
+      - `GET /api/admin/observability/logs`
+      - `GET /api/admin/observability/traces`
+    - Done when: pagination and filters are bounded and stable.
+
+13. [ ] **Add external links endpoint** (0.5d)
+    - Endpoint:
+      - `GET /api/admin/observability/links`
+    - Done when: links are returned only when configured.
+
+### Phase 4 - Admin UI Integration
+
+14. [ ] **Add command-center panel routing + sidebar entry** (0.5d)
+    - Files:
+      - `client/src/components/admin/AdminSidebar.tsx`
+      - `client/src/views/AdminDashboard.tsx`
+
+15. [ ] **Create `CommandCenterPanel` UI skeleton** (1.0d)
+    - Files:
+      - `client/src/components/admin/CommandCenterPanel.tsx` (new)
+      - `client/src/components/admin/index.ts`
+
+16. [ ] **Implement admin store slice + API bindings** (1.5d)
+    - Files:
+      - `client/src/stores/admin.ts`
+      - `client/src/lib/tauri.ts`
+
+17. [ ] **Implement health cards + trends charts** (1.0d)
+    - Done when: top-level operational status is visible and refreshes predictably.
+
+18. [ ] **Implement top-offenders/logs/trace-index tables** (1.0d)
+    - Done when: filtering, pagination, and empty states are usable.
+
+19. [ ] **Implement degraded mode + freshness indicators** (0.75d)
+    - Done when: each section clearly indicates stale/unavailable data without breaking UI.
+
+20. [ ] **Add deep-link actions to external stack** (0.5d)
+    - Done when: relevant rows/cards can open Grafana/Tempo/Loki/Prometheus links when configured.
+
+### Phase 5 - Tests and Governance
+
+21. [ ] **Backend integration tests for auth, bounds, retention** (1.5d)
+    - Files:
+      - `server/tests/*observability*`
+
+22. [ ] **Frontend tests for panel state and data rendering** (1.0d)
+    - Files:
+      - `client/src/components/admin/*.test.tsx`
+
+23. [ ] **E2E smoke coverage for command center access** (0.75d)
+    - Files:
+      - `client/e2e/*admin*.spec.ts`
+
+24. [ ] **CI/governance checks for retention and forbidden fields** (0.75d)
+    - Files:
+      - `.github/workflows/ci.yml`
+      - `scripts/check_docs_governance.py`
+
+## Estimated Effort
+
+- Phase 0: ~1 day
+- Phase 1: ~2.75 days
+- Phase 2: ~3.25 days
+- Phase 3: ~3.25 days
+- Phase 4: ~6.25 days
+- Phase 5: ~4 days
+
+**Total estimate:** ~20.5 engineer-days (single-contributor baseline)
+
+## Milestone Acceptance
+
+### MVP Acceptance
+
+- Command center tab is available to all system admins.
+- Summary + trends + top-offenders + logs + trace-index panels functional.
+- Native data never exceeds 30-day retention.
+- External deep links render only when configured.
+- Redaction and allowlist constraints verified by tests.
+
+### Release Acceptance
+
+- CI checks pass for schema, retention, redaction, and docs linkage.
+- Observability runbook has command center operational guidance.
+- No dependency policy violations (license/maintenance/deprecation checks).

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -609,6 +609,9 @@ This section is the canonical high-level roadmap view. Detailed implementation c
 - [ ] **[Infra] SaaS Observability & Telemetry** ([Design](../plans/2026-02-15-phase-7-a11y-observability-design.md), [Implementation](../plans/2026-02-15-phase-7-a11y-observability-implementation.md))
   - **Context:** Maintain uptime and catch bugs at scale.
   - **Strategy:** Integrate **Sentry** (error tracking) and **OpenTelemetry** for performance monitoring across the Rust backend and Tauri clients.
+- [ ] **[Ops] Admin Command Center (Native Observability Lite)** ([Design](../plans/2026-02-27-phase-7-admin-command-center-design.md), [Implementation](../plans/2026-02-27-phase-7-admin-command-center-implementation.md), [Task Plan](../plans/2026-02-27-phase-7-admin-command-center-task-plan.md))
+  - **Context:** Provide built-in operational visibility for self-hosted admins without requiring a full Grafana stack.
+  - **Strategy:** Ship a cluster-wide admin panel with 30-day native retention for curated metrics, trace indexes, and logs; keep deep forensics (full traces/log search, advanced alerting) in external Tempo/Loki/Prometheus/Grafana.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a new Phase 7 roadmap item for the native Admin Command Center and link all planning artifacts
- add the full design document for cluster-wide, 30-day native observability-lite in admin panel
- add the implementation and task-by-task plans with OSS/maintenance policy gates and phased delivery

## Validation
- python3 scripts/check_docs_governance.py