### PR TITLE
fix(api,client): use on_event for sqlx metrics, restore URL validation

### DIFF
--- a/client/src/views/Login.tsx
+++ b/client/src/views/Login.tsx
@@ -26,7 +26,7 @@ function providerIcon(hint: string | null) {
 
 const Login: Component = () => {
   const navigate = useNavigate();
-  const isTauri = "__TAURI__" in window;
+  const isTauri = typeof window !== "undefined" && "__TAURI__" in window;
   const defaultServerUrl = import.meta.env.VITE_SERVER_URL || window.location.origin;
   const [serverUrl, setServerUrl] = createSignal(defaultServerUrl);
   const [username, setUsername] = createSignal("");
@@ -59,6 +59,10 @@ const Login: Component = () => {
     setLocalError("");
     clearError();
 
+    if (isTauri && !serverUrl().trim()) {
+      setLocalError("Server URL is required");
+      return;
+    }
     if (!username().trim()) {
       setLocalError("Username is required");
       return;

--- a/client/src/views/Register.tsx
+++ b/client/src/views/Register.tsx
@@ -20,7 +20,7 @@ function providerIcon(hint: string | null) {
 
 const Register: Component = () => {
   const navigate = useNavigate();
-  const isTauri = "__TAURI__" in window;
+  const isTauri = typeof window !== "undefined" && "__TAURI__" in window;
   const defaultServerUrl = import.meta.env.VITE_SERVER_URL || window.location.origin;
   const [serverUrl, setServerUrl] = createSignal(defaultServerUrl);
   const [username, setUsername] = createSignal("");
@@ -54,6 +54,10 @@ const Register: Component = () => {
     setLocalError("");
     clearError();
 
+    if (isTauri && !serverUrl().trim()) {
+      setLocalError("Server URL is required");
+      return;
+    }
     if (!username().trim()) {
       setLocalError("Username is required");
       return;

--- a/server/src/observability/sqlx_metrics.rs
+++ b/server/src/observability/sqlx_metrics.rs
@@ -1,16 +1,33 @@
 //! Tracing layer that records sqlx query durations to the `OTel` histogram.
+//!
+//! SQLx 0.8 emits `tracing::event!` (not spans) with `target: "sqlx::query"`
+//! and includes an `elapsed_secs` field containing the query duration as `f64`.
+//! This layer intercepts those events and feeds the duration into the
+//! `kaiku_db_query_duration_seconds` histogram.
 
-use std::time::Instant;
-
+use tracing::field::{Field, Visit};
 use tracing_subscriber::layer::{Context, Layer};
 use tracing_subscriber::registry::LookupSpan;
 
 use super::metrics::record_db_query_duration;
 
-/// Marker stored in span extensions to track query start time.
-struct SqlxQueryStart(Instant);
+/// Visitor that extracts the `elapsed_secs` field from a sqlx query event.
+#[derive(Default)]
+struct ElapsedSecsVisitor {
+    elapsed_secs: Option<f64>,
+}
 
-/// Tracing layer that intercepts `sqlx::query` spans and records their
+impl Visit for ElapsedSecsVisitor {
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        if field.name() == "elapsed_secs" {
+            self.elapsed_secs = Some(value);
+        }
+    }
+
+    fn record_debug(&mut self, _field: &Field, _value: &dyn std::fmt::Debug) {}
+}
+
+/// Tracing layer that intercepts `sqlx::query` events and records their
 /// duration to the `kaiku_db_query_duration_seconds` histogram.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct SqlxMetricsLayer;
@@ -19,26 +36,16 @@ impl<S> Layer<S> for SqlxMetricsLayer
 where
     S: tracing::Subscriber + for<'a> LookupSpan<'a>,
 {
-    fn on_new_span(
-        &self,
-        _attrs: &tracing::span::Attributes<'_>,
-        id: &tracing::span::Id,
-        ctx: Context<'_, S>,
-    ) {
-        if let Some(span) = ctx.span(id) {
-            if span.metadata().target().starts_with("sqlx") {
-                span.extensions_mut().insert(SqlxQueryStart(Instant::now()));
-            }
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        if event.metadata().target() != "sqlx::query" {
+            return;
         }
-    }
 
-    fn on_close(&self, id: tracing::span::Id, ctx: Context<'_, S>) {
-        if let Some(span) = ctx.span(&id) {
-            let extensions = span.extensions();
-            if let Some(start) = extensions.get::<SqlxQueryStart>() {
-                let duration = start.0.elapsed();
-                record_db_query_duration(duration.as_secs_f64());
-            }
+        let mut visitor = ElapsedSecsVisitor::default();
+        event.record(&mut visitor);
+
+        if let Some(elapsed) = visitor.elapsed_secs {
+            record_db_query_duration(elapsed);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Rewrite `SqlxMetricsLayer` to use `on_event` instead of `on_new_span`/`on_close` — sqlx 0.8 emits tracing **events** (not spans) with an `elapsed_secs` field, so the previous span-based approach never recorded any data
- Restore server URL validation for Tauri mode — the validation was removed too broadly in #332, leaving Tauri users without a guard against empty URLs
- Use defensive `typeof window !== "undefined" && "__TAURI__" in window` pattern matching the 11 other codebase locations

## Test plan
- [ ] `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings` passes
- [ ] `kaiku_db_query_duration_seconds` histogram now populates from sqlx query events
- [ ] Tauri: clearing server URL field and submitting shows "Server URL is required"
- [ ] Browser: server URL field remains hidden, login works via `window.location.origin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)