### PR TITLE
fix(api): recover stale export jobs in hourly cleanup loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -709,6 +709,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documentation formatting in admin handlers fixed
 - Orphaned password reset tokens cleaned up when email send fails (#130)
 - Removed unused `update_user_password` database function (#131)
+- Stale data export jobs stuck in `pending`/`processing` after server crash are now automatically recovered by the hourly cleanup loop, instead of only being recovered when the same user requests a new export (#265)
 
 ### Security
 - Enabled Content Security Policy (CSP) in Tauri webview to prevent script injection (#295)

--- a/server/src/governance/export.rs
+++ b/server/src/governance/export.rs
@@ -459,6 +459,25 @@ async fn build_export_archive(pool: &PgPool, user_id: Uuid) -> anyhow::Result<Ve
     Ok(buf)
 }
 
+/// Recover stale export jobs stuck in `pending`/`processing` after a server crash.
+///
+/// Jobs older than 1 hour are marked as `failed` so users can retry.
+/// Returns the number of recovered jobs.
+pub async fn recover_stale_export_jobs(pool: &PgPool) -> anyhow::Result<u64> {
+    let result = sqlx::query(
+        "UPDATE data_export_jobs
+         SET status = 'failed',
+             error_message = COALESCE(error_message, 'Job stale after restart; please retry'),
+             completed_at = NOW()
+         WHERE status IN ('pending', 'processing')
+           AND created_at < NOW() - INTERVAL '1 hour'",
+    )
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected())
+}
+
 /// Cleanup expired export jobs — delete S3 objects and mark as expired.
 pub async fn cleanup_expired_exports(pool: &PgPool, s3: &Option<S3Client>) -> anyhow::Result<()> {
     // If S3 is unavailable, skip cleanup entirely to prevent orphaning objects.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -224,6 +224,17 @@ async fn main() -> Result<()> {
             {
                 tracing::error!(error = %e, "Failed to cleanup expired data exports");
             }
+
+            // Recover stale export jobs stuck in pending/processing after crash
+            match vc_server::governance::export::recover_stale_export_jobs(&db_pool_clone).await {
+                Ok(count) if count > 0 => {
+                    tracing::info!(count, "Recovered stale export jobs");
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "Failed to recover stale export jobs");
+                }
+                _ => {}
+            }
         }
     });
 


### PR DESCRIPTION
## Summary
- Extract stale-recovery SQL from the per-user `request_export` handler into a standalone `recover_stale_export_jobs()` function in `governance/export.rs`
- Call it from the hourly background cleanup loop in `main.rs` so stale jobs are recovered even when no user requests a new export

Closes #265

## Test plan
- [ ] Verify `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings` passes
- [ ] Verify stale jobs (pending/processing with `created_at` > 1h ago) are marked `failed` after the hourly loop runs
- [ ] Verify non-stale jobs are not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)