### PR TITLE
fix(presence): add SetStatus WebSocket event for user status changes

### DIFF
--- a/client/src/lib/tauri.ts
+++ b/client/src/lib/tauri.ts
@@ -633,7 +633,17 @@ export async function updateStatus(
     return invoke("update_status", { status });
   }
 
-  await httpRequest<void>("POST", "/api/presence/status", { status });
+  // Map client status names to server enum values
+  const statusMap: Record<string, string> = {
+    online: "online",
+    idle: "away",
+    dnd: "busy",
+    invisible: "offline",
+    offline: "offline",
+  };
+  browserWs?.send(
+    JSON.stringify({ type: "set_status", status: statusMap[status] ?? "online" }),
+  );
 }
 
 export async function register(


### PR DESCRIPTION
## Summary

- `POST /api/presence/status` didn't exist — status was only updated automatically on WS connect/disconnect, causing 404 errors when the client tried to change status
- Added `SetStatus { status: UserStatus }` variant to the server's `ClientEvent` WebSocket enum, with a handler that updates the DB and broadcasts `PresenceUpdate` to presence subscribers
- Changed the client's `updateStatus()` from a failing HTTP call to a WebSocket message (`type: "set_status"`), mapping UI status labels to server enum values (`idle→away`, `dnd→busy`, `invisible→offline`)

## Test plan

- [ ] Log in and observe no 404 errors in the browser console for presence/status
- [ ] Change status in the UI (online/idle/dnd/invisible) and verify the WS message is sent (`type: "set_status"`)
- [ ] Verify other connected users see the presence update

🤖 Generated with [Claude Code](https://claude.com/claude-code)