### PR TITLE
fix(client): browser-mode frontend bugs

### DIFF
--- a/client/src/components/layout/Sidebar.tsx
+++ b/client/src/components/layout/Sidebar.tsx
@@ -20,7 +20,6 @@ import {
 } from "solid-js";
 import { useNavigate } from "@solidjs/router";
 import { ChevronDown, Settings, Search, BookOpen } from "lucide-solid";
-import { loadChannels } from "@/stores/channels";
 import { getActiveGuild } from "@/stores/guilds";
 import { loadFavorites } from "@/stores/favorites";
 import { clearSearch } from "@/stores/search";
@@ -55,9 +54,8 @@ const Sidebar: Component = () => {
     clearSearch();
   };
 
-  // Load channels and favorites when sidebar mounts
+  // Load pending page acceptance and favorites when sidebar mounts
   onMount(() => {
-    loadChannels();
     loadPendingAcceptance();
     loadFavorites();
   });

--- a/client/src/components/settings/PrivacySettings.tsx
+++ b/client/src/components/settings/PrivacySettings.tsx
@@ -5,7 +5,8 @@
  */
 
 import { Component, createSignal, onMount } from "solid-js";
-import { invoke } from "@tauri-apps/api/core";
+
+const isTauri = typeof window !== "undefined" && "__TAURI__" in window;
 
 const PrivacySettings: Component = () => {
   const [activitySharingEnabled, setActivitySharingEnabled] =
@@ -13,7 +14,13 @@ const PrivacySettings: Component = () => {
   const [isLoading, setIsLoading] = createSignal(true);
 
   onMount(async () => {
+    if (!isTauri) {
+      setIsLoading(false);
+      return;
+    }
+
     try {
+      const { invoke } = await import("@tauri-apps/api/core");
       const enabled = await invoke<boolean>("is_activity_sharing_enabled");
       setActivitySharingEnabled(enabled);
     } catch (e) {
@@ -24,7 +31,13 @@ const PrivacySettings: Component = () => {
   });
 
   const handleActivitySharingChange = async (enabled: boolean) => {
+    if (!isTauri) {
+      setActivitySharingEnabled(enabled);
+      return;
+    }
+
     try {
+      const { invoke } = await import("@tauri-apps/api/core");
       await invoke("set_activity_sharing_enabled", { enabled });
       setActivitySharingEnabled(enabled);
     } catch (e) {

--- a/client/src/components/voice/VoicePanel.tsx
+++ b/client/src/components/voice/VoicePanel.tsx
@@ -22,7 +22,7 @@ import type { ConnectionMetrics } from "@/lib/webrtc/types";
 import VoiceControls from "./VoiceControls";
 
 /**
- * Voice panel shown when connected to a voice channel.
+ * Voice panel shown when connected or connecting to a voice channel.
  * Displays current channel, participants, and controls.
  */
 const VoicePanel: Component = () => {
@@ -36,6 +36,9 @@ const VoicePanel: Component = () => {
   const handleDisconnect = () => {
     leaveVoice();
   };
+
+  const isConnected = () => voiceState.state === "connected";
+  const isConnecting = () => voiceState.state === "connecting";
 
   // Elapsed timer — uses the store's authoritative connectedAt timestamp
   const [elapsedTime, setElapsedTime] = createSignal("00:00");
@@ -56,7 +59,7 @@ const VoicePanel: Component = () => {
   };
 
   return (
-    <Show when={voiceState.state === "connected" && channel()}>
+    <Show when={(isConnected() || isConnecting()) && voiceState.channelId}>
       <div
         data-testid="voice-panel"
         class="bg-surface-base/50 border-t relative transition-all duration-200"
@@ -69,31 +72,45 @@ const VoicePanel: Component = () => {
         {/* Connection info */}
         <div class="px-3 py-2 flex items-center justify-between">
           <div class="flex items-center gap-2 min-w-0">
-            <Signal class="w-4 h-4 text-accent-success flex-shrink-0" />
+            <Signal
+              class="w-4 h-4 flex-shrink-0"
+              classList={{
+                "text-accent-success": isConnected(),
+                "text-amber-400 animate-pulse": isConnecting(),
+              }}
+            />
             <div class="min-w-0">
-              <div class="text-xs font-semibold text-accent-success">
-                Voice Connected
+              <div
+                class="text-xs font-semibold"
+                classList={{
+                  "text-accent-success": isConnected(),
+                  "text-amber-400 animate-pulse": isConnecting(),
+                }}
+              >
+                {isConnected() ? "Voice Connected" : "Connecting..."}
               </div>
               <div class="text-xs text-text-secondary truncate flex items-center gap-1.5">
-                <span>{channel()?.name}</span>
-                <span class="text-text-secondary/50">&middot;</span>
-                <span class="font-mono">{elapsedTime()}</span>
-                <div
-                  class="relative"
-                  onMouseEnter={() => setShowQualityTooltip(true)}
-                  onMouseLeave={() => setShowQualityTooltip(false)}
-                >
-                  <QualityIndicator
-                    metrics={metrics()}
-                    mode="circle"
-                    class="cursor-help"
-                  />
-                  <Show when={showQualityTooltip() && metricsObj()}>
-                    <div class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-50">
-                      <QualityTooltip metrics={metricsObj()!} />
-                    </div>
-                  </Show>
-                </div>
+                <span>{channel()?.name || "Voice Channel"}</span>
+                <Show when={isConnected()}>
+                  <span class="text-text-secondary/50">&middot;</span>
+                  <span class="font-mono">{elapsedTime()}</span>
+                  <div
+                    class="relative"
+                    onMouseEnter={() => setShowQualityTooltip(true)}
+                    onMouseLeave={() => setShowQualityTooltip(false)}
+                  >
+                    <QualityIndicator
+                      metrics={metrics()}
+                      mode="circle"
+                      class="cursor-help"
+                    />
+                    <Show when={showQualityTooltip() && metricsObj()}>
+                      <div class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-50">
+                        <QualityTooltip metrics={metricsObj()!} />
+                      </div>
+                    </Show>
+                  </div>
+                </Show>
               </div>
             </div>
           </div>
@@ -172,8 +189,10 @@ const VoicePanel: Component = () => {
           </div>
         </Show>
 
-        {/* Voice controls */}
-        <VoiceControls />
+        {/* Voice controls - only when fully connected */}
+        <Show when={isConnected()}>
+          <VoiceControls />
+        </Show>
       </div>
     </Show>
   );

--- a/client/src/stores/channels.ts
+++ b/client/src/stores/channels.ts
@@ -46,6 +46,7 @@ export const voiceChannels = () =>
 /**
  * Load channels from server (all channels - legacy).
  * Use loadChannelsForGuild for guild-scoped loading.
+ * @deprecated Use loadChannelsForGuild or loadDMChannels instead.
  */
 export async function loadChannels(): Promise<void> {
   setChannelsState({ isLoading: true, error: null });
@@ -142,19 +143,27 @@ export async function loadChannelsForGuild(guildId: string): Promise<void> {
 
 /**
  * Load DM channels (for Home view).
- * This will load channels where guild_id is null.
+ * Uses the dedicated /api/dm endpoint which returns DMListItem[].
  */
 export async function loadDMChannels(): Promise<void> {
   setChannelsState({ isLoading: true, error: null });
 
   try {
-    // For now, use the generic getChannels and filter for DMs
-    // In Phase 3 Task 5, this will use a dedicated /api/dm endpoint
-    const allChannels = await tauri.getChannels();
-    // Map to ChannelWithUnread (legacy endpoint doesn't return unread counts)
-    const dmChannels: ChannelWithUnread[] = allChannels
-      .filter((c) => c.guild_id === null)
-      .map((c) => ({ ...c, unread_count: 0 }));
+    const dmList = await tauri.getDMList();
+    // DMListItem is structurally compatible with ChannelWithUnread
+    const dmChannels: ChannelWithUnread[] = dmList.map((dm) => ({
+      id: dm.id,
+      name: dm.name,
+      channel_type: dm.channel_type,
+      category_id: dm.category_id,
+      guild_id: dm.guild_id,
+      topic: dm.topic,
+      icon_url: dm.icon_url,
+      user_limit: dm.user_limit,
+      position: dm.position,
+      created_at: dm.created_at,
+      unread_count: dm.unread_count,
+    }));
 
     setChannelsState({
       channels: dmChannels,

--- a/client/src/stores/voice.ts
+++ b/client/src/stores/voice.ts
@@ -112,6 +112,9 @@ let unlisteners: UnlistenFn[] = [];
 // Metrics collection interval
 let metricsInterval: number | null = null;
 
+// Guard against concurrent join calls from rapid clicks
+let isJoining = false;
+
 // Notification state for packet loss incidents
 let currentIncidentStart: number | null = null;
 let goodQualityStartTime: number | null = null;
@@ -392,82 +395,94 @@ export async function cleanupVoice(): Promise<void> {
  * Join a voice channel.
  */
 export async function joinVoice(channelId: string): Promise<void> {
-  // Leave current channel if connected
-  if (voiceState.state !== "disconnected") {
-    await leaveVoice();
+  if (isJoining) {
+    console.warn("[Voice] Join already in progress, ignoring duplicate call");
+    return;
   }
+  isJoining = true;
 
-  setVoiceState({ state: "connecting", channelId, error: null });
+  try {
+    // Leave current channel if connected
+    if (voiceState.state !== "disconnected") {
+      await leaveVoice();
+    }
 
-  const adapter = await createVoiceAdapter();
+    setVoiceState({ state: "connecting", channelId, error: null });
 
-  // Set up adapter event handlers
-  adapter.setEventHandlers({
-    onStateChange: (state) => {
-      const stateMap = {
-        disconnected: "disconnected" as const,
-        requesting_media: "connecting" as const,
-        connecting: "connecting" as const,
-        connected: "connected" as const,
-        reconnecting: "connecting" as const,
-      };
-      setVoiceState({ state: stateMap[state] });
-    },
-    onError: (error) => {
-      setVoiceState({ error });
-    },
-    onLocalMuteChange: (muted) => {
-      setVoiceState({ muted });
-    },
-    onSpeakingChange: (speaking) => {
-      setVoiceState({ speaking });
-    },
-    onScreenShareTrack: (userId, track) => {
-      console.log("[Voice] Screen share track received:", userId);
-      // Import and call viewer store
-      import("@/stores/screenShareViewer").then(({ startViewing }) => {
-        startViewing(userId, track);
-      });
-    },
-    onScreenShareTrackRemoved: (userId) => {
-      console.log("[Voice] Screen share track removed:", userId);
-      import("@/stores/screenShareViewer").then(({ removeAvailableTrack }) => {
-        removeAvailableTrack(userId);
-      });
-    },
-    onScreenShareStopped: (_userId, reason) => {
-      console.log("[Voice] Screen share stopped:", reason);
-      // Sync local state when screen share is stopped (e.g., via system UI)
-      setVoiceState({ screenSharing: false });
-    },
-    onWebcamTrack: (userId, track) => {
-      console.log("[Voice] Webcam track received:", userId);
-      import("@/stores/webcamViewer").then(({ addAvailableTrack }) => {
-        addAvailableTrack(userId, track);
-      });
-    },
-    onWebcamTrackRemoved: (userId) => {
-      console.log("[Voice] Webcam track removed:", userId);
-      import("@/stores/webcamViewer").then(({ removeAvailableTrack }) => {
-        removeAvailableTrack(userId);
-      });
-    },
-  });
+    const adapter = await createVoiceAdapter();
 
-  const result = await adapter.join(channelId);
-  if (!result.ok) {
-    setVoiceState({
-      state: "disconnected",
-      channelId: null,
-      error: result.error,
+    // Set up adapter event handlers
+    adapter.setEventHandlers({
+      onStateChange: (state) => {
+        const stateMap = {
+          disconnected: "disconnected" as const,
+          requesting_media: "connecting" as const,
+          connecting: "connecting" as const,
+          connected: "connected" as const,
+          reconnecting: "connecting" as const,
+        };
+        setVoiceState({ state: stateMap[state] });
+      },
+      onError: (error) => {
+        setVoiceState({ error });
+      },
+      onLocalMuteChange: (muted) => {
+        setVoiceState({ muted });
+      },
+      onSpeakingChange: (speaking) => {
+        setVoiceState({ speaking });
+      },
+      onScreenShareTrack: (userId, track) => {
+        console.log("[Voice] Screen share track received:", userId);
+        // Import and call viewer store
+        import("@/stores/screenShareViewer").then(({ startViewing }) => {
+          startViewing(userId, track);
+        });
+      },
+      onScreenShareTrackRemoved: (userId) => {
+        console.log("[Voice] Screen share track removed:", userId);
+        import("@/stores/screenShareViewer").then(
+          ({ removeAvailableTrack }) => {
+            removeAvailableTrack(userId);
+          },
+        );
+      },
+      onScreenShareStopped: (_userId, reason) => {
+        console.log("[Voice] Screen share stopped:", reason);
+        // Sync local state when screen share is stopped (e.g., via system UI)
+        setVoiceState({ screenSharing: false });
+      },
+      onWebcamTrack: (userId, track) => {
+        console.log("[Voice] Webcam track received:", userId);
+        import("@/stores/webcamViewer").then(({ addAvailableTrack }) => {
+          addAvailableTrack(userId, track);
+        });
+      },
+      onWebcamTrackRemoved: (userId) => {
+        console.log("[Voice] Webcam track removed:", userId);
+        import("@/stores/webcamViewer").then(({ removeAvailableTrack }) => {
+          removeAvailableTrack(userId);
+        });
+      },
     });
-    throw new Error(getErrorMessage(result.error));
-  }
 
-  // Start session tracking and metrics collection
-  setVoiceState("sessionId", crypto.randomUUID());
-  setVoiceState("connectedAt", Date.now());
-  startMetricsLoop();
+    const result = await adapter.join(channelId);
+    if (!result.ok) {
+      setVoiceState({
+        state: "disconnected",
+        channelId: null,
+        error: result.error,
+      });
+      throw new Error(getErrorMessage(result.error));
+    }
+
+    // Start session tracking and metrics collection
+    setVoiceState("sessionId", crypto.randomUUID());
+    setVoiceState("connectedAt", Date.now());
+    startMetricsLoop();
+  } finally {
+    isJoining = false;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- **PrivacySettings crash**: Guard Tauri `invoke` calls with `isTauri` check so browser mode doesn't crash on settings page
- **Voice join concurrency**: Add `isJoining` guard to prevent 6+ rapid adapter creations from fast clicks
- **HTTP 405**: Remove `loadChannels()` from Sidebar `onMount` (called `GET /api/channels` which doesn't exist), switch DMs to `getDMList()` endpoint
- **VoicePanel hidden**: Show panel during "connecting" state with amber pulse indicators, not just when fully connected

## Test plan
- [x] 439/439 client tests pass (`bun run test:run`)
- [x] Browser-mode testing: no 405 errors in console after login
- [x] Privacy settings loads without invoke errors in browser mode
- [x] Voice panel shows "Connecting..." state with amber indicators
- [x] Rapid voice clicks show "Join already in progress" guard messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)