### PR TITLE
fix(api): address review findings from PRs #316-#328

### DIFF
--- a/server/src/chat/s3.rs
+++ b/server/src/chat/s3.rs
@@ -158,13 +158,20 @@ impl S3Client {
         path: &Path,
         content_type: &str,
     ) -> Result<u64, S3Error> {
-        let file_size = std::fs::metadata(path)
+        let file_size = tokio::fs::metadata(path)
+            .await
             .map_err(|e| S3Error::Upload(format!("Failed to read file metadata: {e}")))?
             .len();
 
         let body = ByteStream::from_path(path)
             .await
             .map_err(|e| S3Error::Upload(format!("Failed to open file for streaming: {e}")))?;
+
+        let content_length: i64 = file_size.try_into().map_err(|_| {
+            S3Error::Upload(format!(
+                "File too large: {file_size} bytes exceeds i64 maximum"
+            ))
+        })?;
 
         let upload_future = self
             .client
@@ -173,7 +180,7 @@ impl S3Client {
             .key(key)
             .body(body)
             .content_type(content_type)
-            .content_length(file_size as i64)
+            .content_length(content_length)
             .send();
 
         tokio::time::timeout(Duration::from_secs(300), upload_future)

--- a/server/src/db/mod.rs
+++ b/server/src/db/mod.rs
@@ -8,8 +8,11 @@
 //! Seeds are allocated per lock site:
 //!
 //! - 41 = `workspace_create` (per-user workspace creation limit)
+//!   - Called from: `server/src/workspaces/handlers.rs`
 //! - 43 = `workspace_entry` (per-workspace entry creation limit)
+//!   - Called from: `server/src/workspaces/handlers.rs`
 //! - 51 = `guild_create` (per-user guild creation limit)
+//!   - Called from: `server/src/guild/handlers.rs`
 //! - 53 = `guild_member_join` (per-guild join serialization)
 //!   - Called from: `server/src/guild/invites.rs` (invite join path)
 //!   - Called from: `server/src/discovery/handlers.rs` (discovery join path)

--- a/server/src/governance/export.rs
+++ b/server/src/governance/export.rs
@@ -2,6 +2,7 @@
 //!
 //! Gathers user data from all tables into a versioned JSON archive and uploads to S3.
 
+use std::io::Write;
 use std::sync::Arc;
 
 use anyhow::Context;
@@ -15,6 +16,15 @@ use zip::ZipWriter;
 use crate::chat::S3Client;
 use crate::email::EmailService;
 
+/// Maximum number of messages included in a data export.
+const EXPORT_CAP_MESSAGES: i64 = 500_000;
+/// Maximum number of reactions included in a data export.
+const EXPORT_CAP_REACTIONS: i64 = 500_000;
+/// Maximum number of attachment metadata rows included in a data export.
+const EXPORT_CAP_ATTACHMENTS: i64 = 100_000;
+/// Maximum number of audit log entries included in a data export.
+const EXPORT_CAP_AUDIT_LOG: i64 = 100_000;
+
 /// Versioned export manifest.
 #[derive(Serialize)]
 struct ExportManifest {
@@ -22,6 +32,7 @@ struct ExportManifest {
     exported_at: String,
     user_id: String,
     sections: Vec<&'static str>,
+    truncated_sections: Vec<&'static str>,
 }
 
 /// User profile data for export.
@@ -163,9 +174,11 @@ pub async fn process_export_job(
             let s3_key = format!("exports/{user_id}/{job_id}.zip");
 
             // Stream archive directly to S3 without loading into memory
-            let file_size = s3
+            let file_size: i64 = s3
                 .upload_from_path(&s3_key, tmp.path(), "application/zip")
-                .await? as i64;
+                .await?
+                .try_into()
+                .context("Export archive too large")?;
 
             let expires_at = Utc::now() + Duration::days(7);
 
@@ -246,11 +259,12 @@ pub async fn process_export_job(
 }
 
 /// Build the export ZIP archive, writing sections to a temp file to reduce peak
-/// memory during construction (each section is dropped after serialization).
+/// memory during construction. High-cardinality sections (messages, reactions,
+/// attachments, audit log) are explicitly dropped after serialization to limit
+/// peak heap usage.
 ///
-/// High-cardinality sections (messages, reactions, attachments, audit log) are
-/// capped with `LIMIT` to prevent OOM on large accounts. Returns the temp file
-/// for streaming upload to S3.
+/// Those same sections are capped with `LIMIT` to prevent OOM on large accounts.
+/// Returns the temp file for streaming upload to S3.
 async fn build_export_archive(
     pool: &PgPool,
     user_id: Uuid,
@@ -283,23 +297,37 @@ async fn build_export_archive(
     zip.start_file("profile.json", options)?;
     serde_json::to_writer_pretty(&mut zip, &profile)?;
 
-    // 2. Messages (non-deleted, includes encrypted) — capped at 500K rows
+    // 2. Messages (non-deleted, includes encrypted) — capped
+    let mut truncated_sections: Vec<&'static str> = Vec::new();
+
     let messages: Vec<ExportMessage> = sqlx::query_as(
         "SELECT id, channel_id, content, encrypted, created_at, edited_at
          FROM messages
          WHERE user_id = $1 AND deleted_at IS NULL
          ORDER BY created_at ASC
-         LIMIT 500000",
+         LIMIT $2",
     )
     .bind(user_id)
+    .bind(EXPORT_CAP_MESSAGES)
     .fetch_all(pool)
     .await?;
 
-    tracing::info!(
-        section = "messages",
-        rows = messages.len(),
-        "Export section collected"
-    );
+    if messages.len() as i64 >= EXPORT_CAP_MESSAGES {
+        truncated_sections.push("messages");
+        tracing::warn!(
+            section = "messages",
+            rows = messages.len(),
+            user_id = %user_id,
+            "Export section truncated at cap"
+        );
+    } else {
+        tracing::info!(
+            section = "messages",
+            rows = messages.len(),
+            user_id = %user_id,
+            "Export section collected"
+        );
+    }
     zip.start_file("messages.json", options)?;
     serde_json::to_writer_pretty(&mut zip, &messages)?;
     drop(messages);
@@ -390,45 +418,69 @@ async fn build_export_archive(
     zip.start_file("blocked_users.json", options)?;
     serde_json::to_writer_pretty(&mut zip, &blocked_users)?;
 
-    // 8. Reactions — capped at 500K rows
+    // 8. Reactions — capped
     let reactions: Vec<ExportReaction> = sqlx::query_as(
         "SELECT id, message_id, emoji, created_at
          FROM message_reactions
          WHERE user_id = $1
          ORDER BY created_at ASC
-         LIMIT 500000",
+         LIMIT $2",
     )
     .bind(user_id)
+    .bind(EXPORT_CAP_REACTIONS)
     .fetch_all(pool)
     .await?;
 
-    tracing::info!(
-        section = "reactions",
-        rows = reactions.len(),
-        "Export section collected"
-    );
+    if reactions.len() as i64 >= EXPORT_CAP_REACTIONS {
+        truncated_sections.push("reactions");
+        tracing::warn!(
+            section = "reactions",
+            rows = reactions.len(),
+            user_id = %user_id,
+            "Export section truncated at cap"
+        );
+    } else {
+        tracing::info!(
+            section = "reactions",
+            rows = reactions.len(),
+            user_id = %user_id,
+            "Export section collected"
+        );
+    }
     zip.start_file("reactions.json", options)?;
     serde_json::to_writer_pretty(&mut zip, &reactions)?;
     drop(reactions);
 
-    // 9. Attachments (metadata only, no S3 keys) — capped at 100K rows
+    // 9. Attachments (metadata only, no S3 keys) — capped
     let attachments: Vec<ExportAttachment> = sqlx::query_as(
         "SELECT fa.id, fa.filename, fa.mime_type, fa.size_bytes, fa.created_at
          FROM file_attachments fa
          JOIN messages m ON m.id = fa.message_id
          WHERE m.user_id = $1
          ORDER BY fa.created_at ASC
-         LIMIT 100000",
+         LIMIT $2",
     )
     .bind(user_id)
+    .bind(EXPORT_CAP_ATTACHMENTS)
     .fetch_all(pool)
     .await?;
 
-    tracing::info!(
-        section = "attachments",
-        rows = attachments.len(),
-        "Export section collected"
-    );
+    if attachments.len() as i64 >= EXPORT_CAP_ATTACHMENTS {
+        truncated_sections.push("attachments");
+        tracing::warn!(
+            section = "attachments",
+            rows = attachments.len(),
+            user_id = %user_id,
+            "Export section truncated at cap"
+        );
+    } else {
+        tracing::info!(
+            section = "attachments",
+            rows = attachments.len(),
+            user_id = %user_id,
+            "Export section collected"
+        );
+    }
     zip.start_file("attachments.json", options)?;
     serde_json::to_writer_pretty(&mut zip, &attachments)?;
     drop(attachments);
@@ -475,24 +527,36 @@ async fn build_export_archive(
     zip.start_file("key_backups.json", options)?;
     serde_json::to_writer_pretty(&mut zip, &key_backups)?;
 
-    // 13. Audit log — capped at 100K rows
+    // 13. Audit log — capped
     let audit_log: Vec<ExportAuditLogEntry> = sqlx::query_as(
         "SELECT action, target_type, target_id, details,
                 host(ip_address) as ip_address, created_at
          FROM system_audit_log
          WHERE actor_id = $1
          ORDER BY created_at ASC
-         LIMIT 100000",
+         LIMIT $2",
     )
     .bind(user_id)
+    .bind(EXPORT_CAP_AUDIT_LOG)
     .fetch_all(pool)
     .await?;
 
-    tracing::info!(
-        section = "audit_log",
-        rows = audit_log.len(),
-        "Export section collected"
-    );
+    if audit_log.len() as i64 >= EXPORT_CAP_AUDIT_LOG {
+        truncated_sections.push("audit_log");
+        tracing::warn!(
+            section = "audit_log",
+            rows = audit_log.len(),
+            user_id = %user_id,
+            "Export section truncated at cap"
+        );
+    } else {
+        tracing::info!(
+            section = "audit_log",
+            rows = audit_log.len(),
+            user_id = %user_id,
+            "Export section collected"
+        );
+    }
     zip.start_file("audit_log.json", options)?;
     serde_json::to_writer_pretty(&mut zip, &audit_log)?;
     drop(audit_log);
@@ -517,19 +581,28 @@ async fn build_export_archive(
             "key_backups",
             "audit_log",
         ],
+        truncated_sections,
     };
 
     zip.start_file("manifest.json", options)?;
     serde_json::to_writer_pretty(&mut zip, &manifest)?;
 
-    let buf_writer = zip
+    let mut buf_writer = zip
         .finish()
         .map_err(|e| anyhow::anyhow!("Failed to finalize export ZIP archive: {e}"))?;
-
-    // Flush BufWriter and sync to disk before handing path to ByteStream
+    buf_writer
+        .flush()
+        .context("Failed to flush export archive BufWriter")?;
     drop(buf_writer);
-    tmp.as_file()
-        .sync_all()
+
+    // sync_all is a blocking syscall — run off the async executor
+    let file = tmp
+        .as_file()
+        .try_clone()
+        .context("Failed to clone file handle for sync")?;
+    tokio::task::spawn_blocking(move || file.sync_all())
+        .await
+        .context("sync_all task panicked")?
         .context("Failed to sync export archive to disk")?;
 
     Ok(tmp)

--- a/server/src/guild/emojis.rs
+++ b/server/src/guild/emojis.rs
@@ -16,8 +16,6 @@ use crate::api::AppState;
 use crate::auth::AuthUser;
 use crate::guild::types::{CreateEmojiRequest, GuildEmoji, UpdateEmojiRequest};
 use crate::ws::ServerEvent;
-// Use direct Redis publish for now as broadcast_guild_emoji_update isn't in mod.rs yet
-// but we added GuildEmojiUpdated to ServerEvent.
 
 // ============================================================================
 // Error Types
@@ -381,9 +379,6 @@ pub async fn create_emoji(
         return Err(EmojiError::Storage(upload_err.to_string()));
     }
 
-    // Broadcast update
-    // Re-query full list for broadcast
-
     // Re-query full list for broadcast
     let all_emojis = sqlx::query_as::<_, GuildEmoji>(
         "SELECT * FROM guild_emojis WHERE guild_id = $1 ORDER BY created_at DESC",
@@ -571,7 +566,15 @@ pub async fn delete_emoji(
         let extensions = ["png", "jpg", "gif", "webp"];
         for ext in extensions {
             let key = format!("emojis/{guild_id}/{emoji_id}.{ext}");
-            let _ = s3.delete(&key).await;
+            if let Err(e) = s3.delete(&key).await {
+                tracing::warn!(
+                    emoji_id = %emoji_id,
+                    guild_id = %guild_id,
+                    s3_key = %key,
+                    error = %e,
+                    "Failed to delete emoji file from S3"
+                );
+            }
         }
     }
 

--- a/server/src/pages/handlers.rs
+++ b/server/src/pages/handlers.rs
@@ -163,10 +163,7 @@ pub async fn create_platform_page(
     })?;
 
     // Advisory lock: serialize platform page creation to enforce strict limits under concurrency.
-    // Advisory lock: serialize platform page creation to enforce strict limits under concurrency.
-    // Seed 61 prevents collision with other lock sites (see registry in server/src/db/mod.rs).
-    // Other seeds in this codebase: 41 (workspace_create), 43 (workspace_entry).
-    // Seeds 51/53 are on another branch (fix/review-focus-guild-discovery).
+    // Seed 61 (see registry in server/src/db/mod.rs).
     sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1::text, 61))")
         .bind("platform_pages")
         .execute(&mut *tx)
@@ -661,9 +658,7 @@ pub async fn create_guild_page(
     })?;
 
     // Advisory lock: serialize guild page creation to enforce strict limits under concurrency.
-    // Seed 61 prevents collision with other lock sites (see registry in server/src/db/mod.rs).
-    // Other seeds in this codebase: 41 (workspace_create), 43 (workspace_entry).
-    // Seeds 51/53 are on another branch (fix/review-focus-guild-discovery).
+    // Seed 61 (see registry in server/src/db/mod.rs).
     sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1::text, 61))")
         .bind(guild_id)
         .execute(&mut *tx)


### PR DESCRIPTION
## Summary
- **Critical fix:** Explicit `BufWriter::flush()` before drop in export archive — prevents silent data corruption from swallowed write errors
- **Export truncation transparency:** Added `truncated_sections` field to export manifest and named constants for row caps so users know when data was omitted (GDPR compliance)
- **Async correctness:** Replaced blocking `std::fs::metadata()` and `sync_all()` with async equivalents (`tokio::fs::metadata`, `spawn_blocking`)
- **Defensive casting:** `file_size as i64` → `try_into()` with error handling
- **Logging improvements:** Emoji S3 delete failures now logged (was `let _ =`), export section logs include `user_id`, truncated sections log at `warn`
- **Comment cleanup:** Fixed stale branch references in pages/handlers.rs, duplicate comments in emojis.rs, inaccurate doc comment in export.rs, consistent seed registry annotations

## Test plan
- [ ] `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings` passes
- [ ] `cargo fmt --check` passes
- [ ] Request a data export and verify `manifest.json` contains `truncated_sections` field
- [ ] Verify export section logs include `user_id` in structured fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)