### PR TITLE
feat(auth): add guild ban enforcement on join paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release note structure source: `docs/project/RELEASE_NOTES_TEMPLATE.md`
 
 ### Added
+- Guild bans — per-guild ban enforcement via `guild_bans` table; banned users are blocked from joining via discovery or invite codes, with support for temporary bans via `expires_at` (#272)
 - Admin Command Center observability backend with 7 read-only endpoints: system summary, metric trends, top routes, top errors, log search, trace search, and external tool links
 - Native telemetry ingestion pipeline capturing WARN/ERROR logs and span metadata to PostgreSQL for self-hosted observability without external dependencies
 - Admin Command Center UI with real-time health monitoring, trend charts (uPlot), top routes/errors tables, paginated log/trace search, and external tool deep-links

--- a/server/migrations/20260304000000_guild_bans.sql
+++ b/server/migrations/20260304000000_guild_bans.sql
@@ -1,0 +1,13 @@
+-- Guild-scoped bans (complements global_bans with per-guild enforcement)
+CREATE TABLE guild_bans (
+    guild_id UUID NOT NULL REFERENCES guilds(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    banned_by UUID REFERENCES users(id) ON DELETE SET NULL,
+    reason TEXT NOT NULL DEFAULT '',
+    expires_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (guild_id, user_id)
+);
+
+-- Partial index for efficient expiry checks (only rows with a set expiry)
+CREATE INDEX idx_guild_bans_expires ON guild_bans(expires_at) WHERE expires_at IS NOT NULL;

--- a/server/src/discovery/handlers.rs
+++ b/server/src/discovery/handlers.rs
@@ -289,6 +289,21 @@ pub async fn join_discoverable(
         ));
     }
 
+    // Check guild-specific ban
+    let guild_banned: bool = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM guild_bans WHERE guild_id = $1 AND user_id = $2 AND (expires_at IS NULL OR expires_at > NOW()))",
+    )
+    .bind(guild_id)
+    .bind(auth.id)
+    .fetch_one(&state.db)
+    .await?;
+
+    if guild_banned {
+        return Err(DiscoveryError::Forbidden(
+            "You are banned from this guild".to_string(),
+        ));
+    }
+
     let mut tx = state.db.begin().await?;
 
     // Serialize member joins per guild so limit checks are strict under concurrency.

--- a/server/src/guild/invites.rs
+++ b/server/src/guild/invites.rs
@@ -236,6 +236,19 @@ pub async fn join_via_invite(
         return Err(GuildError::Forbidden);
     }
 
+    // Check guild-specific ban
+    let guild_banned: bool = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM guild_bans WHERE guild_id = $1 AND user_id = $2 AND (expires_at IS NULL OR expires_at > NOW()))",
+    )
+    .bind(invite.guild_id)
+    .bind(auth.id)
+    .fetch_one(&state.db)
+    .await?;
+
+    if guild_banned {
+        return Err(GuildError::Forbidden);
+    }
+
     let mut tx = state.db.begin().await?;
 
     // Serialize member joins per guild so limit checks are strict under concurrency.


### PR DESCRIPTION
## Summary
- Add `guild_bans` table (migration) with composite PK `(guild_id, user_id)`, optional `expires_at` for temporary bans, `banned_by` tracking, and reason field
- Add guild ban check in `discovery/handlers.rs` (`join_discoverable`) after the existing global ban check
- Add guild ban check in `guild/invites.rs` (`join_via_invite`) after the existing global ban check

Closes #272

## Test plan
- [ ] Verify migration creates `guild_bans` table and partial index
- [ ] Verify `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings` passes
- [ ] Verify a guild-banned user cannot join via discovery
- [ ] Verify a guild-banned user cannot join via invite code
- [ ] Verify expired guild bans do not block joining

🤖 Generated with [Claude Code](https://claude.com/claude-code)