### PR TITLE
docs: fix documentation inconsistencies and update diagrams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,71 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Focus modes for intelligent notification routing — suppress notifications during gaming, coding, or streaming sessions with VIP contact overrides and emergency keyword bypass (#253)
 - Auto-activation of focus modes when matching apps are detected (games, IDEs) with support for custom triggers (#253)
 - Focus settings UI with per-mode configuration: suppression level, VIP users/channels, emergency keywords, and trigger categories (#253)
-
-### Changed
-- Rebranded from VoiceChat/Canis to Kaiku across the entire application — window title, TOTP authenticator issuer, OpenAPI docs, Tauri identifier, and all user-facing strings (#302)
-- Simplified admin session elevation to single-click confirmation (MFA verification deferred)
-- Renamed `kaiku_auth_attempts_total` metric to `kaiku_auth_login_attempts_total` to match observability contract (#285)
-- Fixed voice join metric to use `outcome` label (was `result`) with `failure` value (was `error`) (#285)
-### Fixed
-- Browser-mode WebSocket connection now correctly signals readiness, fixing channel and DM subscriptions that previously timed out after 5 seconds (#302)
-- Sending multiple messages rapidly no longer causes earlier pending messages to disappear — only the specific confirmed message's placeholder is removed (#302)
-- Group voice calls no longer lose track of participants when additional users join — participant list and call duration are preserved correctly (#302)
-- Starting a voice call that fails to connect now properly resets call state instead of showing a stuck "calling" indicator (#302)
-- Idle detection (auto-away status) now works correctly after restoring a saved session (#302)
-- Restored missing success/error feedback for friend request acceptance, DM group rename failures, and invite code server joins (#302)
-- Webhook delivery worker no longer logs ERROR-level timeout messages every 2 seconds on idle — fred 10.x BRPOP nil responses are now correctly handled as normal idle behavior (#287)
-- Process scanner now reports correct activity type (coding, listening, watching) instead of hardcoding all detected apps as "game" (#253)
-- Onboarding wizard no longer flashes on page reload before disappearing: visibility is now gated on preferences hydration (`initPreferences`) so users with `onboarding_completed=true` do not briefly see first-run modal content.
-- Accepting friend requests now updates the Pending tab immediately with optimistic UI feedback and a success toast, instead of waiting for slower list refreshes before users see the request disappear.
-- Fixed Direct Message creation bugs where new DMs appeared only after a page reload, sent messages didn't update the sidebar preview, and incoming messages failed to trigger notifications or unread badges.
-- Fixed 1:1 voice call bugs: initiator no longer hears their own ringtone due to a race condition between HTTP call start and WebSocket event handling, ringing now stops reliably when calls end or are declined, and the remote party's call state is properly cleaned up when one side hangs up instead of showing a stale active call.
-- Fixed TanStack Virtual `measureElement` warnings in message list and DM sidebar by ensuring `data-index` DOM attributes are set before virtualizer ref callbacks run.
-
-### Security
-- Enabled Content Security Policy (CSP) in Tauri webview to prevent script injection (#295)
-- Disabled `withGlobalTauri` to restrict IPC bridge access to explicit imports only (#295)
-- OIDC provider error details are no longer leaked to clients — errors are logged server-side (#295)
-- Sessions are now invalidated when a user changes their password (#295)
-- Added WebSocket message size limits (256 KiB max) to prevent memory exhaustion (#295)
-- Fixed SSRF bypass in test webhook delivery — now uses DNS-pinned HTTP client (#295)
-- OIDC flow now requires `PUBLIC_URL` to be set, preventing silently broken callback URLs (#295)
-- Added security response headers: `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy` (#295)
-- Added CORS wildcard origin warning log for production deployments (#295)
-- Fixed X-Forwarded-For IP extraction to use rightmost (proxy-appended) IP, preventing client spoofing (#295)
-- Rate-limited OIDC callback endpoint to prevent abuse (#295)
-- Redacted password and MFA code from `LoginRequest` debug output (#295)
-- Channel creation, member operations, and file uploads now enforce guild membership and permission checks — previously these endpoints could be accessed without proper authorization (#217, #218)
-- Guild join endpoint now requires a valid invite — previously any authenticated user could join any guild directly (#219)
-- E2EE device registration is now limited to 10 devices per user to prevent ghost device attacks (#221)
-- E2EE identity key fallback that produced permanently undecryptable messages has been replaced with a proper error — clients now surface a clear re-verification prompt instead of silently losing messages (#222)
-- Logout now verifies refresh token ownership — previously any valid token could revoke another user's session (#224)
-- MFA setup now requires TOTP verification before activation — previously MFA was activated immediately on secret generation without confirming the user had configured their authenticator (#225)
-- E2EE local key store is now encrypted with AES-256-GCM using SQLCipher — previously session data was stored in plaintext SQLite (#226)
-- Server now validates uploaded E2EE public keys are valid Curve25519 points — previously any byte string was accepted (#227)
-- E2EE key backup overwrites now require password re-authentication — previously backups could be silently replaced (#228)
-- Guild admins can now manage custom emoji regardless of uploader — previously only the original uploader could update or delete emoji (#229)
-- Webhook delivery now resolves DNS and validates the target IP at delivery time to prevent SSRF via DNS rebinding (#230)
-- Webhook signing secrets are now encrypted at rest using AES-256-GCM — previously stored as plaintext in the database (#231)
-- Refresh token rotation now uses atomic database operations to prevent race condition token reuse (#232)
-- E2EE local key store encryption now uses Argon2id key derivation instead of single-pass SHA-256 (#233)
-
-### Fixed
-- WebSocket pubsub handler no longer panics when filtering events from blocked users — `blocking_read()` was incorrectly used in an async context, crashing the server whenever a blocked user's event was processed (#212)
-- Redis failures in block checks and screen share limits are now logged with user context and failsafe policy — previously errors were silently swallowed, making Redis outages invisible in call, DM, message, and friend request flows (#213)
-- Tauri IPC crypto commands now validate string parameter lengths — previously unbounded inputs to `init_e2ee`, `encrypt_message`, `decrypt_message`, `create_backup`, `restore_backup`, and `generate_prekeys` could cause CPU stalls or excessive memory usage (#214)
-- Admin dashboard now correctly shows whether the current session is elevated — previously `is_elevated` was always reported as `false` regardless of actual elevation state (TD-17)
-- Revealed spoilers now stay revealed when scrolling away and back in the message list — previously clicking `||spoiler||` text to reveal it would reset when the message re-rendered (TD-22)
-- E2EE key backups now include the actual identity keys and prekeys — previously the encrypted backup contained only a timestamp placeholder, making it impossible to restore E2EE keys from a backup
-- WebSocket upgrade error paths no longer panic on unexpected conditions — replaced `.expect()` calls with a proper `error_response` helper that returns HTTP status codes (TD-05)
-
-### Changed
-- Message character limits are now evaluated dynamically: standard text is limited to 4,000 characters, while messages containing code blocks can have up to 10,000 total characters.
-- Upload size limits (avatar, emoji, attachment) are now fetched from `GET /api/config/upload-limits` at startup and applied client-side — previously the client used hardcoded defaults that could drift from server configuration (TD-13)
-- Notification sounds now play for the active channel when the application window is in the background
-- Production client builds now selectively strip `console.log` and `console.debug` while preserving `console.error` and `console.warn` for diagnostics (TD-09)
-
-### Added
 - Digital Library — guild pages now support revision history (automatic snapshots on content changes with configurable pruning), page categories (guild-scoped, ordered, with CRUD and reordering), deep-linkable heading anchors (GitHub-style slugs with click-to-copy URL), a library catalog view for browsing pages by category, and per-guild configurable page/revision limits with admin overrides; 13 new API endpoints for revisions, categories, and admin limit management
 - Personal workspaces — users can create named workspace folders and add channels from any guild they're a member of, enabling cross-guild "Mission Control" views; 9 REST API endpoints for workspace CRUD, entry management, and drag-and-drop reordering; real-time cross-device sync via 7 new WebSocket events; configurable max workspaces per user limit (default: 20); guild membership and VIEW_CHANNEL permission checks enforced on entry creation
 - Data export — users can request a full export of their data (profile, messages, guild memberships, friends, preferences) as a downloadable ZIP archive via `POST /api/me/data-export`; background worker gathers data into a versioned JSON archive, uploads to S3, and sends email notification when ready; downloads expire after 7 days
@@ -544,6 +479,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - User-friendly error messages showing both file size and limit in human-readable format (KB/MB)
 
 ### Changed
+- Rebranded from VoiceChat/Canis to Kaiku across the entire application — window title, TOTP authenticator issuer, OpenAPI docs, Tauri identifier, and all user-facing strings (#302)
+- Simplified admin session elevation to single-click confirmation (MFA verification deferred)
+- Renamed `kaiku_auth_attempts_total` metric to `kaiku_auth_login_attempts_total` to match observability contract (#285)
+- Fixed voice join metric to use `outcome` label (was `result`) with `failure` value (was `error`) (#285)
+- Message character limits are now evaluated dynamically: standard text is limited to 4,000 characters, while messages containing code blocks can have up to 10,000 total characters.
+- Upload size limits (avatar, emoji, attachment) are now fetched from `GET /api/config/upload-limits` at startup and applied client-side — previously the client used hardcoded defaults that could drift from server configuration (TD-13)
+- Notification sounds now play for the active channel when the application window is in the background
+- Production client builds now selectively strip `console.log` and `console.debug` while preserving `console.error` and `console.warn` for diagnostics (TD-09)
+- Restored dropped VoicePanel features: elapsed timer, connection quality indicator with tooltip, speaking glow animation, and keyboard shortcuts for mute/deafen (#307)
 - Upgraded message list virtualizer from custom implementation to `@tanstack/solid-virtual` for proper dynamic sizing via ResizeObserver
 - Replaced MinIO (AGPL-3.0) with RustFS (Apache-2.0) as the default S3-compatible object storage for development — no code changes needed, only Docker and documentation updates
 - Bot command responses now enforce single-response semantics — each `interaction_id` accepts exactly one `CommandResponse`, duplicate responses are rejected with a clear error (#176)
@@ -617,15 +561,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Identified critical updates (sqlx, axum) and blockers
   - Phased update strategy executed in subsequent releases
 
-### Deprecated
-
-### Removed
-- Deleted 12 stale documentation files (session artifacts, redundant license docs, completed update checklists, dependency snapshots)
-- Removed phantom dependencies from standards documentation (jsonrpsee, nnnoiseless, metrics, x25519-dalek, ed25519-dalek)
-- Removed stale scripts (resume-session.sh, update-deps.sh)
-- Legacy unscoped `GET /api/channels` endpoint that returned all channels across all guilds
-
 ### Fixed
+- Browser-mode WebSocket connection now correctly signals readiness, fixing channel and DM subscriptions that previously timed out after 5 seconds (#302)
+- Sending multiple messages rapidly no longer causes earlier pending messages to disappear — only the specific confirmed message's placeholder is removed (#302)
+- Group voice calls no longer lose track of participants when additional users join — participant list and call duration are preserved correctly (#302)
+- Starting a voice call that fails to connect now properly resets call state instead of showing a stuck "calling" indicator (#302)
+- Idle detection (auto-away status) now works correctly after restoring a saved session (#302)
+- Restored missing success/error feedback for friend request acceptance, DM group rename failures, and invite code server joins (#302)
+- Webhook delivery worker no longer logs ERROR-level timeout messages every 2 seconds on idle — fred 10.x BRPOP nil responses are now correctly handled as normal idle behavior (#287)
+- Process scanner now reports correct activity type (coding, listening, watching) instead of hardcoding all detected apps as "game" (#253)
+- Onboarding wizard no longer flashes on page reload before disappearing: visibility is now gated on preferences hydration (`initPreferences`) so users with `onboarding_completed=true` do not briefly see first-run modal content.
+- Accepting friend requests now updates the Pending tab immediately with optimistic UI feedback and a success toast, instead of waiting for slower list refreshes before users see the request disappear.
+- Fixed Direct Message creation bugs where new DMs appeared only after a page reload, sent messages didn't update the sidebar preview, and incoming messages failed to trigger notifications or unread badges.
+- Fixed 1:1 voice call bugs: initiator no longer hears their own ringtone due to a race condition between HTTP call start and WebSocket event handling, ringing now stops reliably when calls end or are declined, and the remote party's call state is properly cleaned up when one side hangs up instead of showing a stale active call.
+- Fixed TanStack Virtual `measureElement` warnings in message list and DM sidebar by ensuring `data-index` DOM attributes are set before virtualizer ref callbacks run.
+- WebSocket pubsub handler no longer panics when filtering events from blocked users — `blocking_read()` was incorrectly used in an async context, crashing the server whenever a blocked user's event was processed (#212)
+- Redis failures in block checks and screen share limits are now logged with user context and failsafe policy — previously errors were silently swallowed, making Redis outages invisible in call, DM, message, and friend request flows (#213)
+- Tauri IPC crypto commands now validate string parameter lengths — previously unbounded inputs to `init_e2ee`, `encrypt_message`, `decrypt_message`, `create_backup`, `restore_backup`, and `generate_prekeys` could cause CPU stalls or excessive memory usage (#214)
+- Admin dashboard now correctly shows whether the current session is elevated — previously `is_elevated` was always reported as `false` regardless of actual elevation state (TD-17)
+- Revealed spoilers now stay revealed when scrolling away and back in the message list — previously clicking `||spoiler||` text to reveal it would reset when the message re-rendered (TD-22)
+- E2EE key backups now include the actual identity keys and prekeys — previously the encrypted backup contained only a timestamp placeholder, making it impossible to restore E2EE keys from a backup
+- WebSocket upgrade error paths no longer panic on unexpected conditions — replaced `.expect()` calls with a proper `error_response` helper that returns HTTP status codes (TD-05)
 - Message list layout drift when images load or code blocks expand — now uses real element measurement instead of estimated sizes
 - Toast notifications now use consistent durations (error: 8s, success: 3s) and dedup IDs for repeatable events (command timeout, screen share)
 - Slash command autocomplete now allows hyphens in command names
@@ -747,6 +703,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed unused `update_user_password` database function (#131)
 
 ### Security
+- Enabled Content Security Policy (CSP) in Tauri webview to prevent script injection (#295)
+- Disabled `withGlobalTauri` to restrict IPC bridge access to explicit imports only (#295)
+- OIDC provider error details are no longer leaked to clients — errors are logged server-side (#295)
+- Sessions are now invalidated when a user changes their password (#295)
+- Added WebSocket message size limits (256 KiB max) to prevent memory exhaustion (#295)
+- Fixed SSRF bypass in test webhook delivery — now uses DNS-pinned HTTP client (#295)
+- OIDC flow now requires `PUBLIC_URL` to be set, preventing silently broken callback URLs (#295)
+- Added security response headers: `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy` (#295)
+- Added CORS wildcard origin warning log for production deployments (#295)
+- Fixed X-Forwarded-For IP extraction to use rightmost (proxy-appended) IP, preventing client spoofing (#295)
+- Rate-limited OIDC callback endpoint to prevent abuse (#295)
+- Redacted password and MFA code from `LoginRequest` debug output (#295)
+- Channel creation, member operations, and file uploads now enforce guild membership and permission checks — previously these endpoints could be accessed without proper authorization (#217, #218)
+- Guild join endpoint now requires a valid invite — previously any authenticated user could join any guild directly (#219)
+- E2EE device registration is now limited to 10 devices per user to prevent ghost device attacks (#221)
+- E2EE identity key fallback that produced permanently undecryptable messages has been replaced with a proper error — clients now surface a clear re-verification prompt instead of silently losing messages (#222)
+- Logout now verifies refresh token ownership — previously any valid token could revoke another user's session (#224)
+- MFA setup now requires TOTP verification before activation — previously MFA was activated immediately on secret generation without confirming the user had configured their authenticator (#225)
+- E2EE local key store is now encrypted with AES-256-GCM using SQLCipher — previously session data was stored in plaintext SQLite (#226)
+- Server now validates uploaded E2EE public keys are valid Curve25519 points — previously any byte string was accepted (#227)
+- E2EE key backup overwrites now require password re-authentication — previously backups could be silently replaced (#228)
+- Guild admins can now manage custom emoji regardless of uploader — previously only the original uploader could update or delete emoji (#229)
+- Webhook delivery now resolves DNS and validates the target IP at delivery time to prevent SSRF via DNS rebinding (#230)
+- Webhook signing secrets are now encrypted at rest using AES-256-GCM — previously stored as plaintext in the database (#231)
+- Refresh token rotation now uses atomic database operations to prevent race condition token reuse (#232)
+- E2EE local key store encryption now uses Argon2id key derivation instead of single-pass SHA-256 (#233)
 - Megolm group E2EE stubs gated behind compile-time `megolm` feature flag — previously contained `todo!()` macros that would panic at runtime if group encryption was invoked (TD-01)
 - Search query length capped at 1000 characters across guild, DM, and global search endpoints to prevent resource exhaustion (TD-08)
 - Eliminated all `.unwrap()` calls in production server code — TOTP secret decoding now returns proper errors instead of panicking, WebSocket auth responses use `.expect()` with justification, duration arithmetic uses `saturating_sub()`, and S3 endpoint formatting uses safe `if let` pattern (#163)
@@ -786,6 +768,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ownership verification in page reorder operations prevents cross-guild attacks
 - Fail-fast permission checks on database errors (no silent auth bypass)
 - Fixed missing size validation for user avatar uploads (previously relied only on DefaultBodyLimit middleware)
+
+### Deprecated
+
+### Removed
+- Deleted 12 stale documentation files (session artifacts, redundant license docs, completed update checklists, dependency snapshots)
+- Removed phantom dependencies from standards documentation (jsonrpsee, nnnoiseless, metrics, x25519-dalek, ed25519-dalek)
+- Removed stale scripts (resume-session.sh, update-deps.sh)
+- Legacy unscoped `GET /api/channels` endpoint that returned all channels across all guilds
 
 ## [0.1.0] - 2026-01-18
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ const channel = await invoke<Channel>('get_channel', { id });
 
 ## Git Workflow
 
-> Full specification: `docs/plans/2026-01-18-git-workflow-design.md`
+> Full specification: `docs/developer-guide/plans/2026-01-18-git-workflow-design.md`
 
 **NEVER commit directly to `main`.** Always create a feature branch or worktree for changes and merge via PR.
 **Branch naming:** `feature/<name>`, `fix/<name>`, `refactor/<area>`, `docs/<topic>`
@@ -96,7 +96,7 @@ Review src/api/channels.rs for security only      # Scoped review
 Ask [Faramir|Elrond|Gandalf|Éowyn|Pippin] about [topic]  # Character deep-dive
 ```
 
-See `docs/development/code-review.md` for full review format, concern areas, severity criteria, and character descriptions.
+See `docs/developer-guide/development/code-review.md` for full review format, concern areas, severity criteria, and character descriptions.
 
 ## Quick Reference
 
@@ -114,12 +114,12 @@ GPL-2.0, GPL-3.0, AGPL-3.0, LGPL-2.0, LGPL-2.1, LGPL-3.0, SSPL, Proprietary
 ### Wichtige Crates
 - Web: axum, tower, tokio
 - OpenAPI: utoipa, utoipa-swagger-ui
-- WebRTC: webrtc-rs
+- WebRTC: webrtc
 - DB: sqlx (PostgreSQL)
 - Redis: fred
 - Auth: jsonwebtoken, argon2, openidconnect
 - E2EE Text: vodozemac
-- Crypto: rustls, x25519-dalek, ed25519-dalek
+- Crypto: rustls
 
 ### Package Manager
 - Bun (for package management and script running)
@@ -133,9 +133,9 @@ GPL-2.0, GPL-3.0, AGPL-3.0, LGPL-2.0, LGPL-2.1, LGPL-3.0, SSPL, Proprietary
 
 ## Documentation Pointers
 
-- `PROJECT_SPEC.md` — Anforderungen und Entscheidungslog
-- `ARCHITECTURE.md` — Technische Architektur und Diagramme
-- `STANDARDS.md` — Verwendete Protokolle und Libraries
+- `docs/developer-guide/project/specification.md` — Anforderungen und Entscheidungslog
+- `docs/developer-guide/architecture/overview.md` — Technische Architektur und Diagramme
+- `docs/developer-guide/development/standards.md` — Verwendete Protokolle und Libraries
 - `LICENSE_COMPLIANCE.md` — Lizenzprüfung aller Dependencies
 - `CHANGELOG.md` — Änderungsprotokoll
-- `docs/development/code-review.md` — Review-System, Concern Areas, Characters, Workflows
+- `docs/developer-guide/development/code-review.md` — Review-System, Concern Areas, Characters, Workflows

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,15 +8,21 @@ Welcome to the official documentation for Kaiku. This directory is structured to
 docs/
 ├── admin-guide/        # Guides for self-hosting, configuration, and operations
 │   ├── configuration/  # Details on auth methods, feature flags, rate-limiting, and webhooks
+│   ├── features/       # Feature-specific admin documentation
+│   ├── getting-started/ # Quick-start guides for administrators
 │   ├── ops/            # Deployment guides, incident triage, security hardening, and updates
-│   ├── rules-and-limits/ # Default limits, message policies, and user conduct guidelines
 │   └── self-hosting.md # Overview of self-hosting Kaiku
 │
 └── developer-guide/    # Deep technical dives into Kaiku's architecture and codebase
     ├── agents/         # Architecture and implementation details of AI agents
     ├── architecture/   # Core architecture, data models, networking, and system diagrams
     ├── design/         # Brand, UI/UX guidelines, and image generation rules
-    └── security/       # Cryptographic protocols (Olm/Megolm) and security implementations
+    ├── development/    # Setup, standards, CI, code review, and development workflows
+    ├── examples/       # Code examples and reference implementations
+    ├── plans/          # Design documents and implementation plans
+    ├── project/        # Project specification and roadmap
+    ├── security/       # Cryptographic protocols (Olm/Megolm) and security implementations
+    └── testing/        # Test strategies and testing documentation
 ```
 
 ## Where to Start?

--- a/docs/admin-guide/features/channel-permissions.md
+++ b/docs/admin-guide/features/channel-permissions.md
@@ -639,23 +639,49 @@ cargo test test_channel_override_deny_wins_over_allow
 
 ```rust
 // Guild Permissions (from server/src/permissions/guild.rs)
-const CREATE_INVITE:        i64 = 1 << 0;  // 1
-const KICK_MEMBERS:         i64 = 1 << 1;  // 2
-const BAN_MEMBERS:          i64 = 1 << 2;  // 4
-const SEND_MESSAGES:        i64 = 1 << 3;  // 8
-const MANAGE_CHANNELS:      i64 = 1 << 4;  // 16
-const MANAGE_GUILD:         i64 = 1 << 5;  // 32
-const MANAGE_ROLES:         i64 = 1 << 6;  // 64
-const MANAGE_MESSAGES:      i64 = 1 << 7;  // 128
-const READ_MESSAGE_HISTORY: i64 = 1 << 8;  // 256
-const MENTION_EVERYONE:     i64 = 1 << 9;  // 512
-const VOICE_CONNECT:        i64 = 1 << 10; // 1024
-const VOICE_SPEAK:          i64 = 1 << 11; // 2048
-const VOICE_MUTE_MEMBERS:   i64 = 1 << 12; // 4096
-const VOICE_DEAFEN_MEMBERS: i64 = 1 << 13; // 8192
-const VOICE_MOVE_MEMBERS:   i64 = 1 << 14; // 16384
-const SCREEN_SHARE:         i64 = 1 << 15; // 32768
-const VIEW_CHANNEL:         i64 = 1 << 24; // 16777216 ⭐ NEW
+//
+// === Content (bits 0-4) ===
+const SEND_MESSAGES:        u64 = 1 << 0;   // 1
+const EMBED_LINKS:          u64 = 1 << 1;   // 2
+const ATTACH_FILES:         u64 = 1 << 2;   // 4
+const USE_EMOJI:            u64 = 1 << 3;   // 8
+const ADD_REACTIONS:        u64 = 1 << 4;   // 16
+//
+// === Voice (bits 5-9) ===
+const VOICE_CONNECT:        u64 = 1 << 5;   // 32
+const VOICE_SPEAK:          u64 = 1 << 6;   // 64
+const VOICE_MUTE_OTHERS:    u64 = 1 << 7;   // 128
+const VOICE_DEAFEN_OTHERS:  u64 = 1 << 8;   // 256
+const VOICE_MOVE_MEMBERS:   u64 = 1 << 9;   // 512
+//
+// === Moderation (bits 10-13) ===
+const MANAGE_MESSAGES:      u64 = 1 << 10;  // 1024
+const TIMEOUT_MEMBERS:      u64 = 1 << 11;  // 2048
+const KICK_MEMBERS:         u64 = 1 << 12;  // 4096
+const BAN_MEMBERS:          u64 = 1 << 13;  // 8192
+//
+// === Guild Management (bits 14-18) ===
+const MANAGE_CHANNELS:      u64 = 1 << 14;  // 16384
+const MANAGE_ROLES:         u64 = 1 << 15;  // 32768
+const VIEW_AUDIT_LOG:       u64 = 1 << 16;  // 65536
+const MANAGE_GUILD:         u64 = 1 << 17;  // 131072
+const TRANSFER_OWNERSHIP:   u64 = 1 << 18;  // 262144
+//
+// === Invites (bits 19-20) ===
+const CREATE_INVITE:        u64 = 1 << 19;  // 524288
+const MANAGE_INVITES:       u64 = 1 << 20;  // 1048576
+//
+// === Pages (bit 21) ===
+const MANAGE_PAGES:         u64 = 1 << 21;  // 2097152
+//
+// === Screen Sharing (bit 22) ===
+const SCREEN_SHARE:         u64 = 1 << 22;  // 4194304
+//
+// === Mentions (bit 23) ===
+const MENTION_EVERYONE:     u64 = 1 << 23;  // 8388608
+//
+// === Channel Visibility (bit 24) ===
+const VIEW_CHANNEL:         u64 = 1 << 24;  // 16777216
 ```
 
 ### Related Documentation

--- a/docs/developer-guide/agents/overview.md
+++ b/docs/developer-guide/agents/overview.md
@@ -14,7 +14,7 @@ flowchart LR
         direction TB
         WebView["WebView (Solid.js)"]
         RustCore["Rust Core"]
-        WebRTC["WebRTC (webrtc-rs)"]
+        WebRTC["WebRTC (webrtc)"]
         Audio["Audio (cpal, opus)"]
         
         RustCore --- WebRTC

--- a/docs/developer-guide/architecture/architecture.md
+++ b/docs/developer-guide/architecture/architecture.md
@@ -29,8 +29,8 @@ Instead of shipping an entire Chromium browser instance disguised as a chat app 
 ## <span style="color: #88C0D0;">3. The Audio Core: WebRTC</span>
 Kaiku utilizes deep, customized WebRTC implementations for all real-time media.
 
-- **Mesh vs. SFU**: For small private calls, Kaiku utilizes pure Peer-to-Peer (Mesh) routing. Audio travels directly from your PC to your friend's PC—literally zero intermediary servers (zero latency).
-- **Optimized Routing**: For larger server channels, Kaiku can intelligently switch to an SFU (Selective Forwarding Unit) model to save bandwidth, while maintaining our strict End-to-End Encryption protocols.
+- **SFU Architecture**: All voice calls — including 1:1 DM calls — are routed through a Selective Forwarding Unit (SFU). This simplifies the networking model, provides consistent latency behavior, and makes it straightforward to add participants or record diagnostics without renegotiating peer connections.
+- **End-to-End Encryption**: All voice streams are encrypted with DTLS-SRTP as the baseline, with a planned "Paranoid Mode" upgrade to MLS for true end-to-end encryption.
 
 ---
 *Detailed component diagrams and IPC (Inter-Process Communication) documentation will be added as the codebase matures.*

--- a/docs/developer-guide/architecture/overview.md
+++ b/docs/developer-guide/architecture/overview.md
@@ -25,7 +25,7 @@ flowchart TD
             direction LR
             Auth["Auth Service\n• Local Auth\n• OIDC/SSO\n• MFA\n• Sessions"]
             Chat["Chat Service\n• Channels\n• Messages\n• File Upload\n• E2EE"]
-            Voice["Voice Service (SFU)\n• webrtc-rs\n• Opus Codec\n• DTLS-SRTP"]
+            Voice["Voice Service (SFU)\n• webrtc crate\n• Opus Codec\n• DTLS-SRTP"]
         end
         
         Gateway <--> Auth
@@ -61,7 +61,7 @@ flowchart TD
             direction LR
             Views["Views\n• Login\n• Channels\n• Settings\n• Voice"]
             Comps["Components\n• Channel\n• Message\n• UserList\n• VoiceBar"]
-            Stores["Stores\n• Auth\n• Channels\n• Messages\n• Voice"]
+            Stores["Stores (30+)\n• Auth, Guilds, Channels\n• Messages, DMs, Threads\n• Voice, Call, Presence\n• Friends, Permissions\n• Settings, Search, E2EE"]
             Views --- Comps --- Stores
         end
 
@@ -70,7 +70,7 @@ flowchart TD
         subgraph Backend ["BACKEND (Rust)"]
             direction LR
             Audio["Audio\n• cpal\n• opus"]
-            WebRTC["WebRTC\n• webrtc-rs\n• Signaling\n• DTLS-SRTP"]
+            WebRTC["WebRTC\n• webrtc\n• Signaling\n• DTLS-SRTP"]
             Crypto["Crypto\n• vodozemac\n• Key Store\n• Keyring"]
             Net["Network\n• HTTP/REST\n• WebSocket\n• rustls"]
             Audio --- WebRTC --- Crypto --- Net
@@ -98,35 +98,49 @@ flowchart TD
 #### Auth Service
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                       AUTH SERVICE                               │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  Endpoints:                                                      │
-│  ──────────                                                      │
-│  POST   /auth/register          Local user registration          │
-│  POST   /auth/login             Login (local or SSO start)       │
-│  POST   /auth/logout            End session                      │
-│  POST   /auth/refresh           Renew access token               │
-│  GET    /auth/oidc/callback     SSO callback handler             │
-│  POST   /auth/mfa/setup         TOTP setup                       │
-│  POST   /auth/mfa/verify        TOTP verification                │
-│                                                                  │
-│  Internal Functions:                                             │
-│  ───────────────────                                             │
-│  • Password Hashing (Argon2id)                                   │
-│  • JWT Generation/Validation                                     │
-│  • Session Management (Valkey)                                   │
-│  • OIDC Provider Integration                                     │
-│  • JIT User Provisioning                                         │
-│                                                                  │
-│  Token Strategy:                                                 │
-│  ────────────────                                                │
-│  • Access Token:  JWT, 15 min validity                           │
-│  • Refresh Token: Opaque, 7 days, in Valkey                      │
-│  • Session:       Valkey with user metadata                      │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────┐
+│                          AUTH SERVICE                                 │
+├──────────────────────────────────────────────────────────────────────┤
+│                                                                       │
+│  Public Endpoints:                                                    │
+│  ─────────────────                                                    │
+│  POST   /auth/register                Local user registration         │
+│  POST   /auth/login                   Login (local + MFA)             │
+│  POST   /auth/refresh                 Renew access token              │
+│  GET    /auth/oidc/providers          List configured SSO providers   │
+│  GET    /auth/oidc/authorize/{prov}   Start SSO flow                  │
+│  GET    /auth/oidc/callback           SSO callback handler            │
+│  POST   /auth/forgot-password         Request password reset          │
+│  POST   /auth/reset-password          Complete password reset         │
+│                                                                       │
+│  Protected Endpoints (require JWT):                                   │
+│  ──────────────────────────────────                                   │
+│  POST   /auth/logout                  End session                     │
+│  GET    /auth/me                      Get user profile                │
+│  POST   /auth/me                      Update profile                  │
+│  POST   /auth/me/password             Change password                 │
+│  POST   /auth/me/avatar               Upload avatar                   │
+│  POST   /auth/mfa/setup               TOTP setup                      │
+│  POST   /auth/mfa/verify              TOTP verification               │
+│  POST   /auth/mfa/disable             Disable MFA                     │
+│  POST   /auth/mfa/backup-codes        Generate recovery codes         │
+│  GET    /auth/mfa/backup-codes/count  Remaining code count            │
+│                                                                       │
+│  Internal Functions:                                                  │
+│  ───────────────────                                                  │
+│  • Password Hashing (Argon2id)                                        │
+│  • JWT Generation/Validation (EdDSA/RS256)                            │
+│  • Session Management (Valkey)                                        │
+│  • OIDC Provider Integration (JIT Provisioning)                       │
+│  • MFA: TOTP + Backup Codes (Argon2id hashed)                        │
+│                                                                       │
+│  Token Strategy:                                                      │
+│  ────────────────                                                     │
+│  • Access Token:  JWT, 15 min validity                                │
+│  • Refresh Token: Opaque, 7 days, in Valkey                           │
+│  • Session:       Valkey with user metadata                           │
+│                                                                       │
+└──────────────────────────────────────────────────────────────────────┘
 ```
 
 #### Chat Service
@@ -135,10 +149,10 @@ flowchart TD
 flowchart TD
     subgraph Chat [CHAT SERVICE]
         direction TB
-        R1["REST:\nGET/POST/PATCH/DELETE /channels\nGET/POST/PATCH/DELETE /messages\nPOST /upload"]
-        W1["WS Events:\n→ message.new/edit/delete\n→ typing.start/stop\n→ presence.update\n→ channel.update"]
+        R1["REST:\nGET/POST/PATCH/DELETE /channels\nGET/POST/PATCH/DELETE /messages\nPOST /upload\nGET/POST /guilds, /dm, /search"]
+        W1["WS Events (50+ types):\n→ MessageNew/Edit/Delete\n→ ReactionAdd/Remove\n→ TypingStart/Stop\n→ PresenceUpdate\n→ VoiceUserJoined/Left\n→ CallStarted/Ended\n→ ScreenShareStarted/Stopped"]
         E1["E2EE:\n• Olm (1:1 DMs)\n• Megolm (Groups)"]
-        
+
         R1 ~~~ W1 ~~~ E1
     end
 ```
@@ -166,14 +180,37 @@ flowchart TD
 erDiagram
     users ||--o{ sessions : has
     users ||--o{ user_keys : owns
+    users ||--o{ friendships : has
+    users ||--o{ user_devices : registers
+
+    guilds ||--o{ guild_members : contains
+    guilds ||--o{ channels : has
+    guilds ||--o{ guild_roles : defines
+    guilds ||--o{ guild_invites : creates
+    guilds ||--o{ guild_emojis : owns
+    guilds ||--o{ pages : hosts
+
+    guild_roles ||--o{ guild_member_roles : "assigned via"
+    guild_members ||--o{ guild_member_roles : has
+    users ||--o{ guild_members : joins
+
     channels ||--o{ channel_members : contains
-    users ||--o{ channel_members : joins
-    roles ||--o{ channel_members : "assigned to"
+    channels ||--o{ channel_overrides : configured_by
     channels ||--o{ messages : contains
-    users ||--o{ messages : sends
     channels ||--o{ megolm_sessions : has
-    messages ||--o{ files : has
+
+    users ||--o{ messages : sends
+    messages ||--o{ message_reactions : has
+    messages ||--o{ file_attachments : has
+
+    users ||--o{ bot_applications : develops
+    bot_applications ||--o{ webhooks : configures
+    bot_applications ||--o{ slash_commands : registers
 ```
+
+> **Note:** This is a simplified overview. The full schema has 70+ tables including
+> telemetry, moderation, workspaces, DM state, admin/audit, and more.
+> See `server/migrations/` for the authoritative schema.
 
 ---
 
@@ -220,15 +257,15 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-    subgraph Docker ["Docker Network (voicechat_net)"]
+    subgraph Docker ["Docker Network (voicechat)"]
         Traefik["Traefik (Proxy)\nPort 443 / 80"]
-        Traefik --> API["kaiku-api (Auth + Chat)"]
-        Traefik --> Voice["kaiku-voice (SFU, UDP 10000-10100)"]
-        Traefik --> Web["kaiku-web (Static)"]
-        
-        API --> Valkey["Valkey"]
-        API --> Postgres["Postgres"]
+        Traefik --> Server["kaiku-server\n(Auth + Chat + Voice SFU)\nPort 8080 + UDP 10000-10100"]
+
+        Server --> Valkey["Valkey\n(Sessions, Presence, Pub/Sub)"]
+        Server --> Postgres["PostgreSQL\n(Persistent Data)"]
     end
+
+    OTel["OTel Collector\n(opt-in monitoring profile)"] -.-> Server
 ```
 
 ---

--- a/docs/developer-guide/development/setup.md
+++ b/docs/developer-guide/development/setup.md
@@ -9,7 +9,7 @@ see [CachyOS Multi-Project Development Environment Manual](cachyos-dev-environme
 
 ## Prerequisites
 
-- Docker and Docker Compose
+- Docker and Docker Compose (or Podman with `podman compose`)
 - Rust (latest stable)
 - Bun (install: `curl -fsSL https://bun.sh/install | bash`)
 - Node.js 18+ (required for Playwright tests)
@@ -26,7 +26,7 @@ docker compose -f docker-compose.dev.yml up -d
 ```
 
 This starts:
-- **PostgreSQL** on port 5433 (user: `voicechat`, password: `voicechat_dev_pass`)
+- **PostgreSQL** on port 5433 (user: `voicechat`, password: `voicechat_dev`)
 - **Valkey** on port 6379
 
 ### 2. Configure Environment
@@ -39,10 +39,10 @@ cp .env.example .env
 
 # Verify the database password matches docker-compose.dev.yml
 cat .env | grep DATABASE_URL
-# Should show: postgres://voicechat:voicechat_dev_pass@localhost:5433/voicechat
+# Should show: postgres://voicechat:voicechat_dev@localhost:5433/voicechat
 ```
 
-**Important**: The development database password is `voicechat_dev_pass` (as configured in `docker-compose.dev.yml`).
+**Important**: The development database password is `voicechat_dev` (as configured in `docker-compose.dev.yml`).
 
 ### 3. Run Database Migrations
 
@@ -97,16 +97,16 @@ If you see "password authentication failed for user 'voicechat'":
    ```bash
    # Check container environment
    docker exec voicechat-postgres-dev env | grep POSTGRES_PASSWORD
-   # Should show: POSTGRES_PASSWORD=voicechat_dev_pass
+   # Should show: POSTGRES_PASSWORD=voicechat_dev
 
    # Check .env file
    grep DATABASE_URL .env
-   # Should include: voicechat_dev_pass
+   # Should include: voicechat_dev
    ```
 
 3. If the password is wrong, update `.env`:
    ```
-   DATABASE_URL=postgres://voicechat:voicechat_dev_pass@localhost:5433/voicechat
+   DATABASE_URL=postgres://voicechat:voicechat_dev@localhost:5433/voicechat
    ```
 
 ### Port Already in Use
@@ -146,7 +146,7 @@ cargo run -p vc-server
 docker exec -it voicechat-postgres-dev psql -U voicechat -d voicechat
 
 # Or using psql from host
-PGPASSWORD=voicechat_dev_pass psql -h localhost -p 5433 -U voicechat -d voicechat
+PGPASSWORD=voicechat_dev psql -h localhost -p 5433 -U voicechat -d voicechat
 ```
 
 ## API Endpoints

--- a/docs/developer-guide/development/standards.md
+++ b/docs/developer-guide/development/standards.md
@@ -48,7 +48,7 @@ This document lists all open standards, protocols, and libraries used. The goal 
 |----------|------|
 | **Standard** | W3C WebRTC + IETF RFC 8825-8835 |
 | **Purpose** | Real-Time Audio/Video Communication |
-| **Rust Library** | `webrtc-rs` (webrtc = "0.11") |
+| **Rust Library** | `webrtc` (webrtc = "0.11") |
 | **License** | MIT/Apache 2.0 |
 | **Documentation** | https://webrtc.rs |
 
@@ -104,16 +104,16 @@ This document lists all open standards, protocols, and libraries used. The goal 
 
 | Codec | Standard | Rust Library | License | Status |
 |-------|----------|--------------|--------|--------|
-| VP8 | WebM Project | `vpx-rs` | BSD-3 | Recommended for compatibility |
-| VP9 | WebM Project | `vpx-rs` | BSD-3 | Better quality |
+| VP8 | WebM Project | `vpx-encode` | BSD-3 | Recommended for compatibility |
+| VP9 | WebM Project | `vpx-encode` | BSD-3 | Better quality |
 | AV1 | AOMedia | `rav1e` | BSD-2 | Future, still CPU-intensive |
 
 ### Audio Processing
 
 | Feature | Standard/Library | License |
 |---------|------------------|--------|
-| Echo Cancellation | WebRTC AEC (in webrtc-rs) | MIT/Apache 2.0 |
-| Noise Suppression | WebRTC NS (in webrtc-rs) | MIT/Apache 2.0 |
+| Echo Cancellation | WebRTC AEC (in webrtc) | MIT/Apache 2.0 |
+| Noise Suppression | WebRTC NS (in webrtc) | MIT/Apache 2.0 |
 | Audio I/O | `cpal` (0.17) | Apache 2.0 |
 
 ---
@@ -140,7 +140,7 @@ This document lists all open standards, protocols, and libraries used. The goal 
 |----------|------|
 | **Standard** | DTLS-SRTP (IETF RFC 5764) |
 | **Purpose** | Voice Stream Encryption |
-| **Implementation** | Part of `webrtc-rs` |
+| **Implementation** | Part of `webrtc` |
 
 ### Voice Encryption (Paranoid Mode, later)
 
@@ -494,7 +494,7 @@ pulldown-cmark = "0.13"
 validator = { version = "0.20", features = ["derive"] }
 
 # HTTP Client - MIT/Apache 2.0
-reqwest = { version = "0.13", features = ["json"] }
+reqwest = { version = "0.11", features = ["json"] }
 ```
 
 ### Client Backend (Cargo.toml)
@@ -571,12 +571,18 @@ allow = [
     "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "BSL-1.0",
     "ISC",
-    "Zlib",
-    "MPL-2.0",
-    "Unicode-DFS-2016",
     "CC0-1.0",
     "Unlicense",
+    "Zlib",
+    "Unicode-DFS-2016",
+    "Unicode-3.0",
+    "0BSD",
+    "CDLA-Permissive-2.0",
+    "MPL-2.0",
+    "OpenSSL",
+    "IJG",
 ]
 
 deny = [

--- a/docs/developer-guide/project/specification.md
+++ b/docs/developer-guide/project/specification.md
@@ -4,7 +4,7 @@
 
 A self-hosted voice and text chat platform for gaming communities, optimized for low latency, high voice quality, and maximum security.
 
-**Project Status:** Phase 4 (Advanced Features)
+**Project Status:** Phase 6 (Competitive Differentiators & Mastery)
 **License:** MIT OR Apache-2.0 (Dual License)
 **Target Audience:** Gaming communities, self-hosters, organizations with privacy requirements
 
@@ -34,7 +34,7 @@ A self-hosted voice and text chat platform for gaming communities, optimized for
 | Real-time Voice | 🔴 High | ✅ | WebRTC-based, Opus codec |
 | Push-to-Talk | 🔴 High | ✅ | Configurable hotkeys |
 | Voice Activation | 🔴 High | ✅ | Adjustable thresholds |
-| Noise Cancellation | 🔴 High | ✅ | RNNoise-based |
+| Noise Cancellation | 🔴 High | ✅ | Browser/WebRTC native |
 | Echo Cancellation | 🔴 High | ✅ | WebRTC AEC |
 | Volume Control | 🟡 Medium | ✅ | Adjustable per user |
 | Spatial Audio | 🟢 Low | ❌ | Interesting for gaming, later |
@@ -49,13 +49,13 @@ A self-hosted voice and text chat platform for gaming communities, optimized for
 | Emojis | 🔴 High | ✅ | Unicode + Custom Emojis |
 | @Mentions | 🔴 High | ✅ | User and channel mentions |
 | Image Uploads | 🔴 High | ✅ | With preview |
-| Link Previews | 🟡 Medium | ✅ | Open Graph meta tags |
+| Link Previews | 🟡 Medium | ❌ | Open Graph meta tags |
 | File Uploads | 🟡 Medium | ✅ | Configurable limits |
 | Message History | 🔴 High | ✅ | Searchable |
 | Edit Message | 🟡 Medium | ✅ | With edit indicator |
 | Delete Message | 🟡 Medium | ✅ | Soft-delete |
 | Threads | 🟢 Low | ✅ | Slack-style side threads with participant avatars, unread indicators |
-| Reactions | 🟢 Low | ❌ | Later |
+| Reactions | 🟢 Low | ✅ | Emoji picker with Unicode reactions |
 
 ### User Management
 
@@ -68,7 +68,7 @@ A self-hosted voice and text chat platform for gaming communities, optimized for
 | Roles & Permissions | 🔴 High | ✅ | Fine-grained per channel |
 | User Profiles | 🔴 High | ✅ | Avatar, status, bio |
 | Online Status | 🔴 High | ✅ | Online, Away, Busy, Offline |
-| Friends List | 🟡 Medium | ❌ | Later |
+| Friends List | 🟡 Medium | ✅ | Send/accept/block with online status |
 | Blocking | 🟡 Medium | ✅ | Users can block others |
 
 ### Server Structure


### PR DESCRIPTION
## Summary
- Fix broken path references, stale crate names (`webrtc-rs` → `webrtc`), wrong DB password (`voicechat_dev_pass` → `voicechat_dev`), and outdated feature flags across 10 documentation files
- Update 6 architecture diagrams (Auth endpoints, DB schema, deployment topology, Chat WS events, client stores, voice crate) to match actual codebase
- Rewrite channel permission bit reference to match all 25 permissions in `server/src/permissions/guild.rs`
- Consolidate duplicate CHANGELOG `[Unreleased]` sections (Added/Changed/Fixed/Security) with zero content loss

## Test plan
- [x] All CLAUDE.md path references resolve to existing files
- [x] `voicechat_dev_pass` returns zero grep results in setup.md
- [x] Permission bits match `server/src/permissions/guild.rs` (25 permissions, `u64` type)
- [x] reqwest versions match Cargo.toml (server: 0.11, client: 0.13)
- [x] deny.toml license list matches actual `deny.toml`
- [x] No duplicate `### Fixed` / `### Changed` / `### Added` headers in CHANGELOG `[Unreleased]`
- [x] No `webrtc-rs` references remain in modified files
- [x] No P2P mesh claims remain in architecture docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)