### PR TITLE
fix(client): make browser mode work over HTTPS with Vite proxy

### DIFF
--- a/client/src/components/SetupWizard.tsx
+++ b/client/src/components/SetupWizard.tsx
@@ -32,9 +32,9 @@ function getServerUrl(): string {
     return authState.serverUrl;
   }
   if (typeof localStorage !== "undefined") {
-    return localStorage.getItem("serverUrl") || "http://localhost:8080";
+    return localStorage.getItem("serverUrl") || window.location.origin;
   }
-  return "http://localhost:8080";
+  return window.location.origin;
 }
 
 // Fetch setup config from server

--- a/client/src/lib/tauri.ts
+++ b/client/src/lib/tauri.ts
@@ -334,7 +334,7 @@ export function validateFileSize(file: File, type: UploadType): string | null {
 
 // Browser state (when not in Tauri)
 const browserState = {
-  serverUrl: "http://localhost:8080",
+  serverUrl: typeof window !== "undefined" ? window.location.origin : "",
   accessToken: null as string | null,
   refreshToken: null as string | null,
   tokenExpiresAt: null as number | null,
@@ -912,7 +912,7 @@ async function getUploadAuth(): Promise<{
   }
   return {
     token: browserState.accessToken || localStorage.getItem("accessToken"),
-    baseUrl: (browserState.serverUrl || "http://localhost:8080").replace(
+    baseUrl: (browserState.serverUrl || window.location.origin).replace(
       /\/+$/,
       "",
     ),

--- a/client/src/stores/auth.ts
+++ b/client/src/stores/auth.ts
@@ -151,6 +151,7 @@ export async function login(
       user: result.user,
       serverUrl,
       isLoading: false,
+      isInitialized: true,
       error: null,
       setupRequired: result.setup_required,
       mfaRequired: false,
@@ -231,6 +232,7 @@ export async function register(
       user: result.user,
       serverUrl,
       isLoading: false,
+      isInitialized: true,
       error: null,
       setupRequired: result.setup_required,
     });
@@ -296,6 +298,7 @@ export async function loginWithOidc(
       user,
       serverUrl,
       isLoading: false,
+      isInitialized: true,
       error: null,
       setupRequired,
     });

--- a/client/src/views/Login.tsx
+++ b/client/src/views/Login.tsx
@@ -26,7 +26,7 @@ function providerIcon(hint: string | null) {
 
 const Login: Component = () => {
   const navigate = useNavigate();
-  const defaultServerUrl = import.meta.env.VITE_SERVER_URL || "";
+  const defaultServerUrl = import.meta.env.VITE_SERVER_URL || window.location.origin;
   const [serverUrl, setServerUrl] = createSignal(defaultServerUrl);
   const [username, setUsername] = createSignal("");
   const [password, setPassword] = createSignal("");

--- a/client/src/views/Register.tsx
+++ b/client/src/views/Register.tsx
@@ -20,7 +20,7 @@ function providerIcon(hint: string | null) {
 
 const Register: Component = () => {
   const navigate = useNavigate();
-  const defaultServerUrl = import.meta.env.VITE_SERVER_URL || "";
+  const defaultServerUrl = import.meta.env.VITE_SERVER_URL || window.location.origin;
   const [serverUrl, setServerUrl] = createSignal(defaultServerUrl);
   const [username, setUsername] = createSignal("");
   const [email, setEmail] = createSignal("");

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -35,6 +35,10 @@ export default defineConfig({
         target: "http://localhost:8080",
         changeOrigin: true,
       },
+      "/ws": {
+        target: "ws://localhost:8080",
+        ws: true,
+      },
     },
   },
   build: {


### PR DESCRIPTION
## Summary

- **Mixed content blocked**: `browserState.serverUrl` defaulted to `http://localhost:8080`, bypassing the Vite HTTPS proxy. All API calls now use `window.location.origin` so requests stay on the same origin and route through the proxy
- **Server URL field**: Login/Register/SetupWizard now pre-fill with `window.location.origin` instead of empty string or hardcoded HTTP URL
- **Login loop**: `auth.ts` login/register/OIDC flows now set `isInitialized: true`, preventing `AuthGuard` from re-running `initAuth()` after navigate and kicking the user back to `/login`
- **WebSocket proxy**: Added `/ws` proxy rule (`ws: true`) so `wss://localhost:5173/ws` routes through to `ws://localhost:8080`

## Test plan

- [ ] Login works from `https://localhost:5173`
- [ ] Login works from LAN device at `https://<ip>:5173`
- [ ] No mixed content errors in browser console
- [ ] WebSocket connects after login (real-time messages/presence work)
- [ ] Registration works for new accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)