### PR TITLE
docs(observability): rewrite command center design v2 with golden signals

### DIFF
--- a/docs/plans/2026-02-27-phase-7-admin-command-center-design.md
+++ b/docs/plans/2026-02-27-phase-7-admin-command-center-design.md
@@ -1,236 +1,806 @@
-# Phase 7 Admin Command Center - Design
+# Phase 7 Admin Command Center — Design
 
 **Date:** 2026-02-27
-**Status:** Draft
+**Status:** Draft (v2)
 **Roadmap Scope:** Phase 7 `[Ops] Admin Command Center (Native Observability Lite)`
 **Related:**
 - `docs/project/roadmap.md`
-- `docs/ops/observability-contract.md`
+- `docs/ops/observability-contract.md` — canonical metric/label/redaction spec
 - `docs/ops/observability-runbook.md`
 - `docs/plans/2026-02-15-phase-7-a11y-observability-design.md`
 - `docs/plans/2026-02-15-opentelemetry-grafana-reference-design.md`
 
-## Problem
+---
 
-Phase 7 observability foundations are in place (OTel + collector + Grafana stack reference), but operators currently need external tooling for most runtime visibility. This creates two gaps:
+## 1. Problem
 
-1. Self-hosted operators without full Grafana setup lack practical day-to-day insight.
-2. Admin workflows are split between in-app moderation/admin actions and external telemetry tools.
+Phase 7 observability foundations are in place (OTel instrumentation, collector pipeline, Grafana stack reference design), but operators currently need external tooling for runtime visibility. This creates three gaps:
 
-We need a native admin Command Center that gives immediate operational awareness while preserving external observability as the deep-analysis path.
+1. **Self-hosted operators without Grafana** lack practical day-to-day insight into system health.
+2. **Admin workflows are split** between in-app moderation actions and external telemetry tools.
+3. **Incident triage is slow** because signals (metrics, logs, traces) are scattered across separate tools with no shared context.
 
-## Goals
+Research into mature self-hosted platforms (GitLab admin area, Mattermost System Console, Zulip analytics, Sentry self-hosted monitoring) shows a clear pattern: every platform converges on a **built-in triage layer** that answers "is something wrong right now?" in under 10 seconds, then routes deep analysis to external tools. Our current design covers the bottom of this hierarchy — this rewrite raises it to industry standard.
+
+---
+
+## 2. Goals
 
 - Provide a cluster-wide command center in the existing admin panel for all system admins.
 - Deliver useful native observability with strict 30-day retention.
-- Show high-signal health, reliability, and incident context without requiring external Grafana stack.
+- Organize signals around the **Four Golden Signals** framework (Latency, Traffic, Errors, Saturation) from the Google SRE book.
+- Provide a dedicated **voice operations** view — voice is the product's core differentiator and requires domain-specific monitoring.
+- Show **infrastructure health** (database, cache, storage, OTel pipeline) as first-class signals.
+- Enable **incident correlation** via shared time axis across metrics, logs, and traces.
+- Support **real-time push** via WebSocket for live counters and health transitions.
 - Preserve compatibility with OTel/Grafana stack and deep-link into external tools when available.
 - Keep runtime and storage overhead bounded for self-hosted installations.
 
-## Non-Goals
+## 3. Non-Goals
 
 - Replacing Grafana, Tempo, Loki, or Prometheus.
 - Building an in-app trace waterfall viewer or full log query language.
 - Providing retention beyond 30 days in native storage.
 - Multi-tenant observability segmentation in v1.
 - Per-node access restrictions in v1 (view is cluster-wide for all system admins).
+- Alert-rule authoring UI in v1 (static thresholds only, configurable via server config).
+- Full anomaly detection with ML-based baselines in v1 (rolling 7-day deviation planned for v1.1).
+- Native `INFO`-level log ingestion in v1 (volume would exceed storage budget; INFO stays in external Loki).
 
-## Product Decision Summary
+---
 
-- **Access model:** cluster-wide, visible to all system admins.
-- **Retention model:** native telemetry retained for 30 days max.
-- **Escalation path:** users requiring deeper history or advanced queries must use external stack.
-- **UX boundary:** native panel is for fast triage and operational awareness, not full forensic analysis.
+## 4. Design Decisions (Resolved)
 
-## User Experience
+| Decision | Resolution | Rationale |
+|----------|-----------|-----------|
+| Access model | Cluster-wide, all system admins | Simplest v1; per-role segmentation is v2 |
+| Retention | 30 days hard cap, all native tables | User constraint; external stack for longer |
+| INFO logs in native store | No — WARN/ERROR only in v1 | INFO volume would blow storage; operators need errors first |
+| Trend aggregation strategy | Hybrid — materialized views (hourly refresh) for 30d trends, live queries for real-time cards | Zulip proves pre-aggregation works in PostgreSQL at this scale |
+| Data export | Yes in v1 — CSV/JSON for current filtered view | Operators need this for incident reports and audits |
+| Escalation path | External stack for deep forensics | Explicit boundary; native panel is triage, not forensics |
+| UX boundary | Fast triage + operational awareness | Not full observability platform |
+| Real-time delivery | WebSocket push for health transitions + live counters; polling (10-30s) for trends | Platform already has WS infrastructure; leverage it |
 
-### Command Center Panels
+---
 
-1. **System Health (always visible):**
-   - API request rate (1m)
-   - API error rate (5m)
-   - API p95/p99 latency (5m)
-   - Active WebSocket connections
-   - Active voice sessions
-   - Telemetry pipeline status (collector/export path)
+## 5. Design Framework: Four Golden Signals
 
