### PR TITLE
fix(api,client): CORS hardening, SetupWizard token, default @everyone perms

### DIFF
--- a/client/src/components/SetupWizard.tsx
+++ b/client/src/components/SetupWizard.tsx
@@ -14,6 +14,7 @@
 import { Component, createSignal, createEffect, Show } from "solid-js";
 import { authState, clearSetupRequired } from "@/stores/auth";
 import { AlertCircle, CheckCircle, Server } from "lucide-solid";
+import { getAccessToken } from "@/lib/tauri";
 
 // Setup config interface (matches server API)
 interface SetupConfig {
@@ -83,8 +84,8 @@ async function completeSetup(config: SetupConfig): Promise<void> {
   if (isTauri) {
     const { invoke } = await import("@tauri-apps/api/core");
     accessToken = await invoke<string>("get_access_token");
-  } else if (typeof localStorage !== "undefined") {
-    accessToken = localStorage.getItem("accessToken");
+  } else {
+    accessToken = getAccessToken();
   }
 
   if (!accessToken) {

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -26,7 +26,7 @@ use fred::interfaces::ClientLike;
 use serde::Serialize;
 use sqlx::PgPool;
 use tower_http::compression::CompressionLayer;
-use tower_http::cors::{AllowOrigin, Any, CorsLayer};
+use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer};
 use tower_http::trace::TraceLayer;
 use utoipa::OpenApi;
@@ -114,56 +114,62 @@ impl AppState {
 /// Create the main application router.
 pub fn create_router(state: AppState) -> Router {
     // Configure CORS based on allowed origins
-    let cors = if state.config.cors_allowed_origins.iter().any(|o| o == "*") {
-        // Wildcard `*` is incompatible with `allow_credentials(true)` per the
-        // CORS spec, so mirror the request Origin header instead.
-        tracing::warn!(
-            "CORS wildcard mirrors Origin header; set CORS_ALLOWED_ORIGINS explicitly in production"
-        );
-        CorsLayer::new()
-            .allow_origin(AllowOrigin::mirror_request())
-            .allow_methods(Any)
-            .allow_headers(Any)
-            .allow_credentials(true)
-    } else {
-        // Production mode: restrict to configured origins
+    let cors = {
         use axum::http::{header, HeaderName, Method};
-        let origins: Vec<_> = state
-            .config
-            .cors_allowed_origins
-            .iter()
-            .filter_map(|o| {
-                if let Ok(origin) = o.parse() {
-                    Some(origin)
-                } else {
-                    tracing::warn!(origin = %o, "Invalid CORS origin in configuration, skipping");
-                    None
-                }
-            })
-            .collect();
 
-        if origins.is_empty() {
-            tracing::error!(
-                "No valid CORS origins configured! All cross-origin requests will fail."
+        let allowed_methods = [
+            Method::GET,
+            Method::POST,
+            Method::PUT,
+            Method::PATCH,
+            Method::DELETE,
+            Method::OPTIONS,
+        ];
+        let allowed_headers = [
+            header::CONTENT_TYPE,
+            header::AUTHORIZATION,
+            HeaderName::from_static("x-request-id"),
+        ];
+
+        if state.config.cors_allowed_origins.iter().any(|o| o == "*") {
+            // Wildcard `*` is incompatible with `allow_credentials(true)` per the
+            // CORS spec, so mirror the request Origin header instead.
+            tracing::warn!(
+                "CORS wildcard mirrors Origin header; set CORS_ALLOWED_ORIGINS explicitly in production"
             );
-        }
+            CorsLayer::new()
+                .allow_origin(AllowOrigin::mirror_request())
+                .allow_methods(allowed_methods)
+                .allow_headers(allowed_headers)
+                .allow_credentials(true)
+        } else {
+            // Production mode: restrict to configured origins
+            let origins: Vec<_> = state
+                .config
+                .cors_allowed_origins
+                .iter()
+                .filter_map(|o| {
+                    if let Ok(origin) = o.parse() {
+                        Some(origin)
+                    } else {
+                        tracing::warn!(origin = %o, "Invalid CORS origin in configuration, skipping");
+                        None
+                    }
+                })
+                .collect();
 
-        CorsLayer::new()
-            .allow_origin(origins)
-            .allow_methods([
-                Method::GET,
-                Method::POST,
-                Method::PUT,
-                Method::PATCH,
-                Method::DELETE,
-                Method::OPTIONS,
-            ])
-            .allow_headers([
-                header::CONTENT_TYPE,
-                header::AUTHORIZATION,
-                HeaderName::from_static("x-request-id"),
-            ])
-            .allow_credentials(true)
+            if origins.is_empty() {
+                tracing::error!(
+                    "No valid CORS origins configured! All cross-origin requests will fail."
+                );
+            }
+
+            CorsLayer::new()
+                .allow_origin(origins)
+                .allow_methods(allowed_methods)
+                .allow_headers(allowed_headers)
+                .allow_credentials(true)
+        }
     };
 
     // Get max upload size from config (default 50MB)

--- a/server/src/guild/handlers.rs
+++ b/server/src/guild/handlers.rs
@@ -184,12 +184,13 @@ pub async fn create_guild(
         .execute(&mut *tx)
         .await?;
 
-    // Create default @everyone role
+    // Create default @everyone role with sensible default permissions
     sqlx::query(
         r"INSERT INTO guild_roles (guild_id, name, permissions, position, is_default)
-           VALUES ($1, 'everyone', 0, 0, true)",
+           VALUES ($1, 'everyone', $2, 0, true)",
     )
     .bind(guild_id)
+    .bind(crate::permissions::GuildPermissions::EVERYONE_DEFAULT.bits() as i64)
     .execute(&mut *tx)
     .await?;
 

--- a/server/src/permissions/guild.rs
+++ b/server/src/permissions/guild.rs
@@ -94,7 +94,8 @@ impl GuildPermissions {
     /// Default permissions for the @everyone role.
     ///
     /// Includes basic content and voice permissions that all members should have.
-    pub const EVERYONE_DEFAULT: Self = Self::SEND_MESSAGES
+    pub const EVERYONE_DEFAULT: Self = Self::VIEW_CHANNEL
+        .union(Self::SEND_MESSAGES)
         .union(Self::EMBED_LINKS)
         .union(Self::ATTACH_FILES)
         .union(Self::USE_EMOJI)


### PR DESCRIPTION
## Summary
- **CORS hardening**: Replace `Any` methods/headers with explicit allowlists (`GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS` + `Content-Type`, `Authorization`, `X-Request-Id`), deduplicated between wildcard and production branches
- **SetupWizard token fix**: Use `getAccessToken()` helper instead of raw `localStorage.getItem()` for consistency with the rest of the codebase
- **Default @everyone permissions**: New guilds now create the `@everyone` role with `EVERYONE_DEFAULT` permissions instead of `0`, so members can actually see channels
- **VIEW_CHANNEL added**: `EVERYONE_DEFAULT` constant now includes `VIEW_CHANNEL`

## Test plan
- [x] 439/439 client tests pass (`bun run test:run`)
- [x] `cargo clippy -p vc-server` passes with no warnings
- [x] Self-review: no secrets, correct scope, proper error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)