### PR TITLE
fix(chat): cap decoded image memory at 64 MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -715,6 +715,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Guild resource limits (channels, roles, emojis, bots) now use PostgreSQL advisory locks to prevent TOCTOU races under concurrent creation; invite join member limit check uses live `COUNT(*)` instead of denormalized `member_count` (#270)
 
 ### Security
+- Image upload processing now enforces a 64 MB decoded memory budget (`max_alloc`) and reduces the maximum image dimension from 8192px to 4096px to prevent memory pressure from concurrent large image uploads (#268)
 - Enabled Content Security Policy (CSP) in Tauri webview to prevent script injection (#295)
 - Disabled `withGlobalTauri` to restrict IPC bridge access to explicit imports only (#295)
 - OIDC provider error details are no longer leaked to clients — errors are logged server-side (#295)

--- a/server/src/chat/media_processing.rs
+++ b/server/src/chat/media_processing.rs
@@ -26,8 +26,13 @@ const BLURHASH_COMPONENTS_Y: u32 = 3;
 const BLURHASH_SAMPLE_SIZE: u32 = 32;
 
 /// Maximum image dimension (width or height) to prevent decompression bombs.
-/// An 8192x8192 RGBA image is ~256 MB in memory.
-const MAX_IMAGE_DIMENSION: u32 = 8192;
+const MAX_IMAGE_DIMENSION: u32 = 4096;
+
+/// Maximum decoded image memory budget (bytes).
+/// A 4096x4096 RGBA image = 64 MB. This limits the `image` crate's
+/// internal allocator to reject images that would exceed this budget,
+/// preventing memory pressure from concurrent large image uploads.
+const MAX_DECODE_ALLOC: u64 = 64 * 1024 * 1024;
 
 #[derive(Error, Debug)]
 pub enum ProcessingError {
@@ -87,6 +92,7 @@ pub fn process_image(
     let mut limits = Limits::default();
     limits.max_image_width = Some(MAX_IMAGE_DIMENSION);
     limits.max_image_height = Some(MAX_IMAGE_DIMENSION);
+    limits.max_alloc = Some(MAX_DECODE_ALLOC);
     reader.limits(limits);
 
     let img = reader


### PR DESCRIPTION
## Summary
- Reduce `MAX_IMAGE_DIMENSION` from 8192px to 4096px (8192x8192 RGBA = 256 MB, too much for concurrent uploads)
- Set `max_alloc = 64 MB` on the `image` crate's `Limits` struct to enforce a hard memory budget during decode
- 4096px is sufficient for gaming chat screenshots and photos

Closes #268

## Test plan
- [ ] `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings` passes
- [ ] All 6 media processing unit tests pass
- [ ] Upload a normal image (<4096px) and verify thumbnail/medium variants generated
- [ ] Upload a large image (>4096px) and verify it's rejected with decode error

🤖 Generated with [Claude Code](https://claude.com/claude-code)