### PR TITLE
fix(client,api): hide server URL in browser mode, wire DB query metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -565,6 +565,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Phased update strategy executed in subsequent releases
 
 ### Fixed
+- Server URL field is now hidden in browser mode login/register — derives automatically from `window.location.origin` (#300)
+- Wired `kaiku_db_query_duration_seconds` histogram to actual sqlx query spans via a custom tracing layer (#292)
 - S3 presign expiry cast uses checked conversion instead of truncating `as u64`, with a minimum clamp of 1 second at config parse time
 - Export error path no longer discards the original build error when the subsequent status UPDATE fails — stale-job recovery handles the orphan (#265)
 - Focus mode VIP set cache now uses O(1) reference equality instead of O(n log n) JSON hash comparison on every policy evaluation (#258)

--- a/client/src/views/Login.tsx
+++ b/client/src/views/Login.tsx
@@ -26,6 +26,7 @@ function providerIcon(hint: string | null) {
 
 const Login: Component = () => {
   const navigate = useNavigate();
+  const isTauri = "__TAURI__" in window;
   const defaultServerUrl = import.meta.env.VITE_SERVER_URL || window.location.origin;
   const [serverUrl, setServerUrl] = createSignal(defaultServerUrl);
   const [username, setUsername] = createSignal("");
@@ -58,10 +59,6 @@ const Login: Component = () => {
     setLocalError("");
     clearError();
 
-    if (!serverUrl().trim()) {
-      setLocalError("Server URL is required");
-      return;
-    }
     if (!username().trim()) {
       setLocalError("Username is required");
       return;
@@ -195,23 +192,24 @@ const Login: Component = () => {
           Login to continue to Kaiku
         </p>
 
-        {/* Server URL (always shown) */}
-        <div class="mb-4">
-          <label class="block text-sm font-medium text-text-secondary mb-1">
-            Server URL
-          </label>
-          <input
-            type="url"
-            class="input-field"
-            placeholder="https://chat.example.com"
-            value={serverUrl()}
-            onInput={(e) => handleServerUrlChange(e.currentTarget.value)}
-            disabled={
-              authState.isLoading || !!oidcLoading() || authState.mfaRequired
-            }
-            required
-          />
-        </div>
+        <Show when={isTauri}>
+          <div class="mb-4">
+            <label class="block text-sm font-medium text-text-secondary mb-1">
+              Server URL
+            </label>
+            <input
+              type="url"
+              class="input-field"
+              placeholder="https://chat.example.com"
+              value={serverUrl()}
+              onInput={(e) => handleServerUrlChange(e.currentTarget.value)}
+              disabled={
+                authState.isLoading || !!oidcLoading() || authState.mfaRequired
+              }
+              required
+            />
+          </div>
+        </Show>
 
         {/* MFA Code Step */}
         <Show when={authState.mfaRequired}>

--- a/client/src/views/Register.tsx
+++ b/client/src/views/Register.tsx
@@ -20,6 +20,7 @@ function providerIcon(hint: string | null) {
 
 const Register: Component = () => {
   const navigate = useNavigate();
+  const isTauri = "__TAURI__" in window;
   const defaultServerUrl = import.meta.env.VITE_SERVER_URL || window.location.origin;
   const [serverUrl, setServerUrl] = createSignal(defaultServerUrl);
   const [username, setUsername] = createSignal("");
@@ -53,10 +54,6 @@ const Register: Component = () => {
     setLocalError("");
     clearError();
 
-    if (!serverUrl().trim()) {
-      setLocalError("Server URL is required");
-      return;
-    }
     if (!username().trim()) {
       setLocalError("Username is required");
       return;
@@ -192,22 +189,23 @@ const Register: Component = () => {
           Join Kaiku to start chatting
         </p>
 
-        {/* Server URL (always shown) */}
-        <div class="mb-4">
-          <label class="block text-sm font-medium text-text-secondary mb-1">
-            Server URL
-          </label>
-          <input
-            type="url"
-            class="input-field"
-            data-testid="register-server-url"
-            placeholder="https://chat.example.com"
-            value={serverUrl()}
-            onInput={(e) => handleServerUrlChange(e.currentTarget.value)}
-            disabled={authState.isLoading || !!oidcLoading()}
-            required
-          />
-        </div>
+        <Show when={isTauri}>
+          <div class="mb-4">
+            <label class="block text-sm font-medium text-text-secondary mb-1">
+              Server URL
+            </label>
+            <input
+              type="url"
+              class="input-field"
+              data-testid="register-server-url"
+              placeholder="https://chat.example.com"
+              value={serverUrl()}
+              onInput={(e) => handleServerUrlChange(e.currentTarget.value)}
+              disabled={authState.isLoading || !!oidcLoading()}
+              required
+            />
+          </div>
+        </Show>
 
         {/* Registration closed message */}
         <Show when={isClosed()}>

--- a/server/src/observability/metrics.rs
+++ b/server/src/observability/metrics.rs
@@ -48,8 +48,7 @@ static VOICE_SESSION_DURATION_SECONDS: OnceLock<Histogram<f64>> = OnceLock::new(
 static VOICE_RTP_PACKETS_FORWARDED: AtomicU64 = AtomicU64::new(0);
 static VOICE_RTP_COUNTER: OnceLock<Counter<u64>> = OnceLock::new();
 
-/// Registered but not wired to individual queries — sqlx 0.8 has no query
-/// interceptor. Can be wired per-query in a follow-up.
+/// `SQLx` query execution time, wired via `SqlxMetricsLayer` tracing layer.
 static DB_QUERY_DURATION_SECONDS: OnceLock<Histogram<f64>> = OnceLock::new();
 
 static AUTH_TOKEN_REFRESH_TOTAL: OnceLock<Counter<u64>> = OnceLock::new();
@@ -407,6 +406,13 @@ pub fn record_otel_export_failure() {
     }
 }
 
+/// Record a database query duration in seconds.
+pub fn record_db_query_duration(duration_s: f64) {
+    if let Some(histogram) = DB_QUERY_DURATION_SECONDS.get() {
+        histogram.record(duration_s, &[]);
+    }
+}
+
 // ============================================================================
 // Helpers
 // ============================================================================
@@ -505,6 +511,7 @@ mod tests {
         flush_rtp_counter();
         record_token_refresh(true);
         record_otel_export_failure();
+        record_db_query_duration(0.5);
     }
 
     #[test]

--- a/server/src/observability/mod.rs
+++ b/server/src/observability/mod.rs
@@ -19,6 +19,7 @@
 pub mod ingestion;
 pub mod metrics;
 pub mod retention;
+pub mod sqlx_metrics;
 pub mod storage;
 pub mod tracing;
 pub mod voice;

--- a/server/src/observability/sqlx_metrics.rs
+++ b/server/src/observability/sqlx_metrics.rs
@@ -1,0 +1,44 @@
+//! Tracing layer that records sqlx query durations to the `OTel` histogram.
+
+use std::time::Instant;
+
+use tracing_subscriber::layer::{Context, Layer};
+use tracing_subscriber::registry::LookupSpan;
+
+use super::metrics::record_db_query_duration;
+
+/// Marker stored in span extensions to track query start time.
+struct SqlxQueryStart(Instant);
+
+/// Tracing layer that intercepts `sqlx::query` spans and records their
+/// duration to the `kaiku_db_query_duration_seconds` histogram.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SqlxMetricsLayer;
+
+impl<S> Layer<S> for SqlxMetricsLayer
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(
+        &self,
+        _attrs: &tracing::span::Attributes<'_>,
+        id: &tracing::span::Id,
+        ctx: Context<'_, S>,
+    ) {
+        if let Some(span) = ctx.span(id) {
+            if span.metadata().target().starts_with("sqlx") {
+                span.extensions_mut().insert(SqlxQueryStart(Instant::now()));
+            }
+        }
+    }
+
+    fn on_close(&self, id: tracing::span::Id, ctx: Context<'_, S>) {
+        if let Some(span) = ctx.span(&id) {
+            let extensions = span.extensions();
+            if let Some(start) = extensions.get::<SqlxQueryStart>() {
+                let duration = start.0.elapsed();
+                record_db_query_duration(duration.as_secs_f64());
+            }
+        }
+    }
+}

--- a/server/src/observability/tracing.rs
+++ b/server/src/observability/tracing.rs
@@ -20,6 +20,7 @@ use tracing_subscriber::util::SubscriberInitExt as _;
 use tracing_subscriber::{EnvFilter, Layer, Registry};
 
 use super::ingestion::{CapturedLogEvent, CapturedSpan, NativeLogLayer, NativeSpanProcessor};
+use super::sqlx_metrics::SqlxMetricsLayer;
 use crate::config::ObservabilityConfig;
 
 /// RAII guard that shuts down the `OTel` providers when dropped.
@@ -208,6 +209,7 @@ pub fn init(
         Registry::default()
             .with(filter)
             .with(RedactionLayer)
+            .with(SqlxMetricsLayer)
             .with(native_log_layer)
             .with(tracing_subscriber::fmt::layer().json())
             .init();
@@ -270,6 +272,7 @@ pub fn init(
     Registry::default()
         .with(filter)
         .with(RedactionLayer)
+        .with(SqlxMetricsLayer)
         .with(native_log_layer)
         .with(otel_trace_layer)
         .with(otel_log_layer)


### PR DESCRIPTION
## Summary
- Hide the Server URL input field on Login and Register pages when running in browser mode (`!isTauri`); the URL derives from `window.location.origin` automatically (#300)
- Wire the `kaiku_db_query_duration_seconds` OTel histogram to actual sqlx query spans via a new `SqlxMetricsLayer` tracing layer that timestamps span open/close (#292)

## Test plan
- [ ] `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings` passes
- [ ] Browser mode login/register no longer shows the server URL field
- [ ] Tauri desktop login/register still shows the server URL field
- [ ] `kaiku_db_query_duration_seconds` histogram is populated in Prometheus/OTel after DB queries

Closes #300, closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)