### PR TITLE
perf(api): stream export archive to S3 instead of loading into memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -481,7 +481,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - User-friendly error messages showing both file size and limit in human-readable format (KB/MB)
 
 ### Changed
-- Data export now writes the ZIP archive to a temp file instead of building it entirely in memory, and caps high-cardinality sections (messages: 500K, reactions: 500K, attachments: 100K, audit log: 100K rows) to prevent OOM on large accounts (#266)
+- Data export now writes the ZIP archive to a temp file and streams it directly to S3 instead of loading the entire archive into memory, and caps high-cardinality sections (messages: 500K, reactions: 500K, attachments: 100K, audit log: 100K rows) to prevent OOM on large accounts (#266, #322)
 - Rebranded from VoiceChat/Canis to Kaiku across the entire application — window title, TOTP authenticator issuer, OpenAPI docs, Tauri identifier, and all user-facing strings (#302)
 - Simplified admin session elevation to single-click confirmation (MFA verification deferred)
 - Renamed `kaiku_auth_attempts_total` metric to `kaiku_auth_login_attempts_total` to match observability contract (#285)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,6 +871,7 @@ dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
+ "futures-core",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
@@ -883,6 +884,8 @@ dependencies = [
  "ryu",
  "serde",
  "time",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -10016,6 +10019,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-s3",
  "aws-smithy-async",
+ "aws-smithy-types",
  "axum",
  "axum-tracing-opentelemetry",
  "base64 0.22.1",
@@ -10051,6 +10055,7 @@ dependencies = [
  "serial_test",
  "sha2",
  "sqlx",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ tracing-opentelemetry-instrumentation-sdk = { version = "0.28" }
 aws-sdk-s3 = { version = "1", default-features = false, features = ["behavior-version-latest", "rustls"] }
 aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rustls"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }
+aws-smithy-types = { version = "1", features = ["rt-tokio"] }
 
 # API Docs
 utoipa = { version = "5", features = ["axum_extras", "chrono", "uuid"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -76,6 +76,7 @@ tracing-opentelemetry-instrumentation-sdk.workspace = true
 aws-sdk-s3.workspace = true
 aws-config.workspace = true
 aws-smithy-async.workspace = true
+aws-smithy-types.workspace = true
 
 # API
 utoipa.workspace = true

--- a/server/src/chat/s3.rs
+++ b/server/src/chat/s3.rs
@@ -3,6 +3,7 @@
 //! Handles S3-compatible storage for file uploads.
 //! Supports any S3-compatible backend: AWS S3, `RustFS`, Backblaze B2, Cloudflare R2.
 
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -143,6 +144,46 @@ impl S3Client {
             .map_err(|e| S3Error::Upload(e.to_string()))?;
 
         Ok(())
+    }
+
+    /// Upload a file to S3 by streaming directly from a file path.
+    ///
+    /// Unlike [`upload`], this never loads the entire file into memory.
+    /// Uses a 5-minute timeout since export archives can be large.
+    ///
+    /// Returns the file size in bytes.
+    pub async fn upload_from_path(
+        &self,
+        key: &str,
+        path: &Path,
+        content_type: &str,
+    ) -> Result<u64, S3Error> {
+        let file_size = std::fs::metadata(path)
+            .map_err(|e| S3Error::Upload(format!("Failed to read file metadata: {e}")))?
+            .len();
+
+        let body = ByteStream::from_path(path)
+            .await
+            .map_err(|e| S3Error::Upload(format!("Failed to open file for streaming: {e}")))?;
+
+        let upload_future = self
+            .client
+            .put_object()
+            .bucket(&self.bucket)
+            .key(key)
+            .body(body)
+            .content_type(content_type)
+            .content_length(file_size as i64)
+            .send();
+
+        tokio::time::timeout(Duration::from_secs(300), upload_future)
+            .await
+            .map_err(|_| {
+                S3Error::Upload("S3 streaming upload timed out after 5 minutes".to_string())
+            })?
+            .map_err(|e| S3Error::Upload(e.to_string()))?;
+
+        Ok(file_size)
     }
 
     /// Generate a presigned URL for downloading a file.

--- a/server/src/governance/export.rs
+++ b/server/src/governance/export.rs
@@ -159,12 +159,13 @@ pub async fn process_export_job(
         .await?;
 
     match build_export_archive(pool, user_id).await {
-        Ok(archive_data) => {
-            let file_size = archive_data.len() as i64;
+        Ok(tmp) => {
             let s3_key = format!("exports/{user_id}/{job_id}.zip");
 
-            // Upload to S3
-            s3.upload(&s3_key, archive_data, "application/zip").await?;
+            // Stream archive directly to S3 without loading into memory
+            let file_size = s3
+                .upload_from_path(&s3_key, tmp.path(), "application/zip")
+                .await? as i64;
 
             let expires_at = Utc::now() + Duration::days(7);
 
@@ -248,11 +249,14 @@ pub async fn process_export_job(
 /// memory during construction (each section is dropped after serialization).
 ///
 /// High-cardinality sections (messages, reactions, attachments, audit log) are
-/// capped with `LIMIT` to prevent OOM on large accounts. The finished archive
-/// is read back into memory for S3 upload.
-async fn build_export_archive(pool: &PgPool, user_id: Uuid) -> anyhow::Result<Vec<u8>> {
-    let tmp = tempfile::NamedTempFile::new()
-        .context("Failed to create temp file for export archive")?;
+/// capped with `LIMIT` to prevent OOM on large accounts. Returns the temp file
+/// for streaming upload to S3.
+async fn build_export_archive(
+    pool: &PgPool,
+    user_id: Uuid,
+) -> anyhow::Result<tempfile::NamedTempFile> {
+    let tmp =
+        tempfile::NamedTempFile::new().context("Failed to create temp file for export archive")?;
     let mut zip = ZipWriter::new(std::io::BufWriter::new(
         tmp.as_file()
             .try_clone()
@@ -291,7 +295,11 @@ async fn build_export_archive(pool: &PgPool, user_id: Uuid) -> anyhow::Result<Ve
     .fetch_all(pool)
     .await?;
 
-    tracing::info!(section = "messages", rows = messages.len(), "Export section collected");
+    tracing::info!(
+        section = "messages",
+        rows = messages.len(),
+        "Export section collected"
+    );
     zip.start_file("messages.json", options)?;
     serde_json::to_writer_pretty(&mut zip, &messages)?;
     drop(messages);
@@ -394,7 +402,11 @@ async fn build_export_archive(pool: &PgPool, user_id: Uuid) -> anyhow::Result<Ve
     .fetch_all(pool)
     .await?;
 
-    tracing::info!(section = "reactions", rows = reactions.len(), "Export section collected");
+    tracing::info!(
+        section = "reactions",
+        rows = reactions.len(),
+        "Export section collected"
+    );
     zip.start_file("reactions.json", options)?;
     serde_json::to_writer_pretty(&mut zip, &reactions)?;
     drop(reactions);
@@ -412,7 +424,11 @@ async fn build_export_archive(pool: &PgPool, user_id: Uuid) -> anyhow::Result<Ve
     .fetch_all(pool)
     .await?;
 
-    tracing::info!(section = "attachments", rows = attachments.len(), "Export section collected");
+    tracing::info!(
+        section = "attachments",
+        rows = attachments.len(),
+        "Export section collected"
+    );
     zip.start_file("attachments.json", options)?;
     serde_json::to_writer_pretty(&mut zip, &attachments)?;
     drop(attachments);
@@ -472,7 +488,11 @@ async fn build_export_archive(pool: &PgPool, user_id: Uuid) -> anyhow::Result<Ve
     .fetch_all(pool)
     .await?;
 
-    tracing::info!(section = "audit_log", rows = audit_log.len(), "Export section collected");
+    tracing::info!(
+        section = "audit_log",
+        rows = audit_log.len(),
+        "Export section collected"
+    );
     zip.start_file("audit_log.json", options)?;
     serde_json::to_writer_pretty(&mut zip, &audit_log)?;
     drop(audit_log);
@@ -502,13 +522,17 @@ async fn build_export_archive(pool: &PgPool, user_id: Uuid) -> anyhow::Result<Ve
     zip.start_file("manifest.json", options)?;
     serde_json::to_writer_pretty(&mut zip, &manifest)?;
 
-    zip.finish()
+    let buf_writer = zip
+        .finish()
         .map_err(|e| anyhow::anyhow!("Failed to finalize export ZIP archive: {e}"))?;
 
-    // Read finished archive from temp file for S3 upload
-    let archive_data = std::fs::read(tmp.path())
-        .context("Failed to read completed export archive from temp file")?;
-    Ok(archive_data)
+    // Flush BufWriter and sync to disk before handing path to ByteStream
+    drop(buf_writer);
+    tmp.as_file()
+        .sync_all()
+        .context("Failed to sync export archive to disk")?;
+
+    Ok(tmp)
 }
 
 /// Recover stale export jobs stuck in `pending`/`processing` after a server crash.

--- a/server/src/guild/roles.rs
+++ b/server/src/guild/roles.rs
@@ -244,11 +244,12 @@ pub async fn create_role(
     }
 
     // Get next position (higher number = lower rank)
-    let max_position: i32 =
-        sqlx::query_scalar("SELECT COALESCE(MAX(position), 0) FROM guild_roles WHERE guild_id = $1")
-            .bind(guild_id)
-            .fetch_one(&mut *tx)
-            .await?;
+    let max_position: i32 = sqlx::query_scalar(
+        "SELECT COALESCE(MAX(position), 0) FROM guild_roles WHERE guild_id = $1",
+    )
+    .bind(guild_id)
+    .fetch_one(&mut *tx)
+    .await?;
 
     let role_id = Uuid::now_v7();
     let position = max_position + 1;


### PR DESCRIPTION
## Summary
- Add `S3Client::upload_from_path()` using `ByteStream::from_path()` to stream files directly to S3 without loading the entire archive into RAM
- Change `build_export_archive()` to return the `NamedTempFile` handle instead of `Vec<u8>`, eliminating the final `std::fs::read()` that was the last remaining full-archive memory copy
- Add `aws-smithy-types` dependency with `rt-tokio` feature to enable `ByteStream::from_path`

Closes #322

## Test plan
- [ ] Verify `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings` passes
- [ ] Verify `cargo fmt --check` passes
- [ ] Request a GDPR data export and confirm the archive downloads correctly
- [ ] Monitor server memory during export to confirm reduced peak usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)