-2. **Reliability Trends (30-day charts):**
-   - Daily API error rate
-   - Daily p95/p99 latency
-   - Daily voice join success rate
-   - Daily auth failure rate
-   - Daily WebSocket reconnect rate
+The command center is organized around the [Four Golden Signals](https://sre.google/sre-book/monitoring-distributed-systems/) from Google's SRE handbook. This provides operators with an instant mental model for system health:
 
-3. **Top Offenders:**
-   - Top failing routes
-   - Top slow routes
-   - Top error categories (`auth`, `db`, `ws`, `voice`, `ratelimit`)
+| Signal | What It Measures | Kaiku Domain Mapping |
+|--------|-----------------|---------------------|
+| **Latency** | Time to service requests | API handler duration, DB query time, WebRTC connect time |
+| **Traffic** | Demand on the system | API req/sec, active WS connections, concurrent voice sessions |
+| **Errors** | Rate of failures | HTTP 5xx, auth failures, WS disconnects, voice join failures |
+| **Saturation** | How "full" resources are | DB pool %, OTel queue overflow, process memory |
 
-4. **Logs (curated native view):**
-   - ERROR/WARN focused list
-   - Filter by domain and time range
-   - Display trace id if present
+Every metric displayed in the command center maps to one of these four signals. This prevents the common "dashboard of random metrics" anti-pattern.
 
-5. **Trace Index (not full traces):**
-   - Recent failed trace records
-   - Recent slow trace records
-   - Filters by route/domain/status/time
-   - `Open in Grafana/Tempo` actions when external stack is configured
+---
 
-## Information Architecture
+## 6. Signal Taxonomy
 
-### Signal Split
+Signals are organized in tiers by operator priority. Tier 1 is always visible; lower tiers are tabbed views.
 
-- **Metrics:** first-class native signal, stored in Postgres/Timescale for 30 days.
-- **Logs:** native curated event stream with compact schema and 30-day TTL.
-- **Traces:** native index metadata only (trace id, route/span, duration, status, timestamp), 30-day TTL.
-- **Full traces/log corpus:** external stack only.
+### Tier 1: Health Overview (Triage Entry Point)
 
-This split gives strong native value while avoiding high cardinality and storage blowups from raw spans/logs.
+**Purpose:** Answer "is something wrong right now?" in under 5 seconds.
+**Update model:** WebSocket push for state transitions; poll every 10s for freshness.
 
-## Data Model (Native Retention)
+**Always visible at the top of the command center.**
 
-### 1) `telemetry_metric_samples` (Timescale hypertable)
+#### 6.1.1 Service Health Matrix
 
-- `ts timestamptz not null`
-- `metric_name text not null`
-- `scope text not null` (cluster/domain)
-- `labels jsonb not null` (allowlisted dimensions only)
-- `value_double double precision null`
-- `value_int bigint null`
+A named list of services with current state, inspired by GitLab's admin area and Zulip's supervisorctl model:
 
-Policies:
-- Retention: 30 days hard delete.
-- Downsample: rollups after day 7 to reduce storage/query cost.
+| Service | Health Probe | Status Values |
+|---------|-------------|---------------|
+| HTTP API | `GET /health` response + `kaiku_http_requests_total` rate > 0 | `healthy` / `degraded` / `down` |
+| WebSocket Hub | `kaiku_ws_connections_active` gauge queryable | `healthy` / `degraded` / `down` |
+| Voice SFU | SFU `room_count()` callable, RTP forwarding active | `healthy` / `degraded` / `down` |
+| PostgreSQL | Pool `SELECT 1` success + `kaiku_db_pool_connections_idle` > 0 | `healthy` / `degraded` / `down` |
+| Valkey (Redis) | `PING` success | `healthy` / `down` |
+| S3 Storage | `health_check()` bucket access | `healthy` / `unavailable` (graceful) |
+| OTel Pipeline | `kaiku_otel_export_failures_total` rate < threshold | `healthy` / `degraded` / `down` |
 
-### 2) `telemetry_log_events`
+**Degraded** means: service responds but with elevated error rate or latency above threshold.
 
-- `id uuid pk`
-- `ts timestamptz not null`
-- `level text not null` (`ERROR`, `WARN`, selected `INFO`)
-- `service text not null`
-- `domain text not null`
-- `event text not null`
-- `message text not null`
-- `trace_id text null`
-- `span_id text null`
-- `attrs jsonb not null default '{}'::jsonb`
+#### 6.1.2 Key Vital Signs (Top Cards)
 
-Policies:
-- Retention: 30 days hard delete.
-- Store only sanitized/allowlisted attributes.
+Four summary cards — one per golden signal — with sparkline trend (1h):
 
-### 3) `telemetry_trace_index`
+| Card | Source Metric | Display |
+|------|--------------|---------|
+| **Latency** | `kaiku_http_request_duration_seconds` p95 (5m window) | Value + sparkline + threshold color |
+| **Traffic** | `kaiku_http_requests_total` rate (1m window) | Value + sparkline |
+| **Errors** | `kaiku_http_errors_total` rate (5m window) | Value + sparkline + threshold color |
+| **Saturation** | Max of (DB pool %, OTel queue %) | Highest-pressure resource + sparkline |
 
-- `trace_id text not null`
-- `span_name text not null`
-- `domain text not null`
-- `route text null`
-- `status_code text null`
-- `duration_ms integer not null`
-- `ts timestamptz not null`
-- `service text not null`
+#### 6.1.3 Live Error Feed
 
-Policies:
-- Retention: 30 days hard delete.
-- No span payload/body storage.
+A scrolling unified error stream (last 25 errors, cross-service), inspired by Zulip's `errors.log` triage pattern:
 
-## API Design (Admin)
+- Source: `telemetry_log_events` where level = `ERROR`
+- Display: timestamp, service, domain, event name, message (truncated), trace_id link
+- Auto-scrolls on new entries via WebSocket push
+- Click to expand full error context
+- "View all logs" link to Tier 4
 
-All endpoints are under `/api/admin/observability/*` and require `SystemAdminUser`.
+#### 6.1.4 Server Metadata
 
-### Health and Overview
+- Server version (`CARGO_PKG_VERSION`)
+- Uptime (process start time)
+- Environment (`deployment.environment`)
+- Last deploy timestamp (from config or git tag, if available)
+- Active user count, guild count (from existing `AdminStatsResponse`)
+
+---
+
+### Tier 2: Golden Signals Dashboard (30-Day Trends)
+
+**Purpose:** Show trends over time. Detect gradual degradation. Provide evidence for capacity planning.
+**Update model:** Poll every 30s for live view; pre-aggregated materialized views for historical ranges.
+**Time range picker:** 1h / 6h / 24h / 7d / 30d (default: 24h)
+
+#### 6.2.1 Latency Panel
+
+All latency metrics sourced from histograms with percentile computation. Per SRE guidance: **never show averages for latency — always p50/p95/p99.**
+
+| Metric | Source (Observability Contract) | Visualization |
+|--------|-------------------------------|---------------|
+| API request latency p50/p95/p99 | `kaiku_http_request_duration_seconds` histogram | Time-series line chart, percentile overlays |
+| DB query latency p50/p95 | `kaiku_db_query_duration_seconds` histogram | Time-series line chart |
+| Voice session duration distribution | `kaiku_voice_session_duration_seconds` histogram | Time-series line chart |
+| Client WebRTC connect time p95 | `kaiku_client_voice_webrtc_connect_duration_seconds` histogram | Time-series line chart (v1.1, requires client metric ingestion) |
+
+**Top slow routes table:** Top 10 routes by p95 latency in selected range, from `telemetry_metric_samples` grouped by `http.route` label.
+
+#### 6.2.2 Traffic Panel
+
+| Metric | Source (Observability Contract) | Visualization |
+|--------|-------------------------------|---------------|
+| API request rate | `kaiku_http_requests_total` | Time-series area chart |
+| Active WebSocket connections | `kaiku_ws_connections_active` | Time-series line chart |
+| Active voice sessions | `kaiku_voice_sessions_active` | Time-series line chart |
+| WebSocket messages dispatched | `kaiku_ws_messages_total` | Time-series area chart, stacked by event type |
+| Voice RTP packets forwarded | `kaiku_voice_rtp_packets_forwarded_total` | Time-series area chart |
+
+#### 6.2.3 Errors Panel
+
+| Metric | Source (Observability Contract) | Visualization |
+|--------|-------------------------------|---------------|
+| HTTP error rate (4xx + 5xx) | `kaiku_http_errors_total` by status class | Time-series stacked area (4xx vs 5xx) |
+| Auth failure rate | `kaiku_auth_login_attempts_total{outcome=failure}` | Time-series line chart |
+| Auth token refresh failures | `kaiku_auth_token_refresh_total{outcome=failure}` | Time-series line chart |
+| WebSocket reconnect rate | `kaiku_ws_reconnects_total` | Time-series line chart |
+| Voice join failure rate | `kaiku_voice_joins_total{outcome=error}` | Time-series line chart |
+| OTel export failures | `kaiku_otel_export_failures_total` | Time-series line chart |
+| Client WebRTC failures | `kaiku_client_voice_webrtc_failures_total` | Time-series line chart (v1.1) |
+
+**Top failing routes table:** Top 10 routes by error count in selected range.
+**Top error categories table:** Grouped by `error.type` label (auth, db, ws, voice, ratelimit).
+
+#### 6.2.4 Saturation Panel
+
+| Metric | Source (Observability Contract) | Visualization |
+|--------|-------------------------------|---------------|
+| DB pool utilization | `kaiku_db_pool_connections_active` / pool max | Gauge + time-series |
+| DB idle connections | `kaiku_db_pool_connections_idle` | Time-series |
+| OTel dropped spans | `kaiku_otel_dropped_spans_total` | Counter time-series |
+| Process memory (RSS) | New: `kaiku_process_memory_bytes` (from `/proc/self/statm` or `sysinfo`) | Time-series line chart |
+
+**Note:** Process CPU usage is intentionally omitted from v1 native metrics. CPU profiling belongs in external tooling. Memory (RSS) is included because it's cheap to collect and directly actionable (leak detection).
+
+---
+
+### Tier 3: Voice Operations
+
+**Purpose:** Domain-specific monitoring for the platform's core differentiator.
+**Update model:** WebSocket push for active session count; poll every 10s for quality metrics.
+
+Voice telemetry already exists in TimescaleDB (`connection_metrics`, `connection_sessions` hypertables). This tier surfaces it in the admin panel.
+
+| Signal | Source | Visualization |
+|--------|--------|---------------|
+| Active voice sessions | `kaiku_voice_sessions_active` gauge | Large number + sparkline |
+| Active voice rooms | SFU `room_count()` | Large number |
+| Participant distribution | SFU room data | Histogram (participants per room) |
+| Join success rate (24h) | `kaiku_voice_joins_total` success / total | Percentage + trend chart |
+| Packet loss rate (rolling) | `connection_metrics.packet_loss` | Time-series line chart (p50/p95) |
+| Network jitter (rolling) | `connection_metrics.jitter_ms` | Time-series line chart (p50/p95) |
+| Session latency (rolling) | `connection_metrics.latency_ms` | Time-series line chart (p50/p95) |
+| Quality score distribution | `connection_metrics.quality` (0-3 scale) | Stacked bar chart (poor/fair/good/excellent) |
+| RTP forwarding rate | `kaiku_voice_rtp_packets_forwarded_total` | Time-series rate chart |
+| Session duration distribution | `kaiku_voice_session_duration_seconds` | Histogram |
+
+**Voice Health Score:** A single composite indicator (0-100) derived from: join success rate (40% weight), packet loss p95 (30% weight), jitter p95 (20% weight), session crash rate (10% weight). Displayed as a prominent gauge on the voice tab.
+
+---
+
+### Tier 4: Infrastructure Health
+
+**Purpose:** Show the health of backing services. Critical for self-hosted operators.
+**Update model:** Poll every 10s.
+
+#### 6.4.1 Database
+
+| Signal | Source | Display |
+|--------|--------|---------|
+| Connection pool active/idle/max | `kaiku_db_pool_connections_active`, `kaiku_db_pool_connections_idle`, pool config | Gauge bars |
+| Query latency p95 | `kaiku_db_query_duration_seconds` | Value + trend sparkline |
+| Query rate | `kaiku_db_query_duration_seconds` count | Time-series |
+| Top slow queries | From `telemetry_trace_index` where domain = `db`, sorted by duration | Table (span_name, duration, count) |
+| Connectivity | Health check `SELECT 1` | Status badge |
+
+#### 6.4.2 Valkey (Redis)
+
+| Signal | Source | Display |
+|--------|--------|---------|
+| Connectivity | Health check `PING` | Status badge |
+| Used for | Static: rate limiting, sessions, blocks, elevated admin cache | Info text |
+
+**Note:** Redis `INFO` stats (memory, hit rate, connected clients) require a new `REDIS INFO` query — planned for v1.1. v1 shows connectivity only.
+
+#### 6.4.3 S3 Storage
+
+| Signal | Source | Display |
+|--------|--------|---------|
+| Connectivity | `health_check()` bucket access | Status badge |
+| Status | Configured / Not configured / Degraded | Status badge |
+
+**Note:** Upload/download throughput metrics require new instrumentation — planned for v1.1.
+
+#### 6.4.4 OTel Pipeline
+
+| Signal | Source | Display |
+|--------|--------|---------|
+| Export success/failure rate | `kaiku_otel_export_failures_total` | Time-series + status badge |
+| Dropped spans | `kaiku_otel_dropped_spans_total` | Counter + alert if > 0 |
+| Collector endpoint | Config value | Info text |
+| Pipeline status | Export failure rate < 1% = healthy | Status badge |
+
+---
+
+### Tier 5: Curated Logs
+
+**Purpose:** Triage errors without leaving the admin panel.
+**Update model:** WebSocket push for new ERROR entries; poll every 15s for WARN.
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| Severity | `level` | WARN and ERROR only in v1 |
+| Timestamp | `ts` | |
+| Service | `service` | `vc-server` or `vc-client` |
+| Domain | `domain` | `auth`, `chat`, `voice`, `ws`, `db`, `admin`, `crypto` |
+| Event | `event` | Short event name |
+| Message | `message` | Truncated to 200 chars in list view |
+| Trace ID | `trace_id` | Clickable — links to trace index or external Tempo |
+| Span ID | `span_id` | |
+
+**Filters:** severity, domain, service, time range, free-text search on event/message.
+**Pagination:** Cursor-based, max 100 per page.
+**Export:** CSV/JSON of current filtered view.
+
+---
+
+### Tier 6: Trace Index
+
+**Purpose:** Find problematic requests by metadata, then hand off to external tools for full trace analysis.
+**Update model:** Poll every 30s.
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| Trace ID | `trace_id` | Clickable — "Open in Tempo" when configured |
+| Span name | `span_name` | e.g. `http.server.request`, `voice.session_join` |
+| Route | `route` | Parameterised template |
+| Domain | `domain` | |
+| Status | `status_code` | HTTP status or outcome |
+| Duration | `duration_ms` | Color-coded by threshold |
+| Timestamp | `ts` | |
+
+**Filters:** status (error/slow/all), domain, route, duration threshold, time range.
+**Pre-filtered views:** "Recent errors" (status >= 500), "Recent slow" (duration > p95 threshold).
+**Pagination:** Cursor-based, max 100 per page.
+**Export:** CSV/JSON of current filtered view.
+
+---
+
+### Tier 7: Client Telemetry (v1.1)
+
+**Purpose:** Visibility into client-side performance. Deferred to v1.1 because it requires client-to-server metric ingestion pipeline.
+
+Planned signals from the observability contract:
+
+| Metric | Source | Notes |
+|--------|--------|-------|
+| Tauri command latency p95 | `kaiku_client_tauri_command_duration_seconds` | Per-command breakdown |
+| Tauri command errors | `kaiku_client_tauri_command_errors_total` | By command name |
+| WebRTC connect time p95 | `kaiku_client_voice_webrtc_connect_duration_seconds` | ICE negotiation time |
+| WebRTC connection failures | `kaiku_client_voice_webrtc_failures_total` | By failure reason |
+
+**Ingestion path:** Client → Tauri command → Server endpoint → native storage. Requires new `/api/telemetry/client-metrics` endpoint with rate limiting and size bounds.
+
+---
+
+## 7. Layout and Information Hierarchy
+
+### 7.1 Spatial Layout
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  COMMAND CENTER                    [Time Range ▾] [⟳ Auto]  │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐          │
+│  │ Latency │ │ Traffic │ │ Errors  │ │ Saturat.│  ← Vital  │
+│  │  12ms   │ │ 847/s   │ │  0.3%   │ │  42%    │    Signs  │
+│  │ ~~~^^^~ │ │ ~~~^^^~ │ │ ~~~___~ │ │ ~~~^^^~ │           │
+│  └─────────┘ └─────────┘ └─────────┘ └─────────┘          │
+│                                                             │
+│  ┌───────────────────────────┐ ┌───────────────────────────┐│
+│  │ Service Health Matrix     │ │ Live Error Feed           ││
+│  │ ● API        healthy     │ │ 17:04:12 auth login_fail  ││
+│  │ ● WebSocket  healthy     │ │ 17:03:58 db   query_slow  ││
+│  │ ● Voice SFU  healthy     │ │ 17:03:41 voice join_fail  ││
+│  │ ● PostgreSQL healthy     │ │ 17:03:22 ws   disconnect  ││
+│  │ ● Valkey     healthy     │ │ ...                       ││
+│  │ ● S3         available   │ │ [View all logs →]         ││
+│  │ ● OTel       healthy     │ │                           ││
+│  └───────────────────────────┘ └───────────────────────────┘│
+│                                                             │
+│  ┌─ [Golden Signals] [Voice] [Infrastructure] [Logs] [Traces]│
+│  │                                                          │
+│  │  (Selected tab content fills remaining vertical space)   │
+│  │                                                          │
+│  └──────────────────────────────────────────────────────────┘
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 7.2 Above the Fold
+
+The **Health Overview** (Tier 1) is always visible at the top — never scrolled away. It consists of:
+1. Four vital-sign cards (golden signals summary, 1-row)
+2. Service health matrix + live error feed (2-column, equal width)
+
+### 7.3 Tabbed Detail Area
+
+Below the fold, a tab bar provides access to:
+- **Golden Signals** (Tier 2) — default active tab
+- **Voice** (Tier 3)
+- **Infrastructure** (Tier 4)
+- **Logs** (Tier 5)
+- **Traces** (Tier 6)
+
+Each tab fills the remaining vertical space. Tab state persists across panel switches.
+
+### 7.4 Time Range Picker
+
+Global time range selector in the top-right corner:
+- Presets: `1h`, `6h`, `24h`, `7d`, `30d`
+- Custom range with calendar picker
+- Auto-refresh toggle with cadence indicator (e.g., "Refreshing every 10s")
+- Applies to all trend charts and tables in the active tab
+
+### 7.5 Responsive Behavior
+
+- Desktop (>1200px): Full 2-column health overview, tab content fills width
+- Tablet (768-1200px): Health overview stacks to single column; tab content full-width
+- Below 768px: Not targeted (admin panel is desktop-first)
+
+---
+
+## 8. Status Thresholds
+
+Every numeric signal has a three-tier status (green/yellow/red) with configurable thresholds via server config. Defaults are chosen to be safe for most deployments:
+
+### 8.1 Default Thresholds
+
+| Signal | Green | Yellow | Red |
+|--------|-------|--------|-----|
+| API p95 latency | < 200ms | 200-1000ms | > 1000ms |
+| API error rate (5xx) | < 1% | 1-5% | > 5% |
+| DB pool utilization | < 70% | 70-90% | > 90% |
+| DB query p95 | < 100ms | 100-500ms | > 500ms |
+| Voice join success rate | > 95% | 80-95% | < 80% |
+| Voice packet loss p95 | < 2% | 2-5% | > 5% |
+| OTel export failure rate | < 1% | 1-5% | > 5% |
+| OTel dropped spans (last 5m) | 0 | 1-100 | > 100 |
+| Process memory (RSS) | < 70% of limit | 70-90% | > 90% |
+
+### 8.2 Configuration
+
+Thresholds are stored in server config (environment variables with `COMMAND_CENTER_` prefix):
+
+```
+COMMAND_CENTER_API_LATENCY_P95_WARN_MS=200
+COMMAND_CENTER_API_LATENCY_P95_CRIT_MS=1000
+COMMAND_CENTER_API_ERROR_RATE_WARN_PCT=1
+COMMAND_CENTER_API_ERROR_RATE_CRIT_PCT=5
+# ... etc
+```
+
+Thresholds are returned via `GET /api/admin/observability/config` and displayed as colored indicators (status dot + background tint) on cards and chart annotations.
+
+---
+
+## 9. Real-Time Update Strategy
+
+The platform has mature WebSocket infrastructure. The command center leverages it.
+
+### 9.1 WebSocket Push Events (new `admin.observability.*` event types)
+
+| Event | Payload | Trigger |
+|-------|---------|---------|
+| `admin.observability.health_change` | `{ service, old_status, new_status }` | Service transitions between healthy/degraded/down |
+| `admin.observability.error_event` | `{ ts, service, domain, event, message, trace_id }` | New ERROR-level log ingested |
+| `admin.observability.vital_signs` | `{ latency_p95, traffic_rate, error_rate, saturation_pct }` | Every 5s while admin panel is open |
+| `admin.observability.voice_pulse` | `{ active_sessions, active_rooms, join_success_rate_1h }` | Every 5s while voice tab is open |
+
+Events are only sent to WebSocket connections authenticated as system admins with the command center panel active (not broadcast to all connections).
+
+### 9.2 Polling Cadence
+
+| Data Type | Interval | Rationale |
+|-----------|----------|-----------|
+| Trend charts (time-series) | 30s | Pre-aggregated, not latency-sensitive |
+| Top offenders tables | 30s | Aggregate queries, moderate cost |
+| Log list | 15s (+ WS push for errors) | Balance freshness vs. DB load |
+| Trace index | 30s | Not latency-sensitive |
+| Infrastructure health | 10s | Backing service changes need prompt detection |
+
+### 9.3 Freshness Indicators
+
+Every panel section shows a "Last updated: Xs ago" indicator. If data is stale (> 2x expected interval), the indicator turns yellow with "(stale)" suffix.
+
+---
+
+## 10. Incident Correlation
+
+**Purpose:** When a metric anomaly is detected, operators need to see related signals on a shared time axis to understand cause and effect.
+
+### 10.1 Shared Time Axis
+
+The Golden Signals tab supports an "Incident View" toggle that overlays:
+- Metric chart (selected signal) as primary
+- Error rate overlay (secondary y-axis)
+- Log event markers (vertical lines at ERROR timestamps)
+- Deploy markers (vertical dashed lines, sourced from config or audit log)
+
+This answers the SRE question: *"Our latency just shot up — what else happened around the same time?"*
+
+### 10.2 Click-Through Correlation
+
+| From | To | Mechanism |
+|------|----|-----------|
+| Error in live feed | Full log entry in Logs tab | Click navigates to Logs tab, filters by trace_id |
+| Log entry with trace_id | Trace index entry | Click navigates to Traces tab, filters by trace_id |
+| Trace index entry | External Tempo | "Open in Tempo" button (when configured) |
+| Metric anomaly on chart | Logs tab for that time window | Click on chart point opens Logs tab with time filter |
+
+### 10.3 Deploy Markers (v1.1)
+
+Deploy events are recorded as audit log entries (`admin.deploy.detected`) and displayed as vertical markers on all time-series charts. Source: server start time with new version, or explicit deploy webhook.
+
+---
+
+## 11. Data Model (Native Retention)
+
+All native telemetry tables live in the same PostgreSQL database. TimescaleDB extension is used where available (graceful fallback to standard PostgreSQL with periodic `DELETE` for retention).
+
+### 11.1 `telemetry_metric_samples` (Timescale hypertable)
+
+Stores pre-aggregated metric samples aligned with the observability contract.
+
+```sql
+CREATE TABLE telemetry_metric_samples (
+    ts          TIMESTAMPTZ NOT NULL,
+    metric_name TEXT        NOT NULL,  -- from contract: kaiku_* names
+    scope       TEXT        NOT NULL,  -- 'cluster' (future: per-node)
+    labels      JSONB       NOT NULL DEFAULT '{}'::jsonb,  -- contract-allowlisted only
+    value_count BIGINT      NULL,      -- for counters: cumulative count
+    value_sum   DOUBLE PRECISION NULL, -- for histograms: sum of observations
+    value_p50   DOUBLE PRECISION NULL, -- pre-computed percentile
+    value_p95   DOUBLE PRECISION NULL, -- pre-computed percentile
+    value_p99   DOUBLE PRECISION NULL  -- pre-computed percentile
+);
+
+-- TimescaleDB: convert to hypertable with 1-hour chunks
+SELECT create_hypertable('telemetry_metric_samples', 'ts',
+    chunk_time_interval => INTERVAL '1 hour');
+
+-- Indexes for command center query patterns
+CREATE INDEX idx_tms_metric_ts ON telemetry_metric_samples (metric_name, ts DESC);
+CREATE INDEX idx_tms_scope_ts ON telemetry_metric_samples (scope, ts DESC);
+```
+
+**Histogram strategy:** Rather than storing raw histogram buckets (high cardinality), we pre-compute p50/p95/p99 at ingestion time using the OTel histogram data points. This keeps storage bounded while providing the percentiles operators actually need.
+
+**Ingestion cadence:** Every 60 seconds, an async task aggregates in-memory metric state and inserts one row per metric per label combination.
+
+### 11.2 `telemetry_log_events`
+
+Stores curated log events (WARN/ERROR only).
+
+```sql
+CREATE TABLE telemetry_log_events (
+    id       UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    ts       TIMESTAMPTZ NOT NULL,
+    level    TEXT        NOT NULL CHECK (level IN ('ERROR', 'WARN')),
+    service  TEXT        NOT NULL,
+    domain   TEXT        NOT NULL,
+    event    TEXT        NOT NULL,
+    message  TEXT        NOT NULL,
+    trace_id TEXT        NULL,
+    span_id  TEXT        NULL,
+    attrs    JSONB       NOT NULL DEFAULT '{}'::jsonb  -- allowlisted attrs only
+);
+
+CREATE INDEX idx_tle_ts ON telemetry_log_events (ts DESC);
+CREATE INDEX idx_tle_level_ts ON telemetry_log_events (level, ts DESC);
+CREATE INDEX idx_tle_domain_ts ON telemetry_log_events (domain, ts DESC);
+CREATE INDEX idx_tle_trace_id ON telemetry_log_events (trace_id) WHERE trace_id IS NOT NULL;
+```
+
+### 11.3 `telemetry_trace_index`
+
+Stores trace metadata only — no span payloads or attributes beyond what's needed for filtering.
+
+```sql
+CREATE TABLE telemetry_trace_index (
+    trace_id    TEXT        NOT NULL,
+    span_name   TEXT        NOT NULL,
+    domain      TEXT        NOT NULL,
+    route       TEXT        NULL,
+    status_code TEXT        NULL,
+    duration_ms INTEGER     NOT NULL,
+    ts          TIMESTAMPTZ NOT NULL,
+    service     TEXT        NOT NULL
+);
+
+CREATE INDEX idx_tti_ts ON telemetry_trace_index (ts DESC);
+CREATE INDEX idx_tti_status_ts ON telemetry_trace_index (status_code, ts DESC);
+CREATE INDEX idx_tti_domain_ts ON telemetry_trace_index (domain, ts DESC);
+CREATE INDEX idx_tti_duration ON telemetry_trace_index (duration_ms DESC, ts DESC);
+CREATE INDEX idx_tti_trace_id ON telemetry_trace_index (trace_id);
+```
+
+### 11.4 `telemetry_trend_rollups` (materialized view)
+
+Pre-aggregated daily rollups for 30-day trend queries. Refreshed hourly by background job.
+
+```sql
+CREATE MATERIALIZED VIEW telemetry_trend_rollups AS
+SELECT
+    date_trunc('day', ts) AS day,
+    metric_name,
+    scope,
+    labels->>'http.route' AS route,
+    COUNT(*) AS sample_count,
+    AVG(value_p95) AS avg_p95,
+    MAX(value_p95) AS max_p95,
+    SUM(value_count) AS total_count,
+    SUM(CASE WHEN (labels->>'http.response.status_code')::int >= 500
+         THEN value_count ELSE 0 END) AS error_count
+FROM telemetry_metric_samples
+GROUP BY 1, 2, 3, 4;
+
+CREATE UNIQUE INDEX idx_ttr_day_metric ON telemetry_trend_rollups (day, metric_name, scope, route);
+```
+
+### 11.5 Retention Policies
+
+| Table | Policy | Mechanism |
+|-------|--------|-----------|
+| `telemetry_metric_samples` | 30 days hard delete | TimescaleDB `drop_chunks` / scheduled `DELETE WHERE ts < now() - '30d'` |
+| `telemetry_log_events` | 30 days hard delete | Scheduled `DELETE WHERE ts < now() - '30d'` |
+| `telemetry_trace_index` | 30 days hard delete | Scheduled `DELETE WHERE ts < now() - '30d'` |
+| `telemetry_trend_rollups` | Refreshed hourly, covers available data | `REFRESH MATERIALIZED VIEW CONCURRENTLY` |
+
+Retention job runs as a background task every hour. Logs execution time and rows deleted to its own observability output.
+
+---
+
+## 12. API Design (Admin)
+
+All endpoints under `/api/admin/observability/*`, require `SystemAdminUser` middleware.
+
+### 12.1 Health and Overview
 
 - `GET /api/admin/observability/summary`
-  - Returns top-card KPIs and pipeline status.
+  - Returns: vital signs (4 golden signal values), service health matrix, server metadata, active alert count
+  - Response time target: < 50ms
 
-### Trends
+### 12.2 Trends
 
-- `GET /api/admin/observability/trends?range=24h|7d|30d`
-  - Returns pre-aggregated chart series.
+- `GET /api/admin/observability/trends?range=1h|6h|24h|7d|30d&metric=<name>`
+  - Returns: time-series data points for the requested metric(s)
+  - Uses live query for ranges <= 24h, materialized view for 7d/30d
+  - Response time target: < 200ms (24h), < 500ms (30d)
 
-### Top Offenders
+### 12.3 Top Offenders
 
-- `GET /api/admin/observability/top-routes?range=...`
-- `GET /api/admin/observability/top-errors?range=...`
+- `GET /api/admin/observability/top-routes?range=...&sort=latency|errors&limit=10`
+- `GET /api/admin/observability/top-errors?range=...&limit=10`
+  - Returns: ranked lists with route, count, p95, error rate
 
-### Logs
+### 12.4 Voice
 
-- `GET /api/admin/observability/logs?level=&domain=&from=&to=&limit=&offset=`
+- `GET /api/admin/observability/voice/summary`
+  - Returns: active sessions, rooms, join success rate, voice health score
+- `GET /api/admin/observability/voice/quality?range=...`
+  - Returns: packet loss, jitter, latency time-series from TimescaleDB
 
-### Trace Index
+### 12.5 Infrastructure
 
-- `GET /api/admin/observability/traces?status=&domain=&route=&from=&to=&limit=&offset=`
+- `GET /api/admin/observability/infrastructure`
+  - Returns: health status for DB, Valkey, S3, OTel pipeline with available metrics
 
-### External Deep Links Config
+### 12.6 Logs
+
+- `GET /api/admin/observability/logs?level=&domain=&service=&from=&to=&search=&cursor=&limit=`
+  - Returns: paginated log entries, cursor for next page
+  - Max limit: 100
+
+### 12.7 Trace Index
+
+- `GET /api/admin/observability/traces?status=&domain=&route=&duration_min=&from=&to=&cursor=&limit=`
+  - Returns: paginated trace index entries, cursor for next page
+  - Max limit: 100
+
+### 12.8 Export
+
+- `GET /api/admin/observability/export?type=logs|traces|metrics&format=csv|json&...filters`
+  - Returns: streamed file download of filtered data
+  - Max: 10,000 rows per export
+
+### 12.9 External Links
 
 - `GET /api/admin/observability/links`
-  - Returns enabled external URLs/actions (Grafana/Tempo/Loki/Prometheus) if configured.
+  - Returns: configured external tool URLs (Grafana, Tempo, Loki, Prometheus) or empty if not configured
 
-## Security and Privacy
+### 12.10 Configuration
 
-- Reuse `observability-contract.md` redaction rules.
-- Enforce strict attribute allowlist for persisted logs and metric labels.
-- Never persist secrets, auth tokens, private message content, key material, or raw request bodies.
-- Keep admin-only access behind existing system admin middleware.
-- Record access to observability endpoints in audit log (`admin.observability.view`).
+- `GET /api/admin/observability/config`
+  - Returns: threshold values, refresh cadences, feature flags (v1.1 features enabled/disabled)
 
-## Cardinality and Cost Controls
+---
 
-- Ban high-cardinality labels (`user_id`, `session_id`, arbitrary ids) in native metric labels.
-- Restrict route labels to parameterized templates.
-- Enforce per-query limits and bounded time ranges.
-- Pre-aggregate trend queries; avoid on-demand expensive scans of raw rows.
+## 13. Security and Privacy
 
-## Operational Behavior
+### 13.1 Access Control
 
-- **Degraded mode:** if collector/external stack is unavailable, native panel remains functional using native storage.
-- **Freshness indicators:** each panel shows last successful ingest/update time.
-- **Backfill behavior:** no historical backfill beyond native retention boundaries.
+- All endpoints require `SystemAdminUser` middleware (existing admin auth flow).
+- Elevated session (`ElevatedAdmin`) NOT required for read-only observability — reduces friction for monitoring.
+- Access to observability endpoints is recorded in audit log as `admin.observability.view` event.
 
-## Performance Constraints
+### 13.2 Data Redaction
 
-- Dashboard API p95 target: <= 200 ms for summary/top endpoints.
-- Trend endpoint p95 target: <= 500 ms for 30-day range.
-- UI refresh cadence: 10-30 seconds depending on panel.
-- Ingestion jobs must be async and bounded; no hot-path blocking.
+Native telemetry storage inherits ALL redaction rules from `observability-contract.md`:
 
-## Rollout Plan
+- **Forbidden fields** (Section 7): Never persisted in `attrs` JSONB, `labels` JSONB, or any text field.
+- **Label allowlist** (Section 6): Only contract-allowlisted labels stored in `telemetry_metric_samples.labels`.
+- **Log scrubbing** (Section 9): Applied before native storage, not just before OTLP export.
+- **No PII**: No user IDs, IPs, message content, or credentials in any native telemetry table.
 
-### Phase 1 - Foundations
+### 13.3 WebSocket Security
 
-1. Add `command-center` panel in admin UI.
-2. Define backend observability admin route group.
-3. Add native telemetry tables and retention jobs.
+- `admin.observability.*` events are only sent to authenticated system admin connections.
+- Event subscription is implicit when the command center panel is active (frontend sends a subscription message).
+- No sensitive data in push events — only aggregate values and sanitized error summaries.
 
-### Phase 2 - MVP Data and Views
+---
 
-1. Implement summary/trends/top-routes/top-errors endpoints.
-2. Implement logs and trace-index list endpoints.
-3. Build native command center cards, charts, and tables.
+## 14. Cardinality and Cost Controls
 
-### Phase 3 - External Hand-off
+- **Label allowlist enforcement:** Native metric storage ONLY accepts labels from the contract's Section 6 allowlist. All others are silently dropped at ingestion.
+- **Route label normalization:** `http.route` labels use parameterised templates only (e.g., `/api/v1/guilds/{guild_id}`), never resolved paths.
+- **Cardinality budget:** Max 100 unique label combinations per metric (contract rule). Enforced at ingestion; excess combinations logged as warnings.
+- **Query bounds:** All list endpoints enforce max page size (100), max time range (30d), and required time filters.
+- **Export limits:** Max 10,000 rows per export request.
+- **Storage budget (estimated):** At moderate load (1000 DAU), ~500MB/month for all native telemetry tables combined. At heavy load (10,000 DAU), ~2GB/month. Retention purge keeps total under 6x monthly volume.
 
-1. Add optional external deep-link configuration.
-2. Add `Open in Grafana/Tempo/Loki` actions.
-3. Add empty/degraded states and setup guidance.
+---
 
-### Phase 4 - Hardening
+## 15. Operational Behavior
 
-1. Add tests for redaction and label allowlist enforcement.
-2. Add retention/downsampling verification checks.
-3. Add CI checks for schema and contract conformance.
+- **Degraded mode:** If OTel collector or external stack is unavailable, native panel remains fully functional using native storage. Degraded badges appear for affected services.
+- **Freshness indicators:** Every panel section shows last successful ingest/update timestamp. Stale data (> 2x expected interval) shows yellow warning.
+- **Startup behavior:** Command center shows "Collecting data..." placeholder for the first 60 seconds after server start while initial metrics accumulate.
+- **Backfill:** No historical backfill beyond native retention boundaries. After 30 days of downtime, the panel starts fresh.
+- **Feature flags:** v1.1 features (client telemetry, deploy markers, Redis stats) gated behind config flags. Disabled by default until implemented.
 
-## Success Criteria
+---
 
-- All system admins can open cluster-wide command center and see current health signals.
-- Native logs/trace-index/metrics data is queryable for last 30 days only.
-- Degraded mode works without external stack.
-- External links appear when stack is configured.
-- No forbidden fields leak into persisted native telemetry.
+## 16. Performance Constraints
 
-## Open Questions
+| Endpoint | p95 Target | Notes |
+|----------|-----------|-------|
+| Summary | <= 50ms | In-memory cached, refreshed every 5s |
+| Trends (<= 24h) | <= 200ms | Live query on hypertable |
+| Trends (7d/30d) | <= 500ms | Materialized view |
+| Top offenders | <= 200ms | Aggregate query with limit |
+| Voice summary | <= 100ms | Mix of in-memory gauge + TimescaleDB |
+| Logs/Traces list | <= 200ms | Indexed cursor pagination |
+| Infrastructure | <= 100ms | Cached health probes |
+| Export | <= 5s (streaming) | Streamed response, not buffered |
 
-- Do we expose `INFO` logs in v1 or keep native logs strictly `WARN/ERROR`?
-- Should trend aggregation run synchronous-on-read or precomputed materialized views?
-- Do we add an export endpoint (CSV/JSON) for native command center datasets in v1?
+UI refresh cadence: configurable 5-30 seconds depending on panel (see Section 9.2).
+Ingestion jobs: async, bounded queue, no hot-path blocking.
+Background retention job: hourly, < 10s execution target.
+
+---
+
+## 17. Chart Library Decision
+
+The client currently has **no chart/visualization library** installed. The command center requires time-series charts, gauges, and sparklines. Evaluation:
+
+| Library | Solid.js Support | Bundle Size | Features | Decision |
+|---------|-----------------|-------------|----------|----------|
+| Chart.js | Via solid-chartjs | ~65KB gzip | Line, bar, area, doughnut | **Recommended** |
+| Recharts | React-only (no Solid adapter) | ~130KB gzip | Full featured | Rejected — React dependency |
+| D3 | Framework-agnostic | ~90KB gzip | Maximum flexibility | Rejected — over-engineered for our needs |
+| Lightweight custom (Canvas) | Native | ~5KB | Sparklines only | Rejected — insufficient for trend charts |
+
+**Recommendation:** `chart.js` + `solid-chartjs` (or thin wrapper). Provides line charts, area charts, bar charts, and doughnut/gauge — all needed by the command center. MIT licensed, actively maintained, 60K+ GitHub stars.
+
+---
+
+## 18. Rollout Plan
+
+### Phase 1 — Data Foundation
+1. Native telemetry schema migration (3 tables + materialized view).
+2. Retention and downsampling jobs.
+3. Storage/query module in `server/src/observability/storage.rs`.
+4. Ingestion pipeline wiring (curated logs, trace index, metric samples).
+5. Label allowlist enforcement and cardinality guardrails.
+
+### Phase 2 — Admin API Surface
+6. Summary, trends, top-offenders endpoints.
+7. Voice summary and quality endpoints.
+8. Infrastructure health endpoint.
+9. Logs and trace-index list endpoints with pagination.
+10. Export endpoint (CSV/JSON).
+11. External links and config endpoints.
+12. Audit logging for observability access.
+
+### Phase 3 — Client Admin Panel
+13. Sidebar entry and panel routing (`command-center`).
+14. Health overview (vital signs, service matrix, live error feed).
+15. Golden Signals tab (charts, tables).
+16. Voice tab.
+17. Infrastructure tab.
+18. Logs and Traces tabs.
+19. Time range picker and auto-refresh.
+20. Degraded/empty state handling.
+
+### Phase 4 — Real-Time and Correlation
+21. WebSocket push events for health transitions and vital signs.
+22. Live error feed auto-scroll.
+23. Incident correlation view (shared time axis, click-through).
+24. External deep-link integration (Grafana/Tempo/Loki actions).
+
+### Phase 5 — Quality Gates
+25. Backend integration tests (auth, bounds, retention, redaction).
+26. Frontend component tests (panel states, data rendering).
+27. E2E smoke test (admin can open command center, see health data).
+28. CI governance checks (retention constants, forbidden fields, schema conformance).
+
+---
+
+## 19. Success Criteria
+
+- [ ] All system admins can open cluster-wide command center and see current health signals within 5 seconds.
+- [ ] Health overview answers "is something wrong?" with service matrix + vital signs + live error feed.
+- [ ] Golden signals are organized as Latency/Traffic/Errors/Saturation with time-series charts.
+- [ ] Voice operations tab shows session quality, join success, packet loss, jitter trends.
+- [ ] Infrastructure tab shows DB pool, Valkey, S3, OTel pipeline health.
+- [ ] Logs are WARN/ERROR only, filterable, with trace ID correlation.
+- [ ] Trace index is searchable with "Open in Tempo" when external stack configured.
+- [ ] Native data never exceeds 30-day retention.
+- [ ] Status thresholds are color-coded (green/yellow/red) with configurable values.
+- [ ] Real-time updates via WebSocket for health transitions and vital signs.
+- [ ] Export to CSV/JSON works for logs, traces, and metrics views.
+- [ ] Degraded mode works without external stack.
+- [ ] No forbidden fields leak into persisted native telemetry.
+- [ ] All metrics map to observability contract definitions.

--- a/docs/plans/2026-02-27-phase-7-admin-command-center-implementation.md
+++ b/docs/plans/2026-02-27-phase-7-admin-command-center-implementation.md
@@ -1,14 +1,14 @@
-# Phase 7 Admin Command Center - Implementation Plan
+# Phase 7 Admin Command Center — Implementation Plan
 
 **Date:** 2026-02-27
-**Status:** Draft
+**Status:** Draft (v2)
 **Design Doc:** `docs/plans/2026-02-27-phase-7-admin-command-center-design.md`
 **Task Plan:** `docs/plans/2026-02-27-phase-7-admin-command-center-task-plan.md`
 **Roadmap Item:** Phase 7 `[Ops] Admin Command Center (Native Observability Lite)`
 
 ## Objective
 
-Implement a cluster-wide native admin Command Center that provides 30-day operational visibility for all system admins while preserving external observability (Grafana/Tempo/Loki/Prometheus) for deep analysis.
+Implement a cluster-wide native admin Command Center that provides 30-day operational visibility for all system admins, organized around the Four Golden Signals framework (Latency, Traffic, Errors, Saturation). The panel covers health overview, golden signals trends, voice operations, infrastructure health, curated logs, and trace index — while preserving external observability (Grafana/Tempo/Loki/Prometheus) for deep forensics.
 
 ## Open-Source and Maintenance Policy
 
@@ -40,11 +40,17 @@ This feature must use actively maintained open-source tooling only.
 
 ### In scope (native)
 
-- Admin UI panel `command-center`
-- Summary health cards and 30-day trends
-- Top offenders (slow/failing routes, error categories)
-- Curated log list (WARN/ERROR, redacted)
-- Trace index list (metadata only, no span payload storage)
+- Admin UI panel `command-center` with 7-tier signal taxonomy (Design §6)
+- Health overview: vital signs cards, service health matrix, live error feed (Tier 1)
+- Golden signals dashboard with 30-day trends and top offenders (Tier 2)
+- Voice operations tab: session quality, join success, packet loss, jitter (Tier 3)
+- Infrastructure health: DB pool, Valkey, S3, OTel pipeline (Tier 4)
+- Curated log list (WARN/ERROR only, redacted, filterable) (Tier 5)
+- Trace index list (metadata only, no span payload storage) (Tier 6)
+- Real-time WebSocket push for health transitions and vital signs (Design §9)
+- Status thresholds with green/yellow/red indicators (Design §8)
+- Incident correlation via shared time axis and click-through (Design §10)
+- Export endpoint for logs, traces, and metrics (CSV/JSON) (Design §12.8)
 - Native retention enforcement (30 days max)
 - Optional deep-links to external Grafana stack when configured
 
@@ -55,200 +61,536 @@ This feature must use actively maintained open-source tooling only.
 - Native retention beyond 30 days
 - Alert-rule authoring UI
 - Per-node or per-role observability segmentation
+- Client telemetry ingestion pipeline (v1.1, Design §6 Tier 7)
+- Redis INFO stats beyond connectivity (v1.1)
+- Deploy markers on charts (v1.1)
+- Rolling 7-day anomaly detection baselines (v1.1)
 
 ## Implementation Phases
 
-## Phase 1 - Data Foundation
+The six phases below map directly to the design's rollout plan (Design §18), extended with chart library installation and WebSocket push as distinct phases.
 
-1. **Add telemetry storage schema (30-day native model)**
-   - Files:
-     - `server/migrations/<new>_telemetry_native_command_center.sql`
-   - Tasks:
-     - Create `telemetry_metric_samples` (Timescale hypertable)
-     - Create `telemetry_log_events`
-     - Create `telemetry_trace_index`
-     - Add indexes for `ts`, domain, severity/status, route/span
+---
 
-2. **Add retention/downsampling jobs**
-   - Files:
-     - `server/migrations/<same or follow-up>_telemetry_retention_policies.sql`
-   - Tasks:
-     - Enforce strict 30-day deletion policies
-     - Add metric downsampling after day 7
+## Phase 1 — Data Foundation
 
-3. **Add storage/query modules**
-   - Files:
-     - `server/src/observability/storage.rs` (new)
-     - `server/src/observability/mod.rs`
-   - Tasks:
-     - Insert/query helpers for metrics/logs/trace index
-     - Add bounded query defaults and max limits
+*Design references: §11 (Data Model), §11.1 (histogram strategy), §11.4 (materialized view), §11.5 (retention)*
 
-## Phase 2 - Ingestion and Contracts
+### 1. Add telemetry storage schema
 
-4. **Wire curated native telemetry ingestion**
-   - Files:
-     - `server/src/observability/tracing.rs`
-     - `server/src/observability/metrics.rs`
-     - `server/src/main.rs`
-   - Tasks:
-     - Persist only allowlisted fields for logs and trace index
-     - Persist selected metric aggregates for command center views
-     - Preserve existing OTLP export path
+- Files:
+  - `server/migrations/<timestamp>_telemetry_native_command_center.sql`
+- Tasks:
+  - Create `telemetry_metric_samples` as TimescaleDB hypertable (1-hour chunks), with columns: `ts`, `metric_name`, `scope`, `labels` (JSONB), `value_count`, `value_sum`, `value_p50`, `value_p95`, `value_p99`
+  - Create `telemetry_log_events` with columns: `id` (UUID), `ts`, `level` (WARN/ERROR), `service`, `domain`, `event`, `message`, `trace_id`, `span_id`, `attrs` (JSONB)
+  - Create `telemetry_trace_index` with columns: `trace_id`, `span_name`, `domain`, `route`, `status_code`, `duration_ms`, `ts`, `service`
+  - Add all indexes from Design §11: `idx_tms_metric_ts`, `idx_tms_scope_ts`, `idx_tle_ts`, `idx_tle_level_ts`, `idx_tle_domain_ts`, `idx_tle_trace_id`, `idx_tti_ts`, `idx_tti_status_ts`, `idx_tti_domain_ts`, `idx_tti_duration`, `idx_tti_trace_id`
+  - Graceful fallback: if TimescaleDB extension is unavailable, create as standard PostgreSQL table with scheduled DELETE for retention
 
-5. **Implement cardinality guardrails**
-   - Files:
-     - `server/src/observability/metrics.rs`
-     - `docs/ops/observability-contract.md`
-   - Tasks:
-     - Explicit label allowlist for native metric storage
-     - Reject/drop forbidden high-cardinality labels
+### 2. Add materialized view for 30-day trend rollups
 
-6. **Audit and security hooks**
-   - Files:
-     - `server/src/admin/handlers.rs`
-     - `server/src/permissions/queries.rs`
-   - Tasks:
-     - Add `admin.observability.view` audit event on access
-     - Ensure redaction and no sensitive field persistence
+- Files:
+  - `server/migrations/<timestamp>_telemetry_trend_rollups.sql`
+- Tasks:
+  - Create `telemetry_trend_rollups` materialized view (Design §11.4): daily rollup of `metric_name`, `scope`, `route` (from labels), `sample_count`, `avg_p95`, `max_p95`, `total_count`, `error_count`
+  - Add unique index `idx_ttr_day_metric` on `(day, metric_name, scope, route)`
+  - Document: this view is used for 7d/30d trend queries; live queries serve ranges <= 24h
 
-## Phase 3 - Admin API Surface
+### 3. Add retention and rollup jobs
 
-7. **Add command center admin endpoints**
-   - Files:
-     - `server/src/admin/mod.rs`
-     - `server/src/admin/handlers.rs`
-     - `server/src/admin/types.rs`
-   - Endpoints:
-     - `GET /api/admin/observability/summary`
-     - `GET /api/admin/observability/trends`
-     - `GET /api/admin/observability/top-routes`
-     - `GET /api/admin/observability/top-errors`
-     - `GET /api/admin/observability/logs`
-     - `GET /api/admin/observability/traces`
-     - `GET /api/admin/observability/links`
+- Files:
+  - `server/src/observability/retention.rs` (new)
+  - `server/src/observability/mod.rs`
+- Tasks:
+  - Implement hourly background task: `DELETE WHERE ts < now() - INTERVAL '30 days'` for all three telemetry tables
+  - Implement hourly `REFRESH MATERIALIZED VIEW CONCURRENTLY telemetry_trend_rollups`
+  - Log execution time and rows deleted per run (to tracing output, not to native telemetry tables)
+  - Target: < 10s execution per hourly run
 
-8. **Bounded query protections**
-   - Files:
-     - `server/src/admin/handlers.rs`
-   - Tasks:
-     - Max page size and strict range validation
-     - Default sort order and stable pagination keys
+### 4. Add storage and query module
 
-## Phase 4 - Client Admin Panel
+- Files:
+  - `server/src/observability/storage.rs` (new)
+  - `server/src/observability/mod.rs`
+- Tasks:
+  - Insert helpers: `insert_metric_sample`, `insert_log_event`, `insert_trace_index_entry`
+  - Query helpers: `query_trends` (live vs. materialized view branch by range), `query_logs` (cursor pagination), `query_traces` (cursor pagination), `query_top_routes`, `query_top_errors`
+  - Enforce max page size (100) and max time range (30d) at query layer
+  - All public functions annotated with `#[tracing::instrument(skip(pool))]`
 
-9. **Add sidebar and panel wiring**
-   - Files:
-     - `client/src/components/admin/AdminSidebar.tsx`
-     - `client/src/views/AdminDashboard.tsx`
-   - Tasks:
-     - Add `command-center` panel id and nav entry
-     - Route panel rendering in admin dashboard
+### 5. Implement histogram pre-computation strategy
 
-10. **Create Command Center UI components**
-    - Files:
-      - `client/src/components/admin/CommandCenterPanel.tsx` (new)
-      - `client/src/components/admin/index.ts`
-    - Tasks:
-      - Health cards, trend charts, offender tables, logs table, trace index table
-      - Degraded-state and empty-state handling
+- Files:
+  - `server/src/observability/metrics.rs`
+  - `server/src/observability/storage.rs`
+- Tasks:
+  - At ingestion time, compute p50/p95/p99 from OTel histogram data points before writing to `telemetry_metric_samples`
+  - Do not store raw histogram buckets (high cardinality); store only pre-computed percentiles
+  - Ingestion cadence: async task aggregates in-memory metric state every 60 seconds, inserts one row per metric per label combination
 
-11. **Add store and API client methods**
-    - Files:
-      - `client/src/stores/admin.ts`
-      - `client/src/lib/tauri.ts`
-    - Tasks:
-      - Add state/actions for summary/trends/logs/traces/top offenders
-      - Add polling cadence and freshness timestamps
-      - Add optional external deep-link actions
+### 6. Implement label allowlist and cardinality guardrails
 
-## Phase 5 - External Stack Hand-off
+- Files:
+  - `server/src/observability/metrics.rs`
+  - `docs/ops/observability-contract.md` (reference, do not modify)
+- Tasks:
+  - Enforce contract Section 6 label allowlist: only allowlisted labels stored in `telemetry_metric_samples.labels` JSONB
+  - Silently drop non-allowlisted labels at ingestion
+  - Enforce max 100 unique label combinations per metric; log warning when exceeded
+  - Route label normalization: store parameterised templates only (e.g., `/api/v1/guilds/{guild_id}`), never resolved paths
 
-12. **Config-gated deep links**
-    - Files:
-      - `server/src/config.rs`
-      - `server/src/admin/handlers.rs`
-      - `docs/ops/observability-runbook.md`
-    - Tasks:
-      - Add optional config for Grafana/Tempo/Loki/Prometheus URLs
-      - Return links via `/links` endpoint only when configured
+---
 
-13. **UI integration for deep analysis**
-    - Files:
-      - `client/src/components/admin/CommandCenterPanel.tsx`
-    - Tasks:
-      - `Open in Grafana/Tempo/Loki` actions from relevant rows/cards
+## Phase 2 — Admin API Surface
 
-## Phase 6 - Quality Gates
+*Design references: §12 (API Design), §8 (Status Thresholds), §13 (Security), §14 (Cardinality Controls), §16 (Performance Constraints)*
 
-14. **Tests: backend**
-    - Files:
-      - `server/tests/*` (new coverage files)
-    - Tasks:
-      - Endpoint auth/access tests (system admin required)
-      - Retention and query-bound checks
-      - Redaction/allowlist persistence tests
+All endpoints under `/api/admin/observability/*`, require `SystemAdminUser` middleware. Access recorded as `admin.observability.view` audit event.
 
-15. **Tests: frontend**
-    - Files:
-      - `client/src/components/admin/*.test.tsx`
-      - `client/e2e/*admin*.spec.ts`
-    - Tasks:
-      - Panel rendering and degraded-state tests
-      - Data table/filter interactions
+### 7. Summary and health endpoint
 
-16. **Governance + CI checks**
-    - Files:
-      - `.github/workflows/ci.yml`
-      - `scripts/check_docs_governance.py`
-    - Tasks:
-      - Check retention policy constants (30-day max)
-      - Check forbidden telemetry fields in native schemas
-      - Ensure roadmap links to active design + implementation docs
+- Files:
+  - `server/src/admin/observability.rs` (new)
+  - `server/src/admin/mod.rs`
+  - `server/src/admin/types.rs`
+- Endpoint: `GET /api/admin/observability/summary`
+- Response: vital signs (4 golden signal current values), service health matrix (7 services), server metadata (version, uptime, environment, active users, guild count), active alert count
+- Implementation: in-memory cached, refreshed every 5s; health probes run async
+- Performance target: p95 <= 50ms (Design §16)
+
+### 8. Trends endpoint
+
+- Files:
+  - `server/src/admin/observability.rs`
+- Endpoint: `GET /api/admin/observability/trends?range=1h|6h|24h|7d|30d&metric=<name>`
+- Response: time-series data points for requested metric(s)
+- Implementation: live query on `telemetry_metric_samples` for ranges <= 24h; `telemetry_trend_rollups` materialized view for 7d/30d (Design §12.2)
+- Performance targets: p95 <= 200ms (24h), p95 <= 500ms (30d) (Design §16)
+
+### 9. Top offenders endpoints
+
+- Files:
+  - `server/src/admin/observability.rs`
+- Endpoints:
+  - `GET /api/admin/observability/top-routes?range=...&sort=latency|errors&limit=10`
+  - `GET /api/admin/observability/top-errors?range=...&limit=10`
+- Response: ranked lists with route, count, p95, error rate; top error categories grouped by `error.type` label
+- Performance target: p95 <= 200ms (Design §16)
+
+### 10. Voice endpoints
+
+- Files:
+  - `server/src/admin/observability.rs`
+- Endpoints:
+  - `GET /api/admin/observability/voice/summary`
+  - `GET /api/admin/observability/voice/quality?range=...`
+- Voice summary response: active sessions, active rooms, join success rate (24h), voice health score (0-100 composite: join success 40%, packet loss p95 30%, jitter p95 20%, session crash rate 10%)
+- Voice quality response: packet loss, jitter, latency time-series from `connection_metrics` TimescaleDB hypertable (p50/p95 per interval)
+- Performance targets: voice summary p95 <= 100ms; quality p95 <= 200ms (Design §16)
+
+### 11. Infrastructure health endpoint
+
+- Files:
+  - `server/src/admin/observability.rs`
+- Endpoint: `GET /api/admin/observability/infrastructure`
+- Response: health status for PostgreSQL (pool active/idle/max, query p95, `SELECT 1` probe), Valkey (PING probe), S3 (bucket access probe, graceful if unconfigured), OTel pipeline (export failure rate, dropped spans count, collector endpoint)
+- Implementation: cached health probes, refreshed every 10s
+- Performance target: p95 <= 100ms (Design §16)
+
+### 12. Logs endpoint
+
+- Files:
+  - `server/src/admin/observability.rs`
+- Endpoint: `GET /api/admin/observability/logs?level=&domain=&service=&from=&to=&search=&cursor=&limit=`
+- Response: paginated log entries (cursor-based), max 100 per page
+- Filters: severity (WARN/ERROR), domain, service, time range, free-text search on event/message
+- Performance target: p95 <= 200ms (Design §16)
+
+### 13. Trace index endpoint
+
+- Files:
+  - `server/src/admin/observability.rs`
+- Endpoint: `GET /api/admin/observability/traces?status=&domain=&route=&duration_min=&from=&to=&cursor=&limit=`
+- Response: paginated trace index entries (cursor-based), max 100 per page
+- Pre-filtered views: "Recent errors" (status >= 500), "Recent slow" (duration > p95 threshold)
+- Performance target: p95 <= 200ms (Design §16)
+
+### 14. Export endpoint
+
+- Files:
+  - `server/src/admin/observability.rs`
+- Endpoint: `GET /api/admin/observability/export?type=logs|traces|metrics&format=csv|json&...filters`
+- Response: streamed file download of filtered data; max 10,000 rows per export
+- Implementation: streaming response (not buffered in memory); same filter params as respective list endpoints
+- Performance target: p95 <= 5s streaming (Design §16)
+
+### 15. External links and config endpoints
+
+- Files:
+  - `server/src/admin/observability.rs`
+  - `server/src/config.rs`
+- Endpoints:
+  - `GET /api/admin/observability/links` — returns configured external tool URLs (Grafana, Tempo, Loki, Prometheus) or empty object if not configured
+  - `GET /api/admin/observability/config` — returns threshold values (Design §8.1), refresh cadences, feature flags for v1.1 features
+- Config: threshold values read from environment variables with `COMMAND_CENTER_` prefix (Design §8.2)
+
+### 16. Audit and security hooks
+
+- Files:
+  - `server/src/admin/observability.rs`
+  - `server/src/permissions/queries.rs`
+- Tasks:
+  - Record `admin.observability.view` audit event on every observability endpoint access
+  - Verify `SystemAdminUser` middleware is applied to all routes (elevated session NOT required for read-only access)
+  - Confirm no PII, user IDs, IPs, message content, or credentials reach any native telemetry table
+
+---
+
+## Phase 3 — Chart Library Installation
+
+*Design references: §17 (Chart Library Decision)*
+
+The client currently has no chart or visualization library. This phase installs the chosen library before building any chart components.
+
+### 17. Install chart.js and solid-chartjs
+
+- Files:
+  - `client/package.json`
+  - `client/src/lib/charts.ts` (new — thin wrapper/config)
+- Tasks:
+  - Run `bun add chart.js solid-chartjs` in `client/`
+  - Verify MIT license compliance with `cargo deny check licenses` equivalent for frontend (check `bun pm ls`)
+  - Create `client/src/lib/charts.ts`: export pre-configured Chart.js defaults (font, color palette matching CSS variables, no animation on initial load for performance)
+  - Confirm bundle size impact is acceptable (~65KB gzip per Design §17)
+  - Add chart.js to `client/src/lib/tauri.ts` dual-mode awareness if any chart data fetching differs between Tauri and browser dev mode
+
+---
+
+## Phase 4 — Client Admin Panel
+
+*Design references: §6 (Signal Taxonomy), §7 (Layout and Information Hierarchy), §8 (Status Thresholds), §9.2 (Polling Cadence)*
+
+### 18. Add sidebar entry and panel routing
+
+- Files:
+  - `client/src/components/admin/AdminSidebar.tsx`
+  - `client/src/views/AdminDashboard.tsx`
+- Tasks:
+  - Add `command-center` panel ID and nav entry to admin sidebar
+  - Route panel rendering in admin dashboard to `CommandCenterPanel`
+
+### 19. Add store and API client methods
+
+- Files:
+  - `client/src/stores/admin.ts`
+  - `client/src/lib/tauri.ts`
+- Tasks:
+  - Add state and actions for: summary, trends, top-routes, top-errors, voice summary, voice quality, infrastructure, logs, traces, config, links
+  - Add polling cadence per Design §9.2: trends/traces 30s, logs 15s, infrastructure 10s
+  - Add freshness timestamps per section; mark stale if > 2x expected interval
+  - Add time range state (1h/6h/24h/7d/30d, default 24h) shared across all trend panels
+  - Add optional external deep-link actions (open in Grafana/Tempo/Loki)
+
+### 20. Build Health Overview (Tier 1 — always visible)
+
+- Files:
+  - `client/src/components/admin/CommandCenterPanel.tsx` (new)
+  - `client/src/components/admin/VitalSignsCards.tsx` (new)
+  - `client/src/components/admin/ServiceHealthMatrix.tsx` (new)
+  - `client/src/components/admin/LiveErrorFeed.tsx` (new)
+  - `client/src/components/admin/index.ts`
+- Tasks:
+  - Four vital-sign cards (one per golden signal): current value, sparkline (1h), threshold color (green/yellow/red per Design §8.1)
+  - Service health matrix: 7 services (HTTP API, WebSocket Hub, Voice SFU, PostgreSQL, Valkey, S3, OTel Pipeline) with status dots
+  - Live error feed: last 25 errors, cross-service, scrolling; fields: timestamp, service, domain, event, message (truncated), trace_id link; "View all logs" link
+  - Server metadata strip: version, uptime, environment, active users, guild count
+  - Layout: health overview always above the fold per Design §7.2; 2-column (health matrix + error feed) on desktop, single column on tablet
+
+### 21. Build Golden Signals tab (Tier 2)
+
+- Files:
+  - `client/src/components/admin/GoldenSignalsTab.tsx` (new)
+- Tasks:
+  - Time-series line charts for Latency panel: API p50/p95/p99, DB query p50/p95, voice session duration (Design §6.2.1)
+  - Time-series area/line charts for Traffic panel: API req/s, active WS connections, active voice sessions, WS messages, RTP packets (Design §6.2.2)
+  - Time-series stacked area for Errors panel: HTTP 4xx/5xx, auth failures, token refresh failures, WS reconnects, voice join failures, OTel export failures (Design §6.2.3)
+  - Gauge + time-series for Saturation panel: DB pool utilization, idle connections, OTel dropped spans, process memory RSS (Design §6.2.4)
+  - Top slow routes table (top 10 by p95 in selected range)
+  - Top failing routes table (top 10 by error count)
+  - Top error categories table (grouped by `error.type`)
+  - Incident correlation toggle: overlay error rate on metric chart, log event markers as vertical lines (Design §10.1)
+  - Note: never show averages for latency — always p50/p95/p99 per Design §6.2.1
+
+### 22. Build Voice tab (Tier 3)
+
+- Files:
+  - `client/src/components/admin/VoiceTab.tsx` (new)
+- Tasks:
+  - Voice health score gauge (0-100 composite, prominent display)
+  - Active sessions and active rooms as large number cards with sparklines
+  - Join success rate percentage + trend chart
+  - Packet loss p50/p95 time-series line chart
+  - Network jitter p50/p95 time-series line chart
+  - Session latency p50/p95 time-series line chart
+  - Quality score distribution stacked bar chart (poor/fair/good/excellent)
+  - RTP forwarding rate time-series
+  - Session duration distribution histogram
+  - Participant distribution histogram (participants per room)
+
+### 23. Build Infrastructure tab (Tier 4)
+
+- Files:
+  - `client/src/components/admin/InfrastructureTab.tsx` (new)
+- Tasks:
+  - Database section: pool active/idle/max gauge bars, query p95 value + sparkline, query rate time-series, top slow queries table (span_name, duration, count), connectivity status badge
+  - Valkey section: connectivity status badge, usage info text
+  - S3 section: connectivity status badge, configured/not-configured/degraded status
+  - OTel pipeline section: export success/failure rate time-series, dropped spans counter (alert if > 0), collector endpoint info, pipeline status badge
+  - Poll every 10s per Design §9.2
+
+### 24. Build Logs tab (Tier 5)
+
+- Files:
+  - `client/src/components/admin/LogsTab.tsx` (new)
+- Tasks:
+  - Filterable log table: severity, domain, service, time range, free-text search
+  - Columns: severity, timestamp, service, domain, event, message (truncated to 200 chars), trace_id (clickable)
+  - Click to expand full error context
+  - Cursor-based pagination, max 100 per page
+  - Export button (CSV/JSON of current filtered view)
+  - Click on trace_id navigates to Traces tab filtered by that trace_id (Design §10.2)
+
+### 25. Build Traces tab (Tier 6)
+
+- Files:
+  - `client/src/components/admin/TracesTab.tsx` (new)
+- Tasks:
+  - Filterable trace index table: status (error/slow/all), domain, route, duration threshold, time range
+  - Columns: trace_id (clickable), span_name, route, domain, status, duration (color-coded by threshold), timestamp
+  - Pre-filtered quick views: "Recent errors" and "Recent slow"
+  - Cursor-based pagination, max 100 per page
+  - Export button (CSV/JSON of current filtered view)
+  - "Open in Tempo" button per row when external Tempo URL is configured (Design §10.2)
+
+### 26. Time range picker and auto-refresh
+
+- Files:
+  - `client/src/components/admin/TimeRangePicker.tsx` (new)
+  - `client/src/components/admin/CommandCenterPanel.tsx`
+- Tasks:
+  - Global time range selector: presets 1h/6h/24h/7d/30d, custom range with calendar picker
+  - Auto-refresh toggle with cadence indicator ("Refreshing every 10s")
+  - Applies to all trend charts and tables in active tab
+  - Tab state persists across panel switches
+
+### 27. Degraded and empty state handling
+
+- Files:
+  - `client/src/components/admin/CommandCenterPanel.tsx`
+  - All tab components
+- Tasks:
+  - "Collecting data..." placeholder for first 60s after server start (Design §15)
+  - Degraded badges when external stack is unavailable
+  - Stale data indicator: "Last updated: Xs ago" turns yellow with "(stale)" suffix if > 2x expected interval (Design §9.3)
+  - Empty state for each panel when no data exists yet
+
+---
+
+## Phase 5 — Real-Time and Correlation
+
+*Design references: §9 (Real-Time Update Strategy), §9.1 (WebSocket Push Events), §10 (Incident Correlation)*
+
+### 28. Add WebSocket push event types
+
+- Files:
+  - `shared/vc-common/src/protocol/` (add new `admin.observability.*` event variants)
+  - `server/src/ws/` (event dispatch logic)
+- Tasks:
+  - Add four new event types (Design §9.1):
+    - `admin.observability.health_change` — payload: `{ service, old_status, new_status }`
+    - `admin.observability.error_event` — payload: `{ ts, service, domain, event, message, trace_id }`
+    - `admin.observability.vital_signs` — payload: `{ latency_p95, traffic_rate, error_rate, saturation_pct }`
+    - `admin.observability.voice_pulse` — payload: `{ active_sessions, active_rooms, join_success_rate_1h }`
+  - Note: protocol changes are BREAKING per project conventions; coordinate with any in-flight WS work
+
+### 29. Implement server-side push dispatch
+
+- Files:
+  - `server/src/ws/` (dispatch logic)
+  - `server/src/observability/` (health monitor)
+- Tasks:
+  - Health monitor: detect service state transitions (healthy/degraded/down) and emit `health_change` events
+  - Error ingestion: emit `error_event` on each new ERROR-level log written to `telemetry_log_events`
+  - Vital signs broadcaster: emit `vital_signs` every 5s to admin connections with command center active
+  - Voice pulse broadcaster: emit `voice_pulse` every 5s to admin connections with voice tab active
+  - Events sent ONLY to authenticated system admin WebSocket connections (Design §13.3)
+  - Frontend sends subscription message when command center panel becomes active; server tracks subscription state
+
+### 30. Wire real-time updates in client
+
+- Files:
+  - `client/src/stores/admin.ts`
+  - `client/src/components/admin/LiveErrorFeed.tsx`
+  - `client/src/components/admin/ServiceHealthMatrix.tsx`
+  - `client/src/components/admin/VitalSignsCards.tsx`
+- Tasks:
+  - Subscribe to `admin.observability.*` events on panel mount; unsubscribe on unmount
+  - Live error feed: auto-scroll on new `error_event` push
+  - Service health matrix: update status dots on `health_change` push without full re-fetch
+  - Vital signs cards: update values on `vital_signs` push (5s cadence)
+  - Voice tab active sessions/rooms: update on `voice_pulse` push
+
+### 31. Implement incident correlation
+
+- Files:
+  - `client/src/components/admin/GoldenSignalsTab.tsx`
+  - `client/src/components/admin/LogsTab.tsx`
+  - `client/src/components/admin/TracesTab.tsx`
+- Tasks:
+  - Incident View toggle on Golden Signals tab: overlay error rate on selected metric chart (secondary y-axis), add vertical line markers at ERROR log timestamps (Design §10.1)
+  - Click-through from live error feed to Logs tab filtered by trace_id (Design §10.2)
+  - Click-through from log entry with trace_id to Traces tab filtered by trace_id
+  - Click on chart data point opens Logs tab with time filter set to that point's window
+  - "Open in Tempo" from trace index when external Tempo URL configured
+
+---
+
+## Phase 6 — Quality Gates
+
+*Design references: §18 Phase 5 (Quality Gates), §19 (Success Criteria)*
+
+### 32. Backend integration tests
+
+- Files:
+  - `server/tests/observability_auth.rs` (new)
+  - `server/tests/observability_bounds.rs` (new)
+  - `server/tests/observability_redaction.rs` (new)
+- Tasks:
+  - Auth tests: all `/api/admin/observability/*` endpoints return 403 for non-admin users
+  - Bounds tests: pagination max (100), time range max (30d), export max (10,000 rows) enforced
+  - Retention tests: rows older than 30 days are deleted by retention job
+  - Redaction tests: forbidden fields from observability contract never appear in `telemetry_log_events.attrs` or `telemetry_metric_samples.labels`
+  - Label allowlist tests: non-allowlisted labels are silently dropped at ingestion
+
+### 33. Frontend component tests
+
+- Files:
+  - `client/src/components/admin/CommandCenterPanel.test.tsx` (new)
+  - `client/src/components/admin/VoiceTab.test.tsx` (new)
+  - `client/src/components/admin/InfrastructureTab.test.tsx` (new)
+  - `client/src/components/admin/LogsTab.test.tsx` (new)
+- Tasks:
+  - Panel rendering with mock data for each tab
+  - Degraded state rendering (empty data, stale indicators)
+  - Filter interaction tests for logs and traces tabs
+  - Threshold color coding tests (green/yellow/red per Design §8.1)
+
+### 34. E2E smoke tests
+
+- Files:
+  - `client/e2e/admin-command-center.spec.ts` (new)
+- Tasks:
+  - System admin can open command center and see health data within 5 seconds
+  - Health overview shows service matrix and vital signs
+  - Tab navigation works (Golden Signals, Voice, Infrastructure, Logs, Traces)
+  - Export button triggers file download for logs view
+
+### 35. CI governance checks
+
+- Files:
+  - `.github/workflows/ci.yml`
+  - `scripts/check_docs_governance.py`
+- Tasks:
+  - Check retention policy constants (30-day max) in migration files
+  - Check forbidden telemetry fields are not referenced in native schema columns
+  - Verify `cargo deny check licenses` passes with new chart.js dependency (frontend)
+  - Ensure roadmap links to active design and implementation docs
+
+---
 
 ## Verification Strategy
 
 ### Functional
 
-- Summary/trends/top/logs/traces endpoints return expected bounded results.
+- Summary/trends/top/logs/traces/voice/infrastructure endpoints return expected bounded results.
 - Admin UI shows cluster-wide telemetry for all system admins.
-- Degraded mode works when external stack is unavailable.
+- All 7 services appear in the health matrix with correct status values.
+- Golden signals are organized as Latency/Traffic/Errors/Saturation with time-series charts.
+- Voice operations tab shows session quality, join success, packet loss, jitter trends.
+- Infrastructure tab shows DB pool, Valkey, S3, OTel pipeline health.
+- Logs are WARN/ERROR only, filterable, with trace ID correlation.
+- Trace index is searchable with "Open in Tempo" when external stack configured.
+- Export to CSV/JSON works for logs, traces, and metrics views.
+- Degraded mode works without external stack.
 
 ### Privacy/Security
 
-- No forbidden fields stored in `telemetry_log_events` or `telemetry_trace_index`.
-- Access is restricted to system admins only.
-- Observability view actions are audit-logged.
+- No forbidden fields stored in `telemetry_log_events`, `telemetry_trace_index`, or `telemetry_metric_samples`.
+- No PII, user IDs, IPs, message content, or credentials in any native telemetry table.
+- Access is restricted to system admins only (403 for all other roles).
+- Observability view actions are audit-logged as `admin.observability.view`.
+- WebSocket push events sent only to authenticated system admin connections.
 
 ### Performance
 
-- Summary endpoints p95 <= 200ms under expected load.
-- Trend endpoint p95 <= 500ms for 30-day range.
+- Summary endpoint p95 <= 50ms under expected load.
+- Trends endpoint p95 <= 200ms (24h range), <= 500ms (30d range).
+- Top offenders endpoint p95 <= 200ms.
+- Voice summary endpoint p95 <= 100ms.
+- Infrastructure endpoint p95 <= 100ms.
+- Logs/traces list endpoints p95 <= 200ms.
+- Export endpoint p95 <= 5s (streaming).
 - Polling does not regress server CPU/memory targets.
+- Ingestion jobs are async and do not block hot path.
 
 ### Operability
 
-- Retention purge/downsample jobs run successfully.
-- Data freshness indicators remain accurate.
+- Retention purge and rollup refresh jobs run successfully every hour.
+- Data freshness indicators remain accurate; stale detection triggers at 2x expected interval.
+- "Collecting data..." placeholder appears for first 60s after server start.
+- Degraded badges appear correctly when backing services are unavailable.
+- Background retention job logs execution time and rows deleted.
+
+---
 
 ## Done Criteria
 
-- Command center is available in admin panel and usable without external stack.
-- Native telemetry retention is strictly capped at 30 days.
-- External deep links work when configured.
-- CI/governance checks enforce retention and redaction constraints.
-- Documentation updated (roadmap, runbook, contract references).
+- [ ] All system admins can open cluster-wide command center and see current health signals within 5 seconds.
+- [ ] Health overview answers "is something wrong?" with service matrix, vital signs, and live error feed.
+- [ ] Golden signals are organized as Latency/Traffic/Errors/Saturation with time-series charts.
+- [ ] Voice operations tab shows session quality, join success, packet loss, jitter trends.
+- [ ] Infrastructure tab shows DB pool, Valkey, S3, OTel pipeline health.
+- [ ] Logs are WARN/ERROR only, filterable, with trace ID correlation.
+- [ ] Trace index is searchable with "Open in Tempo" when external stack configured.
+- [ ] Native data never exceeds 30-day retention.
+- [ ] Status thresholds are color-coded (green/yellow/red) with configurable values.
+- [ ] Real-time updates via WebSocket for health transitions and vital signs.
+- [ ] Export to CSV/JSON works for logs, traces, and metrics views.
+- [ ] Degraded mode works without external stack.
+- [ ] No forbidden fields leak into persisted native telemetry.
+- [ ] All metrics map to observability contract definitions.
+- [ ] chart.js + solid-chartjs installed and MIT license verified.
+- [ ] CI/governance checks enforce retention and redaction constraints.
+- [ ] Documentation updated (roadmap, runbook, contract references).
+
+---
 
 ## Risk Register
 
 1. **Cardinality growth risk**
-   - Mitigation: strict label allowlist, bounded dimensions, query limits.
+   - Mitigation: strict label allowlist, max 100 unique label combinations per metric, bounded query limits.
 
 2. **Storage growth risk**
-   - Mitigation: 30-day hard TTL, downsampling, daily size checks.
+   - Mitigation: 30-day hard TTL, hourly retention job, estimated ~500MB/month at moderate load (1000 DAU) per Design §14.
 
 3. **Scope creep into full observability platform**
-   - Mitigation: enforce non-goals; route deep analysis to external stack.
+   - Mitigation: enforce non-goals; route deep forensics to external stack; v1.1 features gated behind config flags.
 
 4. **Dependency drift to stale tooling**
-   - Mitigation: maintenance policy gate and pinned versions.
+   - Mitigation: maintenance policy gate, pinned versions, chart.js chosen for active maintenance (60K+ stars, MIT).
+
+5. **WebSocket protocol change coordination**
+   - Mitigation: new `admin.observability.*` event types are additive; coordinate with any in-flight WS work; protocol changes are BREAKING per project conventions.
+
+6. **TimescaleDB availability**
+   - Mitigation: graceful fallback to standard PostgreSQL with scheduled DELETE; hypertable creation wrapped in conditional migration.

--- a/docs/plans/2026-02-27-phase-7-admin-command-center-task-plan.md
+++ b/docs/plans/2026-02-27-phase-7-admin-command-center-task-plan.md
@@ -1,4 +1,4 @@
-# Phase 7 Admin Command Center - Task-by-Task Plan
+# Phase 7 Admin Command Center — Task Plan
 
 **Date:** 2026-02-27
 **Status:** Not Started
@@ -9,7 +9,7 @@
 
 ## Objective
 
-Deliver a cluster-wide native Command Center for system admins with strict 30-day telemetry retention, while delegating deep forensic analysis to external Grafana/Tempo/Loki/Prometheus when configured.
+Deliver a cluster-wide native Command Center for system admins organized around the Four Golden Signals framework, with strict 30-day telemetry retention, real-time WebSocket push, voice operations monitoring, infrastructure health, and incident correlation. Deep forensic analysis delegates to external Grafana/Tempo/Loki/Prometheus when configured.
 
 ## Delivery Constraints
 
@@ -19,168 +19,548 @@ Deliver a cluster-wide native Command Center for system admins with strict 30-da
 - Preserve OTel standards and current observability contract.
 - No full in-app trace waterfall or advanced log query DSL in v1.
 
+---
+
 ## Task Breakdown (Atomic)
 
-### Phase 0 - Project Guardrails
+### Phase 0 — Project Guardrails
 
-1. [ ] **Confirm contract and roadmap alignment** (0.5d)
-   - Files:
-     - `docs/ops/observability-contract.md`
-     - `docs/project/roadmap.md`
-   - Done when: retention/access/scope decisions are explicitly represented and consistent.
+- [ ] **T-01: Confirm contract and roadmap alignment** (0.5d)
+  - Files:
+    - `docs/ops/observability-contract.md`
+    - `docs/project/roadmap.md`
+    - `docs/plans/2026-02-27-phase-7-admin-command-center-design.md`
+  - Done when: all metric names, label allowlists, redaction rules, and retention/access/scope decisions in the design doc are explicitly cross-referenced against the observability contract with no conflicts.
 
-2. [ ] **Define dependency policy checklist in docs** (0.5d)
-   - Files:
-     - `docs/plans/2026-02-27-phase-7-admin-command-center-implementation.md`
-   - Done when: maintenance/licensing/version policy is enforceable and reviewable.
+- [ ] **T-02: Define dependency policy checklist** (0.5d)
+  - Files:
+    - `docs/plans/2026-02-27-phase-7-admin-command-center-implementation.md`
+    - `Cargo.toml` (workspace)
+    - `client/package.json`
+  - Done when: maintenance, licensing, and version policy for all new dependencies (chart.js, solid-chartjs, sysinfo or proc-based memory crate) is documented and enforceable via `cargo deny`.
 
-### Phase 1 - Data Foundation
+**Phase 0 subtotal: ~1.0d**
 
-3. [ ] **Create native telemetry schema migration** (1.0d)
-   - Files:
-     - `server/migrations/<new>_command_center_telemetry.sql`
-   - Includes:
-     - `telemetry_metric_samples`
-     - `telemetry_log_events`
-     - `telemetry_trace_index`
-   - Done when: schema applies cleanly and supports target query patterns.
+---
 
-4. [ ] **Add retention + downsampling policies** (0.75d)
-   - Files:
-     - `server/migrations/<new>_command_center_retention.sql`
-   - Done when:
-     - hard delete beyond 30 days
-     - downsampling policy after day 7 for metrics
+### Phase 1 — Data Foundation
 
-5. [ ] **Add storage/query module** (1.0d)
-   - Files:
-     - `server/src/observability/storage.rs` (new)
-     - `server/src/observability/mod.rs`
-   - Done when: bounded read/write helpers exist for summary, trends, logs, trace index.
+- [ ] **T-03: Create native telemetry schema migration** (1.0d)
+  - Files:
+    - `server/migrations/<timestamp>_command_center_telemetry.sql`
+  - Includes:
+    - `telemetry_metric_samples` hypertable (ts, metric_name, scope, labels JSONB, value_count, value_sum, value_p50, value_p95, value_p99)
+    - `telemetry_log_events` table (id, ts, level, service, domain, event, message, trace_id, span_id, attrs JSONB)
+    - `telemetry_trace_index` table (trace_id, span_name, domain, route, status_code, duration_ms, ts, service)
+    - All indexes per design Section 11
+  - Done when: migration applies cleanly on both TimescaleDB and plain PostgreSQL 16, and all indexes exist.
 
-### Phase 2 - Ingestion and Safety
+- [ ] **T-04: Create `telemetry_trend_rollups` materialized view** (0.5d)
+  - Files:
+    - `server/migrations/<timestamp>_command_center_rollups.sql`
+  - Includes:
+    - Materialized view aggregating daily rollups (day, metric_name, scope, route, sample_count, avg_p95, max_p95, total_count, error_count)
+    - Unique index `idx_ttr_day_metric` on (day, metric_name, scope, route)
+  - Done when: view creates without error, `REFRESH MATERIALIZED VIEW CONCURRENTLY` succeeds, and a 7d/30d trend query returns in < 500ms on test data.
 
-6. [ ] **Wire native log ingestion with redaction** (1.0d)
-   - Files:
-     - `server/src/observability/tracing.rs`
-   - Done when: persisted log events are allowlisted and sanitized.
+- [ ] **T-05: Add retention and downsampling background job** (1.0d)
+  - Files:
+    - `server/src/observability/retention.rs` (new)
+    - `server/src/observability/mod.rs`
+  - Includes:
+    - Hourly job: hard-delete rows older than 30 days from all three tables
+    - Hourly job: `REFRESH MATERIALIZED VIEW CONCURRENTLY telemetry_trend_rollups`
+    - TimescaleDB `drop_chunks` path with plain-PostgreSQL `DELETE` fallback
+    - Logs execution time and rows deleted to tracing output
+  - Done when: job runs on schedule, deletes correct rows, and completes in < 10s on test data.
 
-7. [ ] **Wire native trace index ingestion** (0.75d)
-   - Files:
-     - `server/src/observability/tracing.rs`
-     - `server/src/observability/storage.rs`
-   - Done when: failed/slow trace metadata is persisted without payload content.
+- [ ] **T-06: Add storage/query module** (1.0d)
+  - Files:
+    - `server/src/observability/storage.rs` (new)
+    - `server/src/observability/mod.rs`
+  - Includes:
+    - Write helpers: `insert_metric_sample`, `insert_log_event`, `insert_trace_span`
+    - Read helpers: `query_summary`, `query_trends`, `query_top_routes`, `query_top_errors`, `query_logs`, `query_traces`
+    - Live query path (ranges <= 24h) vs. materialized view path (7d/30d)
+    - All queries bounded by max page size and required time filters
+  - Done when: all helpers compile, have unit tests with in-memory or test-DB fixtures, and meet response time targets from design Section 16.
 
-8. [ ] **Wire metric sample ingestion and label guardrails** (1.0d)
-   - Files:
-     - `server/src/observability/metrics.rs`
-     - `server/src/observability/storage.rs`
-   - Done when: only allowlisted dimensions are persisted and high-cardinality labels are dropped/rejected.
+- [ ] **T-07: Add `kaiku_process_memory_bytes` metric collection** (0.5d)
+  - Files:
+    - `server/src/observability/metrics.rs`
+    - `Cargo.toml` (add `sysinfo` or read `/proc/self/statm` directly)
+  - Includes:
+    - RSS memory gauge sampled every 60s
+    - Metric name `kaiku_process_memory_bytes` per observability contract
+    - Threshold color logic: < 70% of configured limit = green, 70-90% = yellow, > 90% = red
+  - Done when: metric appears in metric samples table and threshold status is computed correctly.
 
-9. [ ] **Add observability access audit events** (0.5d)
-   - Files:
-     - `server/src/admin/handlers.rs`
-     - `server/src/permissions/queries.rs`
-   - Done when: command center data access emits `admin.observability.view` style audit events.
+**Phase 1 subtotal: ~4.0d**
 
-### Phase 3 - Admin API Surface
+---
 
-10. [ ] **Add summary/trends endpoints** (1.0d)
-    - Files:
-      - `server/src/admin/mod.rs`
-      - `server/src/admin/handlers.rs`
-      - `server/src/admin/types.rs`
-    - Endpoints:
-      - `GET /api/admin/observability/summary`
-      - `GET /api/admin/observability/trends`
+### Phase 2 — Ingestion and Safety
 
-11. [ ] **Add top-offenders endpoints** (0.75d)
-    - Endpoints:
-      - `GET /api/admin/observability/top-routes`
-      - `GET /api/admin/observability/top-errors`
+- [ ] **T-08: Wire native log ingestion with redaction** (1.0d)
+  - Files:
+    - `server/src/observability/tracing.rs`
+    - `server/src/observability/storage.rs`
+  - Includes:
+    - Tracing subscriber layer that captures WARN/ERROR events
+    - Applies all redaction rules from observability contract Section 9 before storage
+    - Persists only allowlisted `attrs` fields
+    - INFO logs are explicitly dropped (not stored)
+  - Done when: WARN/ERROR events appear in `telemetry_log_events`, INFO events do not, and no forbidden fields appear in `attrs`.
 
-12. [ ] **Add logs/trace-index list endpoints** (1.0d)
-    - Endpoints:
-      - `GET /api/admin/observability/logs`
-      - `GET /api/admin/observability/traces`
-    - Done when: pagination and filters are bounded and stable.
+- [ ] **T-09: Wire native trace index ingestion** (0.75d)
+  - Files:
+    - `server/src/observability/tracing.rs`
+    - `server/src/observability/storage.rs`
+  - Includes:
+    - Span completion hook that writes to `telemetry_trace_index`
+    - Stores only metadata (trace_id, span_name, domain, route, status_code, duration_ms, ts, service)
+    - No span payload, attributes, or events stored
+  - Done when: failed and slow spans appear in trace index without any payload content.
 
-13. [ ] **Add external links endpoint** (0.5d)
-    - Endpoint:
-      - `GET /api/admin/observability/links`
-    - Done when: links are returned only when configured.
+- [ ] **T-10: Wire metric sample ingestion with label guardrails** (1.0d)
+  - Files:
+    - `server/src/observability/metrics.rs`
+    - `server/src/observability/storage.rs`
+  - Includes:
+    - Async task that aggregates in-memory metric state every 60s and inserts rows
+    - Label allowlist enforcement: only contract Section 6 labels stored in `labels` JSONB
+    - Cardinality budget: max 100 unique label combinations per metric; excess logged as warnings
+    - Route label normalization: parameterised templates only (e.g., `/api/v1/guilds/{guild_id}`)
+    - Pre-computes p50/p95/p99 from OTel histogram data points at ingestion
+  - Done when: only allowlisted labels persist, high-cardinality combinations are dropped with a warning log, and percentiles are correct.
 
-### Phase 4 - Admin UI Integration
+- [ ] **T-11: Add voice health score computation** (0.75d)
+  - Files:
+    - `server/src/observability/voice.rs` (new)
+    - `server/src/observability/mod.rs`
+  - Includes:
+    - Composite score (0-100): join success rate 40%, packet loss p95 30%, jitter p95 20%, session crash rate 10%
+    - Reads from `connection_metrics` and `connection_sessions` TimescaleDB hypertables
+    - Cached in memory, refreshed every 10s
+  - Done when: score is computed correctly from test data and updates on schedule.
 
-14. [ ] **Add command-center panel routing + sidebar entry** (0.5d)
-    - Files:
-      - `client/src/components/admin/AdminSidebar.tsx`
-      - `client/src/views/AdminDashboard.tsx`
+- [ ] **T-12: Add observability access audit events** (0.5d)
+  - Files:
+    - `server/src/admin/handlers.rs`
+    - `server/src/observability/mod.rs`
+  - Includes:
+    - `admin.observability.view` audit event emitted on each command center endpoint access
+    - Records admin user ID, endpoint, and timestamp
+  - Done when: audit events appear in the audit log for every observability endpoint call.
 
-15. [ ] **Create `CommandCenterPanel` UI skeleton** (1.0d)
-    - Files:
-      - `client/src/components/admin/CommandCenterPanel.tsx` (new)
-      - `client/src/components/admin/index.ts`
+**Phase 2 subtotal: ~4.0d**
 
-16. [ ] **Implement admin store slice + API bindings** (1.5d)
-    - Files:
-      - `client/src/stores/admin.ts`
-      - `client/src/lib/tauri.ts`
+---
 
-17. [ ] **Implement health cards + trends charts** (1.0d)
-    - Done when: top-level operational status is visible and refreshes predictably.
+### Phase 3 — Admin API Surface
 
-18. [ ] **Implement top-offenders/logs/trace-index tables** (1.0d)
-    - Done when: filtering, pagination, and empty states are usable.
+- [ ] **T-13: Add summary endpoint** (0.75d)
+  - Files:
+    - `server/src/admin/observability.rs` (new)
+    - `server/src/admin/mod.rs`
+    - `server/src/admin/types.rs`
+  - Endpoint: `GET /api/admin/observability/summary`
+  - Returns: vital signs (4 golden signal values), service health matrix (7 services), server metadata (version, uptime, environment, active users, guild count), active alert count
+  - Done when: response time < 50ms, all 7 services represented, and `SystemAdminUser` middleware enforced.
 
-19. [ ] **Implement degraded mode + freshness indicators** (0.75d)
-    - Done when: each section clearly indicates stale/unavailable data without breaking UI.
+- [ ] **T-14: Add trends endpoint** (1.0d)
+  - Files:
+    - `server/src/admin/observability.rs`
+    - `server/src/admin/types.rs`
+  - Endpoint: `GET /api/admin/observability/trends?range=1h|6h|24h|7d|30d&metric=<name>`
+  - Returns: time-series data points for requested metric(s)
+  - Routes to live query (ranges <= 24h) or materialized view (7d/30d)
+  - Done when: response time < 200ms for 24h, < 500ms for 30d, and invalid metric names return 400.
 
-20. [ ] **Add deep-link actions to external stack** (0.5d)
-    - Done when: relevant rows/cards can open Grafana/Tempo/Loki/Prometheus links when configured.
+- [ ] **T-15: Add top-offenders endpoints** (0.75d)
+  - Files:
+    - `server/src/admin/observability.rs`
+  - Endpoints:
+    - `GET /api/admin/observability/top-routes?range=...&sort=latency|errors&limit=10`
+    - `GET /api/admin/observability/top-errors?range=...&limit=10`
+  - Returns: ranked lists with route, count, p95, error rate
+  - Done when: both endpoints return correct rankings and respect the `limit` bound.
 
-### Phase 5 - Tests and Governance
+- [ ] **T-16: Add voice summary and quality endpoints** (1.0d)
+  - Files:
+    - `server/src/admin/observability.rs`
+    - `server/src/observability/voice.rs`
+  - Endpoints:
+    - `GET /api/admin/observability/voice/summary` — active sessions, rooms, join success rate, voice health score
+    - `GET /api/admin/observability/voice/quality?range=...` — packet loss, jitter, latency time-series from TimescaleDB `connection_metrics`
+  - Done when: summary response time < 100ms, quality time-series returns p50/p95 for all three signals, and empty state handled when no voice data exists.
 
-21. [ ] **Backend integration tests for auth, bounds, retention** (1.5d)
-    - Files:
-      - `server/tests/*observability*`
+- [ ] **T-17: Add infrastructure health endpoint** (0.75d)
+  - Files:
+    - `server/src/admin/observability.rs`
+  - Endpoint: `GET /api/admin/observability/infrastructure`
+  - Returns: health status for DB (pool active/idle/max, query p95, connectivity), Valkey (PING), S3 (bucket access), OTel pipeline (export failure rate, dropped spans)
+  - Done when: response time < 100ms, all four services represented, and graceful degradation when S3 is not configured.
 
-22. [ ] **Frontend tests for panel state and data rendering** (1.0d)
-    - Files:
-      - `client/src/components/admin/*.test.tsx`
+- [ ] **T-18: Add logs and trace-index list endpoints** (1.0d)
+  - Files:
+    - `server/src/admin/observability.rs`
+  - Endpoints:
+    - `GET /api/admin/observability/logs?level=&domain=&service=&from=&to=&search=&cursor=&limit=`
+    - `GET /api/admin/observability/traces?status=&domain=&route=&duration_min=&from=&to=&cursor=&limit=`
+  - Cursor-based pagination, max 100 per page, required time filters
+  - Done when: filters work correctly, cursor pagination is stable, and response time < 200ms.
 
-23. [ ] **E2E smoke coverage for command center access** (0.75d)
-    - Files:
-      - `client/e2e/*admin*.spec.ts`
+- [ ] **T-19: Add export endpoint** (1.0d)
+  - Files:
+    - `server/src/admin/observability.rs`
+  - Endpoint: `GET /api/admin/observability/export?type=logs|traces|metrics&format=csv|json&...filters`
+  - Streamed response, max 10,000 rows per export
+  - Done when: CSV and JSON formats both work, streaming starts within 1s, and row limit is enforced.
 
-24. [ ] **CI/governance checks for retention and forbidden fields** (0.75d)
-    - Files:
-      - `.github/workflows/ci.yml`
-      - `scripts/check_docs_governance.py`
+- [ ] **T-20: Add config and external links endpoints** (0.5d)
+  - Files:
+    - `server/src/admin/observability.rs`
+  - Endpoints:
+    - `GET /api/admin/observability/config` — threshold values, refresh cadences, feature flags
+    - `GET /api/admin/observability/links` — configured external tool URLs (Grafana, Tempo, Loki, Prometheus)
+  - Done when: config returns all `COMMAND_CENTER_*` threshold env vars with defaults, and links returns empty object when not configured.
+
+**Phase 3 subtotal: ~6.75d**
+
+---
+
+### Phase 4 — WebSocket Push Events
+
+- [ ] **T-21: Add `admin.observability.*` WebSocket event types** (1.0d)
+  - Files:
+    - `shared/vc-common/src/protocol/server_events.rs`
+    - `shared/vc-common/src/lib.rs`
+  - Includes four new event variants:
+    - `admin.observability.health_change` — `{ service, old_status, new_status }`
+    - `admin.observability.error_event` — `{ ts, service, domain, event, message, trace_id }`
+    - `admin.observability.vital_signs` — `{ latency_p95, traffic_rate, error_rate, saturation_pct }`
+    - `admin.observability.voice_pulse` — `{ active_sessions, active_rooms, join_success_rate_1h }`
+  - Done when: all four variants compile, are serializable, and are documented as breaking protocol additions.
+
+- [ ] **T-22: Add server-side WS push dispatcher** (1.0d)
+  - Files:
+    - `server/src/ws/admin_push.rs` (new)
+    - `server/src/ws/mod.rs`
+    - `server/src/observability/mod.rs`
+  - Includes:
+    - Subscription tracking: events sent only to authenticated system admin connections with command center active
+    - `health_change` triggered on service state transitions
+    - `error_event` triggered on new ERROR log ingestion
+    - `vital_signs` pushed every 5s while any admin has command center open
+    - `voice_pulse` pushed every 5s while any admin has voice tab open
+  - Done when: events reach only admin connections, non-admin connections receive nothing, and push cadence matches design Section 9.1.
+
+**Phase 4 subtotal: ~2.0d**
+
+---
+
+### Phase 5 — Client Admin Panel
+
+- [ ] **T-23: Install chart library** (0.5d)
+  - Files:
+    - `client/package.json`
+    - `client/src/lib/charts.ts` (new — thin wrapper/re-export)
+  - Installs: `chart.js` + `solid-chartjs` (MIT licensed)
+  - Done when: `cargo deny check licenses` passes, `bun run build` succeeds, and a minimal line chart renders in a test component.
+
+- [ ] **T-24: Add command-center panel routing and sidebar entry** (0.5d)
+  - Files:
+    - `client/src/components/admin/AdminSidebar.tsx`
+    - `client/src/views/AdminDashboard.tsx`
+  - Done when: "Command Center" entry appears in admin sidebar, clicking it renders the panel, and tab state persists across panel switches.
+
+- [ ] **T-25: Create `CommandCenterPanel` skeleton with layout** (1.0d)
+  - Files:
+    - `client/src/components/admin/CommandCenterPanel.tsx` (new)
+    - `client/src/components/admin/index.ts`
+  - Implements the wireframe from design Section 7:
+    - Top row: four vital-sign cards (always visible)
+    - Middle row: service health matrix + live error feed (2-column)
+    - Tab bar: Golden Signals / Voice / Infrastructure / Logs / Traces
+    - "Collecting data..." placeholder for first 60s after server start
+  - Done when: layout matches wireframe, tab switching works, and responsive behavior handles tablet width (768-1200px).
+
+- [ ] **T-26: Implement time range picker component** (0.75d)
+  - Files:
+    - `client/src/components/admin/TimeRangePicker.tsx` (new)
+  - Includes:
+    - Presets: 1h / 6h / 24h / 7d / 30d (default: 24h)
+    - Auto-refresh toggle with cadence indicator ("Refreshing every 10s")
+    - Applies to all trend charts and tables in the active tab
+  - Done when: selecting a preset updates all charts, auto-refresh fires on schedule, and selected range persists when switching tabs.
+
+- [ ] **T-27: Implement admin store slice and API bindings** (1.5d)
+  - Files:
+    - `client/src/stores/admin.ts`
+    - `client/src/lib/tauri.ts`
+  - Includes:
+    - `createStore` slice for command center state (summary, trends, voice, infra, logs, traces)
+    - Fetch functions for all 10 observability endpoints
+    - WS event handlers for all four `admin.observability.*` event types
+    - Polling timers per design Section 9.2 cadences (10s/15s/30s by data type)
+    - Freshness tracking: last-updated timestamp per section
+  - Done when: store updates correctly from both polling and WS push, and stale detection triggers at 2x expected interval.
+
+- [ ] **T-28: Implement vital-sign cards with sparklines** (1.0d)
+  - Files:
+    - `client/src/components/admin/VitalSignCard.tsx` (new)
+  - Includes:
+    - Four cards: Latency (p95), Traffic (req/s), Errors (rate), Saturation (max %)
+    - Sparkline trend (1h) using chart.js
+    - Threshold color coding (green/yellow/red) from config endpoint
+    - Updates via `admin.observability.vital_signs` WS push
+  - Done when: all four cards render with correct values, sparklines animate on update, and threshold colors match config.
+
+- [ ] **T-29: Implement service health matrix** (0.75d)
+  - Files:
+    - `client/src/components/admin/ServiceHealthMatrix.tsx` (new)
+  - Includes:
+    - All 7 services: HTTP API, WebSocket Hub, Voice SFU, PostgreSQL, Valkey, S3, OTel Pipeline
+    - Status dot: healthy (green) / degraded (yellow) / down (red) / unavailable (gray)
+    - Updates via `admin.observability.health_change` WS push
+  - Done when: all 7 services shown, status transitions animate, and S3 shows "unavailable" (not "down") when not configured.
+
+- [ ] **T-30: Implement live error feed component** (1.0d)
+  - Files:
+    - `client/src/components/admin/LiveErrorFeed.tsx` (new)
+  - Includes:
+    - Scrolling list of last 25 errors (cross-service)
+    - Fields: timestamp, service, domain, event name, message (truncated), trace_id link
+    - Auto-scrolls on new entries via `admin.observability.error_event` WS push
+    - Click to expand full error context
+    - "View all logs" link navigates to Logs tab
+  - Done when: feed auto-scrolls on new WS events, click-through to Logs tab works with trace_id filter pre-applied, and list caps at 25 entries.
+
+- [ ] **T-31: Implement Golden Signals tab (charts and tables)** (1.5d)
+  - Files:
+    - `client/src/components/admin/GoldenSignalsTab.tsx` (new)
+    - `client/src/components/admin/TrendChart.tsx` (new)
+  - Includes:
+    - Latency panel: p50/p95/p99 line chart, DB query latency chart, top slow routes table
+    - Traffic panel: API req rate area chart, active WS connections, active voice sessions, WS messages stacked area
+    - Errors panel: HTTP 4xx/5xx stacked area, auth failure rate, WS reconnect rate, voice join failure rate, OTel export failures
+    - Saturation panel: DB pool gauge + time-series, OTel dropped spans counter, process memory RSS time-series
+    - All charts respect time range picker selection
+    - Top offenders tables (top 10 routes by p95, top 10 by error count)
+  - Done when: all four signal panels render with correct chart types, tables sort correctly, and charts update when time range changes.
+
+- [ ] **T-32: Implement Voice tab** (1.5d)
+  - Files:
+    - `client/src/components/admin/VoiceTab.tsx` (new)
+  - Includes:
+    - Voice health score gauge (0-100, prominent)
+    - Active sessions + active rooms large-number cards (updated via `admin.observability.voice_pulse`)
+    - Join success rate percentage + trend chart
+    - Packet loss p50/p95 time-series line chart
+    - Network jitter p50/p95 time-series line chart
+    - Session latency p50/p95 time-series line chart
+    - Quality score distribution stacked bar chart (poor/fair/good/excellent)
+    - RTP forwarding rate area chart
+    - Session duration histogram
+  - Done when: all charts render from voice quality endpoint data, health score gauge updates every 10s, and empty state shows when no voice sessions exist.
+
+- [ ] **T-33: Implement Infrastructure tab** (1.0d)
+  - Files:
+    - `client/src/components/admin/InfrastructureTab.tsx` (new)
+  - Includes:
+    - Database section: pool active/idle/max gauge bars, query p95 sparkline, query rate time-series, top slow queries table, connectivity badge
+    - Valkey section: connectivity badge, usage info text
+    - S3 section: connectivity badge, configured/not-configured/degraded status
+    - OTel pipeline section: export success/failure rate time-series, dropped spans counter (alert if > 0), collector endpoint info, pipeline status badge
+  - Done when: all four service sections render, S3 section handles unconfigured state gracefully, and OTel dropped spans shows alert styling when count > 0.
+
+- [ ] **T-34: Implement Logs tab** (1.0d)
+  - Files:
+    - `client/src/components/admin/LogsTab.tsx` (new)
+  - Includes:
+    - Filterable log list: severity, domain, service, time range, free-text search
+    - Cursor-based pagination (max 100 per page)
+    - Trace ID column links to Traces tab with filter pre-applied
+    - Export button (CSV/JSON) for current filtered view
+    - New ERROR entries auto-appended via WS push
+  - Done when: all filters work, pagination navigates correctly, trace_id click-through pre-filters Traces tab, and export downloads a valid file.
+
+- [ ] **T-35: Implement Traces tab** (1.0d)
+  - Files:
+    - `client/src/components/admin/TracesTab.tsx` (new)
+  - Includes:
+    - Filterable trace index: status (error/slow/all), domain, route, duration threshold, time range
+    - Pre-filtered views: "Recent errors" (status >= 500), "Recent slow" (duration > p95 threshold)
+    - Cursor-based pagination (max 100 per page)
+    - "Open in Tempo" button per row (visible only when Tempo URL configured)
+    - Export button (CSV/JSON) for current filtered view
+    - Duration column color-coded by threshold
+  - Done when: pre-filtered views work, "Open in Tempo" appears only when configured, and export downloads a valid file.
+
+- [ ] **T-36: Implement incident correlation view** (1.5d)
+  - Files:
+    - `client/src/components/admin/IncidentCorrelationView.tsx` (new)
+    - `client/src/components/admin/GoldenSignalsTab.tsx`
+  - Includes:
+    - "Incident View" toggle on Golden Signals tab
+    - Shared time axis overlaying: selected metric (primary), error rate (secondary y-axis), log event markers (vertical lines at ERROR timestamps), deploy markers (dashed vertical lines, v1.1 placeholder)
+    - Click on chart point opens Logs tab with time filter for that window
+    - Click on error in live feed navigates to Logs tab filtered by trace_id
+    - Click on log entry with trace_id navigates to Traces tab filtered by trace_id
+  - Done when: incident view toggle works, all three overlays render on shared time axis, and all three click-through navigations land on the correct tab with correct filters pre-applied.
+
+- [ ] **T-37: Implement degraded mode and freshness indicators** (0.75d)
+  - Files:
+    - `client/src/components/admin/CommandCenterPanel.tsx`
+    - `client/src/components/admin/FreshnessIndicator.tsx` (new)
+  - Includes:
+    - "Last updated: Xs ago" indicator on every panel section
+    - Stale indicator turns yellow with "(stale)" suffix at 2x expected interval
+    - "Collecting data..." placeholder for first 60s after server start
+    - Degraded badges on service health matrix when external stack unavailable
+  - Done when: freshness indicators update correctly, stale state triggers at correct threshold, and degraded mode shows without breaking any panel layout.
+
+- [ ] **T-38: Add external deep-link actions** (0.5d)
+  - Files:
+    - `client/src/components/admin/TracesTab.tsx`
+    - `client/src/components/admin/LogsTab.tsx`
+    - `client/src/components/admin/CommandCenterPanel.tsx`
+  - Includes:
+    - "Open in Grafana", "Open in Tempo", "Open in Loki", "Open in Prometheus" actions
+    - Visible only when respective URL is returned by config/links endpoints
+    - Opens in system browser via Tauri shell API
+  - Done when: links appear only when configured, and clicking opens the correct external URL.
+
+**Phase 5 subtotal: ~15.25d**
+
+---
+
+### Phase 6 — Tests and Governance
+
+- [ ] **T-39: Backend integration tests (auth, bounds, retention, redaction)** (1.5d)
+  - Files:
+    - `server/tests/observability_auth.rs` (new)
+    - `server/tests/observability_bounds.rs` (new)
+    - `server/tests/observability_retention.rs` (new)
+    - `server/tests/observability_redaction.rs` (new)
+  - Covers:
+    - Non-admin requests to all observability endpoints return 403
+    - Page size bounds enforced (max 100)
+    - Time range bounds enforced (max 30d)
+    - Retention job deletes rows older than 30 days and nothing newer
+    - No forbidden fields appear in persisted `attrs` or `labels` JSONB
+    - Export row limit enforced (max 10,000)
+  - Done when: all tests pass with `SQLX_OFFLINE=true cargo test -p vc-server`.
+
+- [ ] **T-40: Backend integration tests (voice and infra endpoints)** (1.0d)
+  - Files:
+    - `server/tests/observability_voice.rs` (new)
+    - `server/tests/observability_infra.rs` (new)
+  - Covers:
+    - Voice summary returns correct health score from fixture data
+    - Voice quality endpoint returns p50/p95 for packet loss, jitter, latency
+    - Infrastructure endpoint handles S3 unconfigured state
+    - Infrastructure endpoint handles Valkey unavailable state
+  - Done when: all tests pass and edge cases (no voice data, no S3) return correct empty/degraded responses.
+
+- [ ] **T-41: Frontend component tests (panel states and data rendering)** (1.0d)
+  - Files:
+    - `client/src/components/admin/CommandCenterPanel.test.tsx` (new)
+    - `client/src/components/admin/VoiceTab.test.tsx` (new)
+    - `client/src/components/admin/LiveErrorFeed.test.tsx` (new)
+  - Covers:
+    - Panel renders "Collecting data..." on first load
+    - Vital-sign cards show correct threshold colors
+    - Service health matrix transitions on WS health_change event
+    - Live error feed appends and caps at 25 entries
+    - Voice health score gauge renders correct value
+    - Freshness indicator turns stale at 2x interval
+  - Done when: `bun run test:run` passes with no failures.
+
+- [ ] **T-42: E2E smoke test for command center access** (0.75d)
+  - Files:
+    - `client/e2e/admin_command_center.spec.ts` (new)
+  - Covers:
+    - System admin can open command center and see health data within 5s
+    - Non-admin user cannot access command center
+    - Time range picker changes chart data
+    - Tab switching works for all 5 tabs
+    - Export button downloads a file
+  - Done when: `npx playwright test` passes for all command center scenarios.
+
+- [ ] **T-43: CI governance checks** (0.75d)
+  - Files:
+    - `.github/workflows/ci.yml`
+    - `scripts/check_docs_governance.py`
+  - Includes:
+    - `cargo deny check licenses` covers new chart.js dependency (MIT confirmed)
+    - Schema conformance check: retention constants match 30-day spec
+    - Forbidden field check: no PII field names in migration SQL
+    - Design/implementation doc linkage check
+  - Done when: CI pipeline passes on a clean branch with all new code, and governance script catches a deliberate violation in a test run.
+
+**Phase 6 subtotal: ~4.0d**
+
+---
 
 ## Estimated Effort
 
-- Phase 0: ~1 day
-- Phase 1: ~2.75 days
-- Phase 2: ~3.25 days
-- Phase 3: ~3.25 days
-- Phase 4: ~6.25 days
-- Phase 5: ~4 days
+| Phase | Description | Days |
+|-------|-------------|------|
+| Phase 0 | Project Guardrails | 1.0d |
+| Phase 1 | Data Foundation | 4.0d |
+| Phase 2 | Ingestion and Safety | 4.0d |
+| Phase 3 | Admin API Surface | 6.75d |
+| Phase 4 | WebSocket Push Events | 2.0d |
+| Phase 5 | Client Admin Panel | 15.25d |
+| Phase 6 | Tests and Governance | 4.0d |
 
-**Total estimate:** ~20.5 engineer-days (single-contributor baseline)
+**Grand total: ~37.0 engineer-days (single-contributor baseline)**
+
+---
 
 ## Milestone Acceptance
 
 ### MVP Acceptance
 
-- Command center tab is available to all system admins.
-- Summary + trends + top-offenders + logs + trace-index panels functional.
-- Native data never exceeds 30-day retention.
-- External deep links render only when configured.
-- Redaction and allowlist constraints verified by tests.
+- [ ] Command center tab is available to all system admins.
+- [ ] Health overview (vital signs, service matrix, live error feed) answers "is something wrong?" within 5 seconds.
+- [ ] Golden Signals tab shows Latency/Traffic/Errors/Saturation with time-series charts.
+- [ ] Voice tab shows session quality, join success rate, packet loss, jitter, and health score.
+- [ ] Infrastructure tab shows DB pool, Valkey, S3, and OTel pipeline health.
+- [ ] Logs tab is WARN/ERROR only, filterable, with trace ID correlation.
+- [ ] Traces tab is searchable with "Open in Tempo" when external stack configured.
+- [ ] Native data never exceeds 30-day retention.
+- [ ] Status thresholds are color-coded (green/yellow/red) with configurable values.
+- [ ] External deep links render only when configured.
+- [ ] Redaction and allowlist constraints verified by tests.
 
 ### Release Acceptance
 
-- CI checks pass for schema, retention, redaction, and docs linkage.
-- Observability runbook has command center operational guidance.
-- No dependency policy violations (license/maintenance/deprecation checks).
+- [ ] Real-time updates via WebSocket for health transitions, vital signs, error feed, and voice pulse.
+- [ ] Export to CSV/JSON works for logs, traces, and metrics views.
+- [ ] Incident correlation view (shared time axis, click-through) is functional.
+- [ ] Time range picker applies to all charts and tables.
+- [ ] Degraded mode works without external stack.
+- [ ] Freshness indicators show stale state correctly.
+- [ ] CI checks pass for schema, retention, redaction, and docs linkage.
+- [ ] Observability runbook has command center operational guidance.
+- [ ] No dependency policy violations (license/maintenance/deprecation checks).
+- [ ] No forbidden fields leak into persisted native telemetry.
+- [ ] All metrics map to observability contract definitions.
+
+---
+
+## Future Tasks (v1.1)
+
+The following are explicitly out of scope for v1 and should not be started until the release milestone is accepted:
+
+- **Client telemetry ingestion** (Tier 7): Tauri command latency, WebRTC connect time, client-side errors. Requires new `/api/telemetry/client-metrics` endpoint with rate limiting.
+- **Deploy markers on charts**: Audit log `admin.deploy.detected` events as vertical markers on time-series charts.
+- **Redis INFO stats**: Memory, hit rate, connected clients from `REDIS INFO` command.
+- **Rolling anomaly detection**: 7-day deviation baselines for automatic degraded state detection.
+- **S3 throughput metrics**: Upload/download throughput requires new instrumentation.
+- **Client WebRTC metrics on charts**: `kaiku_client_voice_webrtc_connect_duration_seconds` and `kaiku_client_voice_webrtc_failures_total` (depend on client telemetry pipeline).
+- **Per-role observability segmentation**: v1 is cluster-wide for all system admins.
+- **Alert-rule authoring UI**: v1 uses static configurable thresholds only.


### PR DESCRIPTION
## Summary

Full rewrite of the Admin Command Center planning documents (design, implementation, task plan) to v2 with 12 major improvements based on codebase signal inventory, observability contract alignment, and industry research (GitLab, Mattermost, Zulip, Sentry, Google SRE).

## Key Improvements

- **Golden Signals framework** — all signals organized as Latency/Traffic/Errors/Saturation per SRE book
- **Observability contract alignment** — every dashboard metric maps to a specific `kaiku_*` contract metric
- **Voice Operations tier** — 10 signals + composite voice health score, leveraging existing TimescaleDB data
- **Infrastructure Health tier** — DB pool, Valkey, S3, OTel pipeline as first-class signals
- **Real-time WebSocket push** — 4 new `admin.observability.*` event types for live updates
- **Status thresholds** — green/yellow/red with configurable env-var overrides
- **Incident correlation** — shared time axis, click-through from error → log → trace → Tempo
- **Layout wireframe** — ASCII wireframe, above-the-fold strategy, responsive spec
- **Live error feed** — scrolling unified error stream (Zulip `errors.log` pattern)
- **Resolved open questions** — INFO logs: no, aggregation: hybrid materialized views, export: yes
- **Data model alignment** — pre-computed percentiles, materialized view for trends, storage budget estimates
- **Chart library decision** — chart.js + solid-chartjs recommended

## Document Changes

| Document | v1 | v2 |
|---|---|---|
| Design | 236 lines | 806 lines |
| Implementation | 254 lines | 596 lines |
| Task Plan | 186 lines (24 tasks, 20.5d) | 566 lines (43 tasks, 37.0d) |

## Docs-only change — no code changes.