### PR TITLE
fix(api): log export email notification failures (#324)

### DIFF
--- a/server/src/governance/export.rs
+++ b/server/src/governance/export.rs
@@ -189,13 +189,38 @@ pub async fn process_export_job(
                 "Export job completed"
             );
 
-            // Send email notification if configured
+            // Send email notification if configured (best-effort, non-fatal)
             if let Some(email) = email_service {
-                if let Ok(Some(user)) = crate::db::find_user_by_id(pool, user_id).await {
-                    if let Some(user_email) = &user.email {
-                        let _ = email
-                            .send_data_export_ready(user_email, &user.username)
-                            .await;
+                match crate::db::find_user_by_id(pool, user_id).await {
+                    Ok(Some(user)) => {
+                        if let Some(user_email) = &user.email {
+                            if let Err(e) = email
+                                .send_data_export_ready(user_email, &user.username)
+                                .await
+                            {
+                                tracing::warn!(
+                                    job_id = %job_id,
+                                    user_id = %user_id,
+                                    error = %e,
+                                    "Failed to send data export notification email"
+                                );
+                            }
+                        }
+                    }
+                    Ok(None) => {
+                        tracing::warn!(
+                            job_id = %job_id,
+                            user_id = %user_id,
+                            "Cannot send export notification: user not found"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            job_id = %job_id,
+                            user_id = %user_id,
+                            error = %e,
+                            "Failed to look up user for export notification email"
+                        );
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Replace silent `let _ =` email send with `if let Err(e)` + `tracing::warn!`
- Replace `if let Ok(Some(user))` with full `match` that logs DB errors and missing users
- Export job still returns `Ok(())` — email is best-effort, non-fatal

Closes #324

## Test plan
- [x] `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings` passes
- [ ] Verify warn-level logs appear when email service is misconfigured

🤖 Generated with [Claude Code](https://claude.com/claude-code)