### PR TITLE
fix(api): add error context to export try_clone and fs::read

### DIFF
--- a/server/src/governance/export.rs
+++ b/server/src/governance/export.rs
@@ -228,7 +228,11 @@ pub async fn process_export_job(
 async fn build_export_archive(pool: &PgPool, user_id: Uuid) -> anyhow::Result<Vec<u8>> {
     let tmp = tempfile::NamedTempFile::new()
         .context("Failed to create temp file for export archive")?;
-    let mut zip = ZipWriter::new(std::io::BufWriter::new(tmp.as_file().try_clone()?));
+    let mut zip = ZipWriter::new(std::io::BufWriter::new(
+        tmp.as_file()
+            .try_clone()
+            .context("Failed to clone temp file handle for ZIP writer")?,
+    ));
     let options = SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
 
     // 1. Profile
@@ -477,7 +481,8 @@ async fn build_export_archive(pool: &PgPool, user_id: Uuid) -> anyhow::Result<Ve
         .map_err(|e| anyhow::anyhow!("Failed to finalize export ZIP archive: {e}"))?;
 
     // Read finished archive from temp file for S3 upload
-    let archive_data = std::fs::read(tmp.path())?;
+    let archive_data = std::fs::read(tmp.path())
+        .context("Failed to read completed export archive from temp file")?;
     Ok(archive_data)
 }
 


### PR DESCRIPTION
## Summary
- Add `.context()` to `tmp.as_file().try_clone()` for clearer diagnostics on file descriptor exhaustion
- Add `.context()` to `std::fs::read(tmp.path())` for clearer diagnostics on temp file read failure

Both calls were using bare `?` while surrounding IO operations already had context annotations, creating an inconsistency in the error chain.

## Test plan
- [x] `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)