### PR TITLE
fix(api,client): checked S3 cast, export error path, focus perf, Unicode length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -565,6 +565,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Phased update strategy executed in subsequent releases
 
 ### Fixed
+- S3 presign expiry cast uses checked conversion instead of truncating `as u64`, with a minimum clamp of 1 second at config parse time
+- Export error path no longer discards the original build error when the subsequent status UPDATE fails — stale-job recovery handles the orphan (#265)
+- Focus mode VIP set cache now uses O(1) reference equality instead of O(n log n) JSON hash comparison on every policy evaluation (#258)
+- Focus settings inputs no longer use HTML `maxLength` (UTF-16 code units) which miscounted emoji — server-side validation uses Unicode code points consistently (#257)
 - Data export friends query referenced non-existent `friend_requests` table — fixed to use `friendships` table with correct `updated_at` column (#289)
 - Friend presence indicators now update immediately on WebSocket reconnect instead of showing stale online/offline status until next full refresh (#314)
 - Unread badge polling no longer hammers the server after receiving a 429 rate-limit response — backs off exponentially instead of retrying immediately (#314)

--- a/client/src/components/settings/FocusSettings.tsx
+++ b/client/src/components/settings/FocusSettings.tsx
@@ -352,7 +352,6 @@ const FocusSettings: Component = () => {
                         <input
                           type="text"
                           value={mode.name}
-                          maxLength={MAX_MODE_NAME_LEN}
                           onInput={(e) => {
                             const name = e.currentTarget.value;
                             if (
@@ -482,12 +481,9 @@ const FocusSettings: Component = () => {
                       </div>
                       <Show when={mode.emergencyKeywords.length < MAX_KEYWORDS}>
                         <div class="flex gap-2">
-                          {/* NOTE: maxLength counts UTF-16 code units; server counts Unicode code points.
-                              Emoji (surrogate pairs) count as 2 here but 1 on server. This is conservative. */}
                           <input
                             type="text"
                             value={keywordInput()}
-                            maxLength={MAX_KEYWORD_LEN}
                             onInput={(e) =>
                               setKeywordInput(e.currentTarget.value)
                             }

--- a/client/src/stores/focus.ts
+++ b/client/src/stores/focus.ts
@@ -29,65 +29,47 @@ const [focusState, setFocusState] = createSignal<FocusState>({
 
 const EMPTY_SET: ReadonlySet<string> = new Set();
 
-type VipSetCache = {
-  modeId: string | null;
-  userIdsHash: string | null;
-  channelIdsHash: string | null;
-  userSet: ReadonlySet<string>;
-  channelSet: ReadonlySet<string>;
-};
-
-const vipSetCache: VipSetCache = {
-  modeId: null,
-  userIdsHash: null,
-  channelIdsHash: null,
-  userSet: EMPTY_SET,
-  channelSet: EMPTY_SET,
-};
-
 /**
  * Build a Set from a mode's VIP list for O(1) lookups.
  * Called on every evaluateFocusPolicy to stay in sync with live preferences.
  * Lists are capped at 50 entries so construction cost is negligible.
  */
-function buildVipSet(ids: string[]): ReadonlySet<string> {
+function buildVipSet(ids: readonly string[]): ReadonlySet<string> {
   return ids.length > 0
     ? new Set(ids.map((id) => id.toLowerCase()))
     : EMPTY_SET;
 }
 
-function hashVipIds(ids: string[]): string {
-  return JSON.stringify([...ids].map((id) => id.toLowerCase()).sort());
-}
+// Module-level cache using reference equality (O(1) per check)
+let cachedModeId: string | null = null;
+let cachedVipUserIds: readonly string[] | null = null;
+let cachedVipChannelIds: readonly string[] | null = null;
+let cachedUserSet: ReadonlySet<string> = EMPTY_SET;
+let cachedChannelSet: ReadonlySet<string> = EMPTY_SET;
 
 function getCachedVipSets(mode: FocusMode): {
   userSet: ReadonlySet<string>;
   channelSet: ReadonlySet<string>;
 } {
-  if (vipSetCache.modeId !== mode.id) {
-    vipSetCache.modeId = mode.id;
-    vipSetCache.userIdsHash = null;
-    vipSetCache.channelIdsHash = null;
-    vipSetCache.userSet = EMPTY_SET;
-    vipSetCache.channelSet = EMPTY_SET;
+  if (cachedModeId !== mode.id) {
+    cachedModeId = mode.id;
+    cachedVipUserIds = null;
+    cachedVipChannelIds = null;
+    cachedUserSet = EMPTY_SET;
+    cachedChannelSet = EMPTY_SET;
   }
 
-  const userIdsHash = hashVipIds(mode.vipUserIds);
-  if (vipSetCache.userIdsHash !== userIdsHash) {
-    vipSetCache.userIdsHash = userIdsHash;
-    vipSetCache.userSet = buildVipSet(mode.vipUserIds);
+  if (cachedVipUserIds !== mode.vipUserIds) {
+    cachedVipUserIds = mode.vipUserIds;
+    cachedUserSet = buildVipSet(mode.vipUserIds);
   }
 
-  const channelIdsHash = hashVipIds(mode.vipChannelIds);
-  if (vipSetCache.channelIdsHash !== channelIdsHash) {
-    vipSetCache.channelIdsHash = channelIdsHash;
-    vipSetCache.channelSet = buildVipSet(mode.vipChannelIds);
+  if (cachedVipChannelIds !== mode.vipChannelIds) {
+    cachedVipChannelIds = mode.vipChannelIds;
+    cachedChannelSet = buildVipSet(mode.vipChannelIds);
   }
 
-  return {
-    userSet: vipSetCache.userSet,
-    channelSet: vipSetCache.channelSet,
-  };
+  return { userSet: cachedUserSet, channelSet: cachedChannelSet };
 }
 
 // ============================================================================

--- a/server/src/api/preferences.rs
+++ b/server/src/api/preferences.rs
@@ -107,6 +107,7 @@ const MAX_KEYWORD_LEN: usize = 30;
 const MIN_KEYWORD_LEN: usize = 3;
 const MAX_MODE_NAME_LEN: usize = 30;
 
+/// Counts Unicode scalar values (code points), matching `Array.from(str).length` in JavaScript.
 fn unicode_len(s: &str) -> usize {
     s.chars().count()
 }

--- a/server/src/chat/s3.rs
+++ b/server/src/chat/s3.rs
@@ -109,7 +109,15 @@ impl S3Client {
         Ok(Self {
             client,
             bucket: config.s3_bucket.clone(),
-            presign_expiry: Duration::from_secs(config.s3_presign_expiry as u64),
+            // Safety: s3_presign_expiry is clamped to >= 1 at parse time in Config::from_env
+            presign_expiry: Duration::from_secs(u64::try_from(config.s3_presign_expiry).map_err(
+                |_| {
+                    S3Error::Config(format!(
+                        "s3_presign_expiry must be positive, got {}",
+                        config.s3_presign_expiry
+                    ))
+                },
+            )?),
         })
     }
 

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -255,7 +255,8 @@ impl Config {
             s3_presign_expiry: env::var("S3_PRESIGN_EXPIRY")
                 .ok()
                 .and_then(|v| v.parse().ok())
-                .unwrap_or(3600), // 1 hour
+                .unwrap_or(3600) // 1 hour
+                .max(1),
             s3_access_key: env::var("AWS_ACCESS_KEY_ID").ok(),
             s3_secret_key: env::var("AWS_SECRET_ACCESS_KEY").ok(),
             allowed_mime_types: env::var("ALLOWED_MIME_TYPES").ok().map(|s| {

--- a/server/src/governance/export.rs
+++ b/server/src/governance/export.rs
@@ -240,8 +240,8 @@ pub async fn process_export_job(
             }
         }
         Err(e) => {
-            // Mark as failed
-            sqlx::query(
+            // Mark as failed — use if-let so the original error is never discarded
+            if let Err(db_err) = sqlx::query(
                 "UPDATE data_export_jobs
                  SET status = 'failed', error_message = $1, completed_at = NOW()
                  WHERE id = $2",
@@ -249,7 +249,15 @@ pub async fn process_export_job(
             .bind(e.to_string())
             .bind(job_id)
             .execute(pool)
-            .await?;
+            .await
+            {
+                tracing::error!(
+                    job_id = %job_id,
+                    original_error = %e,
+                    db_error = %db_err,
+                    "Failed to mark export job as failed; stale-job recovery will handle it"
+                );
+            }
 
             return Err(e);
         }


### PR DESCRIPTION
## Summary
- Replace unsafe `as u64` cast on S3 presign expiry with `u64::try_from()` and clamp config value ≥ 1 at parse time
- Preserve original error in export failure path instead of discarding it via `?` when the status UPDATE also fails
- Replace O(n log n) hash-based VIP set cache with O(1) reference equality checks in focus policy evaluation (#258)
- Remove HTML `maxLength` attributes that miscounted emoji (UTF-16 code units vs Unicode code points); server-side validation is authoritative (#257)

## Test plan
- [ ] `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings` passes
- [ ] Focus mode VIP filtering still works correctly after cache refactor
- [ ] Emoji in focus mode name/keyword inputs are no longer truncated at wrong boundaries
- [ ] Export jobs that fail during archive build are correctly marked as failed

Closes #258, closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)