### PR TITLE
fix(ci): resolve pre-existing fmt, clippy, and frontend CI failures

### DIFF
--- a/client/src-tauri/src/commands/admin.rs
+++ b/client/src-tauri/src/commands/admin.rs
@@ -797,9 +797,11 @@ fn build_query(pairs: &[(&str, Option<String>)]) -> String {
             if !s.is_empty() {
                 s.push('&');
             }
-            s.push_str(&form_urlencoded::Serializer::new(String::new())
-                .append_pair(key, v)
-                .finish());
+            s.push_str(
+                &form_urlencoded::Serializer::new(String::new())
+                    .append_pair(key, v)
+                    .finish(),
+            );
         }
     }
     s
@@ -807,9 +809,7 @@ fn build_query(pairs: &[(&str, Option<String>)]) -> String {
 
 /// Fetch observability summary (vital signs, server metadata, voice health).
 #[command]
-pub async fn admin_obs_summary(
-    state: State<'_, AppState>,
-) -> Result<serde_json::Value, String> {
+pub async fn admin_obs_summary(state: State<'_, AppState>) -> Result<serde_json::Value, String> {
     let (server_url, token) = read_auth(&state).await?;
     debug!("Fetching observability summary");
 
@@ -843,7 +843,11 @@ pub async fn admin_obs_trends(
 ) -> Result<serde_json::Value, String> {
     validate_optional(Some(range.as_str()), VALID_RANGES, "range")?;
     let (server_url, token) = read_auth(&state).await?;
-    debug!("Fetching observability trends (range={}, metrics={})", range, metrics.len());
+    debug!(
+        "Fetching observability trends (range={}, metrics={})",
+        range,
+        metrics.len()
+    );
 
     let params = {
         let mut p = build_query(&[("range", Some(range))]);
@@ -851,9 +855,11 @@ pub async fn admin_obs_trends(
             if !p.is_empty() {
                 p.push('&');
             }
-            p.push_str(&form_urlencoded::Serializer::new(String::new())
-                .append_pair("metric", m)
-                .finish());
+            p.push_str(
+                &form_urlencoded::Serializer::new(String::new())
+                    .append_pair("metric", m)
+                    .finish(),
+            );
         }
         p
     };
@@ -1022,7 +1028,10 @@ pub async fn admin_obs_traces(
 ) -> Result<serde_json::Value, String> {
     validate_optional(status.as_deref(), VALID_TRACE_STATUSES, "status")?;
     let (server_url, token) = read_auth(&state).await?;
-    debug!("Fetching obs traces (status={:?}, domain={:?})", status, domain);
+    debug!(
+        "Fetching obs traces (status={:?}, domain={:?})",
+        status, domain
+    );
 
     let params = build_query(&[
         ("status", status),
@@ -1049,9 +1058,7 @@ pub async fn admin_obs_traces(
         let status_code = response.status();
         let body = response.text().await.unwrap_or_default();
         error!("Failed to fetch obs traces: {} - {}", status_code, body);
-        return Err(format!(
-            "Failed to fetch obs traces: {status_code}"
-        ));
+        return Err(format!("Failed to fetch obs traces: {status_code}"));
     }
 
     response
@@ -1062,9 +1069,7 @@ pub async fn admin_obs_traces(
 
 /// Fetch external observability tool links.
 #[command]
-pub async fn admin_obs_links(
-    state: State<'_, AppState>,
-) -> Result<serde_json::Value, String> {
+pub async fn admin_obs_links(state: State<'_, AppState>) -> Result<serde_json::Value, String> {
     let (server_url, token) = read_auth(&state).await?;
     debug!("Fetching observability links");
 

--- a/client/src-tauri/src/crypto/store.rs
+++ b/client/src-tauri/src/crypto/store.rs
@@ -4,11 +4,10 @@
 
 use std::path::Path;
 
-use aes_gcm::{
-    aead::{Aead, KeyInit},
-    Aes256Gcm, Nonce,
-};
-use base64::{engine::general_purpose::STANDARD, Engine};
+use aes_gcm::aead::{Aead, KeyInit};
+use aes_gcm::{Aes256Gcm, Nonce};
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
 use hmac::{Hmac, Mac};
 use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};

--- a/client/src/components/guilds/UsageTab.tsx
+++ b/client/src/components/guilds/UsageTab.tsx
@@ -1,0 +1,87 @@
+import { Component, For, Show, createSignal, onMount } from "solid-js";
+import { getGuildUsage } from "@/lib/tauri";
+import type { GuildUsageStats } from "@/lib/types";
+
+interface UsageTabProps {
+  guildId: string;
+}
+
+const UsageTab: Component<UsageTabProps> = (props) => {
+  const [usage, setUsage] = createSignal<GuildUsageStats | null>(null);
+  const [loading, setLoading] = createSignal(true);
+  const [error, setError] = createSignal<string | null>(null);
+
+  onMount(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getGuildUsage(props.guildId);
+      setUsage(data);
+    } catch (err) {
+      console.error("Failed to load guild usage stats:", err);
+      setError("Could not load usage stats.");
+    } finally {
+      setLoading(false);
+    }
+  });
+
+  const rows = () => {
+    const data = usage();
+    if (!data) return [];
+    return [
+      { label: "Members", value: data.members.current, limit: data.members.limit },
+      { label: "Channels", value: data.channels.current, limit: data.channels.limit },
+      { label: "Roles", value: data.roles.current, limit: data.roles.limit },
+      { label: "Emojis", value: data.emojis.current, limit: data.emojis.limit },
+      { label: "Bots", value: data.bots.current, limit: data.bots.limit },
+      { label: "Pages", value: data.pages.current, limit: data.pages.limit },
+    ];
+  };
+
+  return (
+    <div class="p-6 space-y-4">
+      <div>
+        <h3 class="text-sm font-semibold text-text-primary uppercase tracking-wide">Usage</h3>
+        <p class="text-xs text-text-secondary mt-1">Current guild usage against plan limits.</p>
+      </div>
+
+      <Show when={loading()}>
+        <p class="text-sm text-text-secondary">Loading usage stats...</p>
+      </Show>
+
+      <Show when={error()}>{(msg) => <p class="text-sm text-red-400">{msg()}</p>}</Show>
+
+      <Show when={!loading() && usage()}>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <For each={rows()}>
+            {(row) => {
+              const percent = () => {
+                if (row.limit <= 0) return 0;
+                return Math.min(100, Math.round((row.value / row.limit) * 100));
+              };
+
+              return (
+                <div class="p-4 rounded-xl border border-white/10 bg-surface-layer2">
+                  <div class="flex items-center justify-between text-sm">
+                    <span class="text-text-primary font-medium">{row.label}</span>
+                    <span class="text-text-secondary">
+                      {row.value} / {row.limit}
+                    </span>
+                  </div>
+                  <div class="mt-2 h-2 rounded-full bg-white/10 overflow-hidden">
+                    <div
+                      class="h-full bg-accent-primary transition-all"
+                      style={{ width: `${percent()}%` }}
+                    />
+                  </div>
+                </div>
+              );
+            }}
+          </For>
+        </div>
+      </Show>
+    </div>
+  );
+};
+
+export default UsageTab;

--- a/client/src/stores/settings.ts
+++ b/client/src/stores/settings.ts
@@ -5,7 +5,7 @@ import type { AppSettings } from "@/lib/types";
 // Note: updateSettings only works in Tauri natively.
 // Fallback defaults are provided by getSettings().
 
-const [settingsTrigger, setSettingsTrigger] = createSignal(0);
+const [settingsTrigger, _setSettingsTrigger] = createSignal(0);
 
 const fetchSettings = async () => {
   return await getSettings();

--- a/server/src/admin/handlers.rs
+++ b/server/src/admin/handlers.rs
@@ -20,9 +20,8 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Deserializer, Serialize};
 use sqlx::{PgPool, QueryBuilder};
 use tracing::warn;
-use uuid::Uuid;
-
 use utoipa::ToSchema;
+use uuid::Uuid;
 
 use super::types::{
     AdminError, AdminStatsResponse, AdminStatusResponse, BulkActionFailure, BulkBanRequest,

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -171,7 +171,8 @@ pub fn create_router(state: AppState) -> Router {
         .layer(from_fn_with_state(state.clone(), rate_limit_by_user))
         .layer(from_fn(with_category(RateLimitCategory::Social)));
 
-    // Discovery join route with Social rate limit (20 req/60s) — frictionless join needs tighter limit
+    // Discovery join route with Social rate limit (20 req/60s) — frictionless join needs tighter
+    // limit
     let discovery_join_routes = Router::new()
         .nest("/api/discover", discovery::protected_router())
         .layer(from_fn_with_state(state.clone(), rate_limit_by_user))

--- a/server/src/chat/uploads.rs
+++ b/server/src/chat/uploads.rs
@@ -3,8 +3,7 @@
 //! Handles file uploads to S3-compatible storage and metadata management.
 
 use axum::extract::{Multipart, Path, Query, State};
-use axum::http::HeaderName;
-use axum::http::StatusCode;
+use axum::http::{HeaderName, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use serde::{Deserialize, Serialize};

--- a/server/src/db/mod.rs
+++ b/server/src/db/mod.rs
@@ -1,26 +1,19 @@
-//! Advisory Lock Seed Registry
-//!
-//! `PostgreSQL` advisory locks use integer seeds to prevent collisions.
-//! Seeds are allocated per lock site:
-//! - 41 = `workspace_create` (per-user workspace creation limit)
-//! - 43 = `workspace_entry` (per-workspace entry creation limit)
-//! - 51 = `guild_create` (per-user guild creation limit) — see fix/review-focus-guild-discovery branch
-//! - 53 = `guild_join` (per-guild join serialization) — see fix/review-focus-guild-discovery branch
-//! - 61 = `page_create` (per-guild page creation limit)
-//!
-
 //! Database Layer
 //!
 //! `PostgreSQL` and Redis connections.
 //!
-//! Advisory Lock Seed Registry
-//! - 41 = `workspace_create`
-//! - 43 = `workspace_entry`
-//! - 51 = `guild_create`
-//! - 53 = `guild_member_join` (used by both invite joins and discovery joins)
-//!   - Called from: server/src/guild/invites.rs (invite join path)
-//!   - Called from: server/src/discovery/handlers.rs (discovery join path)
+//! ## Advisory Lock Seed Registry
 //!
+//! `PostgreSQL` advisory locks use integer seeds to prevent collisions.
+//! Seeds are allocated per lock site:
+//!
+//! - 41 = `workspace_create` (per-user workspace creation limit)
+//! - 43 = `workspace_entry` (per-workspace entry creation limit)
+//! - 51 = `guild_create` (per-user guild creation limit)
+//! - 53 = `guild_member_join` (per-guild join serialization)
+//!   - Called from: `server/src/guild/invites.rs` (invite join path)
+//!   - Called from: `server/src/discovery/handlers.rs` (discovery join path)
+//! - 61 = `page_create` (per-guild page creation limit)
 
 mod models;
 mod queries;

--- a/server/src/governance/handlers.rs
+++ b/server/src/governance/handlers.rs
@@ -45,8 +45,8 @@ pub async fn request_export(
 ) -> Result<impl IntoResponse, GovError> {
     // Recover stale jobs that may have been left behind by crash/restart so
     // users are not blocked forever by the active-job uniqueness constraint.
-    // NOTE: Uses `created_at` for stale detection because `data_export_jobs` has no `updated_at` field.
-    // The 1-hour threshold assumes exports complete well within this window.
+    // NOTE: Uses `created_at` for stale detection because `data_export_jobs` has no `updated_at`
+    // field. The 1-hour threshold assumes exports complete well within this window.
     // If exports grow to exceed 1 hour, add an `updated_at`/heartbeat column.
     // users are not blocked forever by the active-job uniqueness constraint.
     sqlx::query(

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -372,16 +372,15 @@ async fn main() -> Result<()> {
     let _ = voice_health_handle.await;
     info!("Background cleanup tasks stopped");
 
-    // 2. Flush and shut down OTel providers. Dropping these closes the
-    //    channel senders (NativeLogLayer, NativeSpanProcessor,
-    //    NativeMetricExporter), which lets the ingestion workers drain
-    //    remaining items and terminate naturally.
+    // 2. Flush and shut down OTel providers. Dropping these closes the channel senders
+    //    (NativeLogLayer, NativeSpanProcessor, NativeMetricExporter), which lets the ingestion
+    //    workers drain remaining items and terminate naturally.
     drop(otel_guard);
     drop(meter_provider);
     info!("OTel providers shut down, draining ingestion channels...");
 
-    // 3. Wait for ingestion workers to drain (no abort — they exit when
-    //    their channel senders are dropped above).
+    // 3. Wait for ingestion workers to drain (no abort — they exit when their channel senders are
+    //    dropped above).
     let _ = ingestion_handles.log_handle.await;
     let _ = ingestion_handles.span_handle.await;
     let _ = ingestion_handles.metric_handle.await;

--- a/server/src/observability/mod.rs
+++ b/server/src/observability/mod.rs
@@ -46,11 +46,11 @@ pub struct IngestionChannels {
 /// from metric initialisation is captured).
 ///
 /// # Returns
-/// * `OtelGuard` — drop-on-exit guard; keep it alive for the lifetime of
-///   `main` so providers flush and shut down gracefully.
+/// * `OtelGuard` — drop-on-exit guard; keep it alive for the lifetime of `main` so providers flush
+///   and shut down gracefully.
 /// * `Option<SdkMeterProvider>` — always `Some` (native exporter always active).
-/// * `IngestionChannels` — receivers for the native telemetry pipeline.
-///   Pass to [`ingestion::spawn_ingestion_workers`] after pool creation.
+/// * `IngestionChannels` — receivers for the native telemetry pipeline. Pass to
+///   [`ingestion::spawn_ingestion_workers`] after pool creation.
 pub fn init(
     config: &ObservabilityConfig,
 ) -> (OtelGuard, Option<SdkMeterProvider>, IngestionChannels) {

--- a/server/src/observability/tracing.rs
+++ b/server/src/observability/tracing.rs
@@ -19,9 +19,8 @@ use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::util::SubscriberInitExt as _;
 use tracing_subscriber::{EnvFilter, Layer, Registry};
 
-use crate::config::ObservabilityConfig;
-
 use super::ingestion::{CapturedLogEvent, CapturedSpan, NativeLogLayer, NativeSpanProcessor};
+use crate::config::ObservabilityConfig;
 
 /// RAII guard that shuts down the `OTel` providers when dropped.
 ///

--- a/server/src/workspaces/handlers.rs
+++ b/server/src/workspaces/handlers.rs
@@ -8,10 +8,6 @@ use axum::Json;
 use uuid::Uuid;
 use validator::Validate;
 
-use crate::api::AppState;
-use crate::auth::AuthUser;
-use crate::ws::{broadcast_to_user, ServerEvent};
-
 use super::error::WorkspaceError;
 use super::types::{
     AddEntryRequest, CreateWorkspaceRequest, ReorderEntriesRequest, ReorderWorkspacesRequest,
@@ -19,6 +15,9 @@ use super::types::{
     WorkspaceListItem, WorkspaceListRow, WorkspaceResponse, WorkspaceRow,
     MAX_WORKSPACE_ICON_LENGTH,
 };
+use crate::api::AppState;
+use crate::auth::AuthUser;
+use crate::ws::{broadcast_to_user, ServerEvent};
 
 // ============================================================================
 // Workspace CRUD
@@ -63,8 +62,9 @@ pub async fn create_workspace(
 
     let mut tx = state.db.begin().await?;
 
-    // Advisory lock: serialize workspace creation per user to enforce strict limits under concurrency.
-    // Seed 41 prevents collision with other lock sites (see seed registry in server/src/db/mod.rs).
+    // Advisory lock: serialize workspace creation per user to enforce strict limits under
+    // concurrency. Seed 41 prevents collision with other lock sites (see seed registry in
+    // server/src/db/mod.rs).
     sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1::text, 41))")
         .bind(auth_user.id)
         .execute(&mut *tx)
@@ -393,8 +393,9 @@ pub async fn add_entry(
 
     let mut tx = state.db.begin().await?;
 
-    // Advisory lock: serialize entry creation per workspace to enforce strict limits under concurrency.
-    // Seed 43 prevents collision with other lock sites (see seed registry in server/src/db/mod.rs).
+    // Advisory lock: serialize entry creation per workspace to enforce strict limits under
+    // concurrency. Seed 43 prevents collision with other lock sites (see seed registry in
+    // server/src/db/mod.rs).
     sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1::text, 43))")
         .bind(workspace_id)
         .execute(&mut *tx)

--- a/server/src/ws/mod.rs
+++ b/server/src/ws/mod.rs
@@ -194,9 +194,7 @@ pub enum ClientEvent {
     },
 
     /// Set user status (online, away, busy, offline).
-    SetStatus {
-        status: crate::db::UserStatus,
-    },
+    SetStatus { status: crate::db::UserStatus },
 
     /// Subscribe to admin events (requires elevated admin).
     AdminSubscribe,

--- a/server/tests/integration/admin_reports.rs
+++ b/server/tests/integration/admin_reports.rs
@@ -5,12 +5,13 @@
 //!
 //! Run with: `cargo test --test integration admin_reports -- --nocapture`
 
+use axum::body::Body;
+use axum::http::Method;
+
 use super::helpers::{
     body_to_json, create_elevated_session, create_test_report, create_test_user, delete_user,
     generate_access_token, make_admin, TestApp,
 };
-use axum::body::Body;
-use axum::http::Method;
 
 // ============================================================================
 // Access Control Tests

--- a/server/tests/integration/blocking.rs
+++ b/server/tests/integration/blocking.rs
@@ -5,11 +5,12 @@
 //!
 //! Run with: `cargo test --test integration blocking -- --nocapture`
 
+use axum::body::Body;
+use axum::http::Method;
+
 use super::helpers::{
     body_to_json, create_dm_channel, create_test_user, delete_user, generate_access_token, TestApp,
 };
-use axum::body::Body;
-use axum::http::Method;
 
 // ============================================================================
 // Block / Unblock Tests

--- a/server/tests/integration/bot_ecosystem.rs
+++ b/server/tests/integration/bot_ecosystem.rs
@@ -2,13 +2,14 @@
 
 use std::time::Duration;
 
-use super::helpers::{create_test_user, delete_user, generate_access_token, TestApp};
 use axum::body::Body;
 use axum::http::Method;
 use fred::interfaces::{ClientLike, EventInterface, KeysInterface, PubsubInterface};
 use http_body_util::BodyExt;
 use serde_json::json;
 use vc_server::db;
+
+use super::helpers::{create_test_user, delete_user, generate_access_token, TestApp};
 
 /// Test creating a bot application.
 #[tokio::test]

--- a/server/tests/integration/bot_intents.rs
+++ b/server/tests/integration/bot_intents.rs
@@ -1,8 +1,9 @@
 //! Bot Gateway Intent Integration Tests
 
-use super::helpers::*;
 use axum::body::Body;
 use axum::http::{Method, StatusCode};
+
+use super::helpers::*;
 
 // ============================================================================
 // Intent Persistence Tests

--- a/server/tests/integration/channels_http.rs
+++ b/server/tests/integration/channels_http.rs
@@ -5,11 +5,12 @@
 //!
 //! Run with: `cargo test --test integration channels_http -- --nocapture`
 
-use super::helpers::{body_to_json, create_test_user, generate_access_token, TestApp};
 use axum::body::Body;
 use axum::http::Method;
 use uuid::Uuid;
 use vc_server::permissions::GuildPermissions;
+
+use super::helpers::{body_to_json, create_test_user, generate_access_token, TestApp};
 
 // ============================================================================
 // Channel CRUD

--- a/server/tests/integration/connectivity_http.rs
+++ b/server/tests/integration/connectivity_http.rs
@@ -7,11 +7,12 @@
 //!
 //! Run with: `cargo test --test integration connectivity_http -- --nocapture`
 
-use super::helpers::{body_to_json, create_test_user, generate_access_token, TestApp};
 use axum::body::Body;
 use axum::http::Method;
 use sqlx::PgPool;
 use uuid::Uuid;
+
+use super::helpers::{body_to_json, create_test_user, generate_access_token, TestApp};
 
 // ============================================================================
 // Test Data Helpers

--- a/server/tests/integration/dm_http.rs
+++ b/server/tests/integration/dm_http.rs
@@ -5,10 +5,11 @@
 //!
 //! Run with: `cargo test --test integration dm_http -- --nocapture`
 
-use super::helpers::{body_to_json, create_test_user, generate_access_token, TestApp};
 use axum::body::Body;
 use axum::http::Method;
 use uuid::Uuid;
+
+use super::helpers::{body_to_json, create_test_user, generate_access_token, TestApp};
 
 // ============================================================================
 // Test Helpers

--- a/server/tests/integration/filters_http.rs
+++ b/server/tests/integration/filters_http.rs
@@ -5,11 +5,12 @@
 //!
 //! Run with: `cargo test --test integration filters_http -- --nocapture`
 
-use super::helpers::{body_to_json, create_test_user, generate_access_token, TestApp};
 use axum::body::Body;
 use axum::http::Method;
 use uuid::Uuid;
 use vc_server::permissions::GuildPermissions;
+
+use super::helpers::{body_to_json, create_test_user, generate_access_token, TestApp};
 
 // ============================================================================
 // Test Helpers

--- a/server/tests/integration/global_search_http.rs
+++ b/server/tests/integration/global_search_http.rs
@@ -5,14 +5,15 @@
 //!
 //! Run with: `cargo test --test integration global_search_http -- --test-threads=1`
 
+use axum::body::Body;
+use axum::http::Method;
+
 use super::helpers::{
     add_guild_member, body_to_json, create_channel, create_dm_channel, create_guild,
     create_test_user, delete_dm_channel, delete_guild, delete_user, generate_access_token,
     insert_attachment, insert_deleted_message, insert_encrypted_message, insert_message,
     insert_message_at, TestApp,
 };
-use axum::body::Body;
-use axum::http::Method;
 
 // ============================================================================
 // Local helpers

--- a/server/tests/integration/governance.rs
+++ b/server/tests/integration/governance.rs
@@ -4,10 +4,11 @@
 //!
 //! Run with: `cargo test --test integration governance -- --nocapture`
 
-use super::helpers::{body_to_json, create_test_user, generate_access_token, TestApp};
 use axum::body::Body;
 use axum::http::Method;
 use vc_server::auth::hash_password;
+
+use super::helpers::{body_to_json, create_test_user, generate_access_token, TestApp};
 
 // ============================================================================
 // Helpers

--- a/server/tests/integration/guild_limits.rs
+++ b/server/tests/integration/guild_limits.rs
@@ -1,13 +1,14 @@
 //! Integration tests for guild resource limits.
 
+use axum::body::Body;
+use axum::http::{Method, StatusCode};
+use vc_server::config::Config;
+
 use super::helpers::{
     add_guild_member, body_to_json, create_bot_application, create_channel, create_guild,
     create_test_user, delete_bot_application, delete_guild, delete_user, generate_access_token,
     TestApp,
 };
-use axum::body::Body;
-use axum::http::{Method, StatusCode};
-use vc_server::config::Config;
 
 /// Helper: create a Config with low limits for testing.
 fn low_limit_config() -> Config {

--- a/server/tests/integration/media_processing.rs
+++ b/server/tests/integration/media_processing.rs
@@ -7,12 +7,13 @@
 //!
 //! Run with: `cargo test --test integration media_processing -- --nocapture`
 
-use super::helpers::{create_test_user, generate_access_token, TestApp};
 use axum::body::Body;
 use axum::http::Method;
 use http_body_util::BodyExt;
 use uuid::Uuid;
 use vc_server::permissions::GuildPermissions;
+
+use super::helpers::{create_test_user, generate_access_token, TestApp};
 
 /// Create a minimal PNG image in memory (10x10 solid color).
 fn create_test_png(width: u32, height: u32) -> Vec<u8> {

--- a/server/tests/integration/messages_http.rs
+++ b/server/tests/integration/messages_http.rs
@@ -5,11 +5,12 @@
 //!
 //! Run with: `cargo test --test integration messages_http -- --nocapture`
 
-use super::helpers::{body_to_json, create_test_user, generate_access_token, TestApp};
 use axum::body::Body;
 use axum::http::Method;
 use uuid::Uuid;
 use vc_server::permissions::GuildPermissions;
+
+use super::helpers::{body_to_json, create_test_user, generate_access_token, TestApp};
 
 // ============================================================================
 // Test Helpers

--- a/server/tests/integration/ratelimit_http.rs
+++ b/server/tests/integration/ratelimit_http.rs
@@ -13,11 +13,12 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use super::helpers::spawn_test_server;
 use vc_server::api::{create_router, AppState, AppStateConfig};
 use vc_server::config::Config;
 use vc_server::ratelimit::{LimitConfig, RateLimitConfig, RateLimiter, RateLimits};
 use vc_server::voice::sfu::SfuServer;
+
+use super::helpers::spawn_test_server;
 
 /// Create a test app with rate limiting enabled using a real server.
 async fn create_rate_limited_app(limits: RateLimits) -> (super::helpers::TestServer, Config) {

--- a/server/tests/integration/reports.rs
+++ b/server/tests/integration/reports.rs
@@ -5,9 +5,10 @@
 //!
 //! Run with: `cargo test --test integration reports -- --nocapture`
 
-use super::helpers::{body_to_json, create_test_user, delete_user, generate_access_token, TestApp};
 use axum::body::Body;
 use axum::http::Method;
+
+use super::helpers::{body_to_json, create_test_user, delete_user, generate_access_token, TestApp};
 
 // ============================================================================
 // Report Creation Tests

--- a/server/tests/integration/search_http.rs
+++ b/server/tests/integration/search_http.rs
@@ -5,16 +5,17 @@
 //!
 //! Run with: `cargo test --test integration search_http`
 
+use axum::body::Body;
+use axum::http::Method;
+use uuid::Uuid;
+use vc_server::permissions::GuildPermissions;
+
 use super::helpers::{
     add_guild_member, body_to_json, create_channel, create_dm_channel, create_guild,
     create_guild_with_default_role, create_test_user, delete_dm_channel, delete_guild, delete_user,
     generate_access_token, insert_attachment, insert_encrypted_message, insert_message,
     insert_message_at, TestApp,
 };
-use axum::body::Body;
-use axum::http::Method;
-use uuid::Uuid;
-use vc_server::permissions::GuildPermissions;
 
 // ============================================================================
 // Local request helpers

--- a/server/tests/integration/setup_concurrent_http.rs
+++ b/server/tests/integration/setup_concurrent_http.rs
@@ -10,12 +10,13 @@
 //!
 //! Run with: `cargo test --test integration setup_concurrent_http -- --nocapture`
 
-use super::helpers::{create_test_user, generate_access_token, make_admin, TestApp};
 use axum::body::Body;
 use axum::http::Method;
 use serial_test::serial;
 use tokio::time::{timeout, Duration};
 use tower::ServiceExt;
+
+use super::helpers::{create_test_user, generate_access_token, make_admin, TestApp};
 
 /// Set `setup_complete` to the given value and return the previous value.
 async fn set_setup_complete(pool: &sqlx::PgPool, complete: bool) -> bool {

--- a/server/tests/integration/setup_http.rs
+++ b/server/tests/integration/setup_http.rs
@@ -10,11 +10,12 @@
 //!
 //! Run with: `cargo test --test integration setup_http -- --nocapture`
 
-use super::helpers::{body_to_json, create_test_user, generate_access_token, make_admin, TestApp};
 use axum::body::Body;
 use axum::http::Method;
 use serial_test::serial;
 use tokio::time::{timeout, Duration};
+
+use super::helpers::{body_to_json, create_test_user, generate_access_token, make_admin, TestApp};
 
 // ============================================================================
 // Database state helpers

--- a/server/tests/integration/threads.rs
+++ b/server/tests/integration/threads.rs
@@ -5,11 +5,12 @@
 //!
 //! Run with: `cargo test --test integration threads -- --nocapture`
 
-use super::helpers::{body_to_json, create_test_user, delete_user, generate_access_token, TestApp};
 use axum::body::Body;
 use axum::http::Method;
 use sqlx::PgPool;
 use uuid::Uuid;
+
+use super::helpers::{body_to_json, create_test_user, delete_user, generate_access_token, TestApp};
 
 // ============================================================================
 // Test Helpers

--- a/server/tests/integration/uploads_http.rs
+++ b/server/tests/integration/uploads_http.rs
@@ -5,11 +5,12 @@
 //!
 //! Run with: `cargo test --test integration uploads_http -- --nocapture`
 
-use super::helpers::{create_test_user, generate_access_token, TestApp};
 use axum::body::Body;
 use axum::http::Method;
 use uuid::Uuid;
 use vc_server::permissions::GuildPermissions;
+
+use super::helpers::{create_test_user, generate_access_token, TestApp};
 
 // ============================================================================
 // Upload Error Paths

--- a/server/tests/integration/webhooks.rs
+++ b/server/tests/integration/webhooks.rs
@@ -1,8 +1,9 @@
 //! Webhook Integration Tests
 
-use super::helpers::*;
 use axum::body::Body;
 use axum::http::{Method, StatusCode};
+
+use super::helpers::*;
 
 // ============================================================================
 // CRUD Tests

--- a/server/tests/integration/workspaces.rs
+++ b/server/tests/integration/workspaces.rs
@@ -2,11 +2,12 @@
 //!
 //! Run with: `cargo test --test integration workspaces -- --nocapture`
 
+use axum::body::Body;
+use axum::http::Method;
+
 use super::helpers::{
     body_to_json, create_channel, create_guild, create_test_user, generate_access_token, TestApp,
 };
-use axum::body::Body;
-use axum::http::Method;
 
 // ============================================================================
 // Workspace CRUD Tests

--- a/shared/vc-crypto/src/megolm.rs
+++ b/shared/vc-crypto/src/megolm.rs
@@ -4,9 +4,10 @@
 //!
 //! This module is only compiled when the `megolm` feature is enabled.
 
-use crate::{CryptoError, Result};
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
+
+use crate::{CryptoError, Result};
 
 /// Outbound Megolm session for encrypting messages to a group.
 #[cfg(feature = "megolm")]


### PR DESCRIPTION
## Summary

- **Rust fmt**: Run `cargo +nightly fmt --all` to fix import ordering across 30+ files (nightly `group_imports = StdExternalCrate` convention)
- **Clippy**: Merge duplicate advisory lock doc blocks in `server/src/db/mod.rs` to fix `doc-lazy-continuation` lint
- **Frontend (UsageTab)**: Populate empty `UsageTab.tsx` with guild usage stats component (was imported by `GuildSettingsModal` but file was empty, causing `TS2306: not a module`)
- **Frontend (settings)**: Prefix unused `setSettingsTrigger` with underscore in `settings.ts` to fix `TS6133: declared but never read`

## Verification

- `cargo +nightly fmt --all -- --check` passes
- `SQLX_OFFLINE=true cargo clippy -- -D warnings` passes
- `bunx tsc --noEmit` passes
- `bun run test:run` passes (431/431 tests)

## Test plan

- [ ] CI Rust Lint (fmt) passes
- [ ] CI Rust Lint (clippy) passes
- [ ] CI Frontend check passes
- [ ] CI Rust Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)