### PR TITLE
fix(api): use advisory locks for guild resource limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -711,6 +711,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Orphaned password reset tokens cleaned up when email send fails (#130)
 - Removed unused `update_user_password` database function (#131)
 - Stale data export jobs stuck in `pending`/`processing` after server crash are now automatically recovered by the hourly cleanup loop, instead of only being recovered when the same user requests a new export (#265)
+- Guild resource limits (channels, roles, emojis, bots) now use PostgreSQL advisory locks to prevent TOCTOU races under concurrent creation; invite join member limit check uses live `COUNT(*)` instead of denormalized `member_count` (#270)
 
 ### Security
 - Enabled Content Security Policy (CSP) in Tauri webview to prevent script injection (#295)

--- a/server/src/chat/channels.rs
+++ b/server/src/chat/channels.rs
@@ -170,27 +170,6 @@ pub async fn create(
         _ => return Err(ChannelError::Validation("Invalid channel type".to_string())),
     };
 
-    // For guild channels, verify membership and MANAGE_CHANNELS permission
-    if let Some(guild_id) = body.guild_id {
-        crate::permissions::require_guild_permission(
-            &state.db,
-            guild_id,
-            auth_user.id,
-            crate::permissions::GuildPermissions::MANAGE_CHANNELS,
-        )
-        .await
-        .map_err(|_| ChannelError::Forbidden)?;
-
-        // Check channel limit
-        let channel_count = crate::guild::limits::count_guild_channels(&state.db, guild_id).await?;
-        if channel_count >= state.config.max_channels_per_guild {
-            return Err(ChannelError::LimitExceeded(format!(
-                "Maximum number of channels per guild reached ({})",
-                state.config.max_channels_per_guild
-            )));
-        }
-    }
-
     // Validate voice channel user limit
     if channel_type == ChannelType::Voice {
         if let Some(limit) = body.user_limit {
@@ -202,19 +181,78 @@ pub async fn create(
         }
     }
 
-    let channel = db::create_channel(
-        &state.db,
-        db::CreateChannelParams {
-            name: &body.name,
-            channel_type: &channel_type,
-            category_id: body.category_id,
-            guild_id: body.guild_id,
-            topic: body.topic.as_deref(),
-            icon_url: None,
-            user_limit: body.user_limit,
-        },
-    )
-    .await?;
+    // For guild channels, use advisory lock to prevent TOCTOU race on channel limits.
+    let channel = if let Some(guild_id) = body.guild_id {
+        crate::permissions::require_guild_permission(
+            &state.db,
+            guild_id,
+            auth_user.id,
+            crate::permissions::GuildPermissions::MANAGE_CHANNELS,
+        )
+        .await
+        .map_err(|_| ChannelError::Forbidden)?;
+
+        let mut tx = state.db.begin().await?;
+
+        // Advisory lock seed 55 = channel_create (see db/mod.rs registry)
+        sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1::text, 55))")
+            .bind(guild_id)
+            .execute(&mut *tx)
+            .await?;
+
+        let channel_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM channels WHERE guild_id = $1")
+                .bind(guild_id)
+                .fetch_one(&mut *tx)
+                .await?;
+
+        if channel_count >= state.config.max_channels_per_guild {
+            return Err(ChannelError::LimitExceeded(format!(
+                "Maximum number of channels per guild reached ({})",
+                state.config.max_channels_per_guild
+            )));
+        }
+
+        let position: i32 = sqlx::query_scalar(
+            "SELECT COALESCE(MAX(position), 0) + 1 FROM channels WHERE category_id IS NOT DISTINCT FROM $1",
+        )
+        .bind(body.category_id)
+        .fetch_one(&mut *tx)
+        .await?;
+
+        let channel = sqlx::query_as::<_, db::Channel>(
+            r"INSERT INTO channels (name, channel_type, category_id, guild_id, topic, icon_url, user_limit, position)
+              VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+              RETURNING id, name, channel_type, category_id, guild_id, topic, icon_url, user_limit, position, max_screen_shares, created_at, updated_at",
+        )
+        .bind(&body.name)
+        .bind(&channel_type)
+        .bind(body.category_id)
+        .bind(body.guild_id)
+        .bind(body.topic.as_deref())
+        .bind(None::<&str>) // icon_url
+        .bind(body.user_limit)
+        .bind(position)
+        .fetch_one(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        channel
+    } else {
+        db::create_channel(
+            &state.db,
+            db::CreateChannelParams {
+                name: &body.name,
+                channel_type: &channel_type,
+                category_id: body.category_id,
+                guild_id: body.guild_id,
+                topic: body.topic.as_deref(),
+                icon_url: None,
+                user_limit: body.user_limit,
+            },
+        )
+        .await?
+    };
 
     Ok((StatusCode::CREATED, Json(channel.into())))
 }

--- a/server/src/db/mod.rs
+++ b/server/src/db/mod.rs
@@ -13,7 +13,11 @@
 //! - 53 = `guild_member_join` (per-guild join serialization)
 //!   - Called from: `server/src/guild/invites.rs` (invite join path)
 //!   - Called from: `server/src/discovery/handlers.rs` (discovery join path)
+//! - 55 = `channel_create` (per-guild channel creation limit)
+//! - 57 = `role_create` (per-guild role creation limit)
+//! - 59 = `emoji_create` (per-guild emoji creation limit)
 //! - 61 = `page_create` (per-guild page creation limit)
+//! - 63 = `bot_install` (per-guild bot installation limit)
 
 mod models;
 mod queries;

--- a/server/src/guild/emojis.rs
+++ b/server/src/guild/emojis.rs
@@ -248,15 +248,6 @@ pub async fn create_emoji(
         return Err(EmojiError::GuildNotFound);
     }
 
-    // Check emoji limit before processing multipart upload
-    let emoji_count = super::limits::count_guild_emojis(&state.db, guild_id).await?;
-    if emoji_count >= state.config.max_emojis_per_guild {
-        return Err(EmojiError::LimitExceeded(format!(
-            "Maximum number of emojis per guild reached ({})",
-            state.config.max_emojis_per_guild
-        )));
-    }
-
     let s3 = state
         .s3
         .as_ref()
@@ -265,7 +256,7 @@ pub async fn create_emoji(
     let mut name: Option<String> = None;
     let mut file_data: Option<Vec<u8>> = None;
 
-    // Parse multipart
+    // Parse multipart (outside lock — no DB interaction needed)
     while let Ok(Some(field)) = multipart.next_field().await {
         let field_name = field.name().unwrap_or_default().to_string();
         match field_name.as_str() {
@@ -324,7 +315,29 @@ pub async fn create_emoji(
 
     let s3_key = format!("emojis/{guild_id}/{emoji_id}.{extension}");
 
-    // Upload to S3
+    // Advisory lock seed 59 = emoji_create (see db/mod.rs registry).
+    // Lock is held during S3 upload but emoji files are small (<256KB).
+    let mut tx = state.db.begin().await?;
+
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1::text, 59))")
+        .bind(guild_id)
+        .execute(&mut *tx)
+        .await?;
+
+    let emoji_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM guild_emojis WHERE guild_id = $1")
+            .bind(guild_id)
+            .fetch_one(&mut *tx)
+            .await?;
+
+    if emoji_count >= state.config.max_emojis_per_guild {
+        return Err(EmojiError::LimitExceeded(format!(
+            "Maximum number of emojis per guild reached ({})",
+            state.config.max_emojis_per_guild
+        )));
+    }
+
+    // Upload to S3 (inside lock — acceptable for small emoji files)
     s3.upload(&s3_key, file_data, content_type)
         .await
         .map_err(|e| EmojiError::Storage(e.to_string()))?;
@@ -342,11 +355,13 @@ pub async fn create_emoji(
     .bind(emoji_id)
     .bind(guild_id)
     .bind(&req.name)
-    .bind(&image_url) // Store the proxy URL (placeholder)
+    .bind(&image_url)
     .bind(animated)
     .bind(auth_user.id)
-    .fetch_one(&state.db)
+    .fetch_one(&mut *tx)
     .await?;
+
+    tx.commit().await?;
 
     // Broadcast update
     // Re-query full list for broadcast

--- a/server/src/guild/handlers.rs
+++ b/server/src/guild/handlers.rs
@@ -789,15 +789,7 @@ pub async fn add_bot_to_guild(
                 other => GuildError::Permission(other),
             })?;
 
-    // Check bot installation limit
-    let bot_count = super::limits::count_guild_bots(&state.db, guild_id).await?;
-    if bot_count >= state.config.max_bots_per_guild {
-        return Err(GuildError::LimitExceeded(format!(
-            "Maximum number of bots per guild reached ({})",
-            state.config.max_bots_per_guild
-        )));
-    }
-
+    // Validate bot exists and is installable (outside lock)
     let bot_exists = sqlx::query!(
         "SELECT id FROM users WHERE id = $1 AND is_bot = true",
         bot_id
@@ -827,18 +819,37 @@ pub async fn add_bot_to_guild(
 
     let application_id = app.id;
 
-    sqlx::query!(
-        r#"
-        INSERT INTO guild_bot_installations (guild_id, application_id, installed_by)
-        VALUES ($1, $2, $3)
-        ON CONFLICT (guild_id, application_id) DO NOTHING
-        "#,
-        guild_id,
-        application_id,
-        auth.id
+    // Advisory lock seed 63 = bot_install (see db/mod.rs registry)
+    let mut tx = state.db.begin().await?;
+
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1::text, 63))")
+        .bind(guild_id)
+        .execute(&mut *tx)
+        .await?;
+
+    let bot_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM guild_bot_installations WHERE guild_id = $1")
+            .bind(guild_id)
+            .fetch_one(&mut *tx)
+            .await?;
+
+    if bot_count >= state.config.max_bots_per_guild {
+        return Err(GuildError::LimitExceeded(format!(
+            "Maximum number of bots per guild reached ({})",
+            state.config.max_bots_per_guild
+        )));
+    }
+
+    sqlx::query(
+        "INSERT INTO guild_bot_installations (guild_id, application_id, installed_by) VALUES ($1, $2, $3) ON CONFLICT (guild_id, application_id) DO NOTHING",
     )
-    .execute(&state.db)
+    .bind(guild_id)
+    .bind(application_id)
+    .bind(auth.id)
+    .execute(&mut *tx)
     .await?;
+
+    tx.commit().await?;
 
     Ok(StatusCode::NO_CONTENT)
 }

--- a/server/src/guild/invites.rs
+++ b/server/src/guild/invites.rs
@@ -285,10 +285,9 @@ pub async fn join_via_invite(
         }));
     }
 
-    // Check member limit (best-effort; concurrent joins may overshoot by a small
-    // bounded amount due to TOCTOU, but the denormalized member_count self-corrects).
+    // Live count inside advisory lock (seed 53) for strict limit enforcement.
     let member_count: i64 =
-        sqlx::query_scalar("SELECT member_count::bigint FROM guilds WHERE id = $1")
+        sqlx::query_scalar("SELECT COUNT(*) FROM guild_members WHERE guild_id = $1")
             .bind(invite.guild_id)
             .fetch_one(&mut *tx)
             .await?;

--- a/server/src/guild/roles.rs
+++ b/server/src/guild/roles.rs
@@ -207,15 +207,6 @@ pub async fn create_role(
                 other => RoleError::Permission(other),
             })?;
 
-    // Check role limit
-    let role_count = super::limits::count_guild_roles(&state.db, guild_id).await?;
-    if role_count >= state.config.max_roles_per_guild {
-        return Err(RoleError::LimitExceeded(format!(
-            "Maximum number of roles per guild reached ({})",
-            state.config.max_roles_per_guild
-        )));
-    }
-
     // Check if trying to grant permissions we don't have
     let new_perms = GuildPermissions::from_bits_truncate(body.permissions.unwrap_or(0));
     let actor_position = if ctx.is_owner {
@@ -230,15 +221,37 @@ pub async fn create_role(
         Some(new_perms),
     )?;
 
-    // Get next position (higher number = lower rank)
-    let max_position: (i32,) =
-        sqlx::query_as("SELECT COALESCE(MAX(position), 0) FROM guild_roles WHERE guild_id = $1")
+    let mut tx = state.db.begin().await?;
+
+    // Advisory lock seed 57 = role_create (see db/mod.rs registry)
+    sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1::text, 57))")
+        .bind(guild_id)
+        .execute(&mut *tx)
+        .await?;
+
+    // Atomic count check inside lock
+    let role_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM guild_roles WHERE guild_id = $1")
             .bind(guild_id)
-            .fetch_one(&state.db)
+            .fetch_one(&mut *tx)
+            .await?;
+
+    if role_count >= state.config.max_roles_per_guild {
+        return Err(RoleError::LimitExceeded(format!(
+            "Maximum number of roles per guild reached ({})",
+            state.config.max_roles_per_guild
+        )));
+    }
+
+    // Get next position (higher number = lower rank)
+    let max_position: i32 =
+        sqlx::query_scalar("SELECT COALESCE(MAX(position), 0) FROM guild_roles WHERE guild_id = $1")
+            .bind(guild_id)
+            .fetch_one(&mut *tx)
             .await?;
 
     let role_id = Uuid::now_v7();
-    let position = max_position.0 + 1;
+    let position = max_position + 1;
 
     let role = sqlx::query_as::<
         _,
@@ -265,8 +278,10 @@ pub async fn create_role(
     .bind(&body.color)
     .bind(new_perms.bits() as i64)
     .bind(position)
-    .fetch_one(&state.db)
+    .fetch_one(&mut *tx)
     .await?;
+
+    tx.commit().await?;
 
     Ok(Json(RoleResponse {
         id: role.0,


### PR DESCRIPTION
## Summary
- Wrap channel creation in a transaction with advisory lock (seed 55) for guild channels — non-guild channels (DMs) use the existing non-transactional path
- Wrap role creation in a transaction with advisory lock (seed 57) — count check + position calc + insert all inside the lock
- Wrap emoji creation in a transaction with advisory lock (seed 59) — lock held through S3 upload (acceptable for small emoji files <256KB)
- Wrap bot installation in a transaction with advisory lock (seed 63)
- Fix invite join to use live `COUNT(*)` from `guild_members` instead of denormalized `member_count` from `guilds` table
- Update advisory lock seed registry in `db/mod.rs`

Closes #270

## Test plan
- [ ] Verify `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings` passes
- [ ] Verify channel/role/emoji/bot creation still works correctly under normal usage
- [ ] Verify concurrent creation requests are properly serialized and don't exceed limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)