### PR TITLE
fix(infra): cargo fmt, unused imports, stale advisory, docs date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Roadmap Alignment
 - Current roadmap phase: Phase 6 (Competitive Differentiators & Mastery) - In Progress
-- Roadmap last updated: 2026-02-27
+- Roadmap last updated: 2026-03-11
 
 ### Milestone Metadata
 - Milestone: Phase 6 - Competitive Differentiators & Mastery

--- a/client/src-tauri/src/commands/channel_pins.rs
+++ b/client/src-tauri/src/commands/channel_pins.rs
@@ -64,11 +64,16 @@ pub async fn pin_message(
     let server_url = server_url.ok_or("Not authenticated")?;
     let token = token.ok_or("Not authenticated")?;
 
-    debug!("Pinning message: channel_id={}, message_id={}", channel_id, message_id);
+    debug!(
+        "Pinning message: channel_id={}, message_id={}",
+        channel_id, message_id
+    );
 
     let response = state
         .http
-        .put(format!("{server_url}/api/channels/{channel_id}/messages/{message_id}/pin"))
+        .put(format!(
+            "{server_url}/api/channels/{channel_id}/messages/{message_id}/pin"
+        ))
         .header("Authorization", format!("Bearer {token}"))
         .send()
         .await
@@ -103,11 +108,16 @@ pub async fn unpin_message(
     let server_url = server_url.ok_or("Not authenticated")?;
     let token = token.ok_or("Not authenticated")?;
 
-    debug!("Unpinning message: channel_id={}, message_id={}", channel_id, message_id);
+    debug!(
+        "Unpinning message: channel_id={}, message_id={}",
+        channel_id, message_id
+    );
 
     let response = state
         .http
-        .delete(format!("{server_url}/api/channels/{channel_id}/messages/{message_id}/pin"))
+        .delete(format!(
+            "{server_url}/api/channels/{channel_id}/messages/{message_id}/pin"
+        ))
         .header("Authorization", format!("Bearer {token}"))
         .send()
         .await

--- a/client/src-tauri/src/commands/screen_share.rs
+++ b/client/src-tauri/src/commands/screen_share.rs
@@ -3,9 +3,9 @@
 //! Tauri commands for native screen capture and sharing via WebRTC.
 
 use serde::{Deserialize, Serialize};
+use std::sync::mpsc as std_mpsc;
 use tauri::{command, State};
 use tokio::sync::{mpsc, watch};
-use std::sync::mpsc as std_mpsc;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
@@ -83,8 +83,7 @@ pub async fn start_screen_share(
     stream_id: String,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
-    let stream_uuid = Uuid::parse_str(&stream_id)
-        .map_err(|e| format!("Invalid stream_id: {e}"))?;
+    let stream_uuid = Uuid::parse_str(&stream_id).map_err(|e| format!("Invalid stream_id: {e}"))?;
 
     info!(source_id = %source_id, quality = %quality, stream_id = %stream_id, "Starting screen share");
 
@@ -234,8 +233,7 @@ pub async fn stop_screen_share(
     stream_id: String,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
-    let stream_uuid = Uuid::parse_str(&stream_id)
-        .map_err(|e| format!("Invalid stream_id: {e}"))?;
+    let stream_uuid = Uuid::parse_str(&stream_id).map_err(|e| format!("Invalid stream_id: {e}"))?;
 
     info!(stream_id = %stream_id, "Stopping screen share");
 

--- a/client/src-tauri/src/commands/websocket.rs
+++ b/client/src-tauri/src/commands/websocket.rs
@@ -100,11 +100,7 @@ pub async fn ws_send_custom_status(
     custom_status: Option<serde_json::Value>,
 ) -> Result<(), String> {
     debug!("Sending custom status update: {:?}", custom_status);
-    send_event(
-        &state,
-        ClientEvent::SetCustomStatus { custom_status },
-    )
-    .await
+    send_event(&state, ClientEvent::SetCustomStatus { custom_status }).await
 }
 
 /// Helper to send an event.

--- a/client/src/__tests__/notifications.test.ts
+++ b/client/src/__tests__/notifications.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect } from "vitest";
 
 // We only test the pure formatting function — no mocking needed
 import { formatNotificationContent } from "@/lib/notifications";

--- a/client/src/lib/__tests__/pttManager.test.ts
+++ b/client/src/lib/__tests__/pttManager.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockSetMute = vi.fn().mockResolvedValue(undefined);
 
-import { resolveState, PttConfig, PttController, PttFullConfig, mapCodeToTauriShortcut, keyCodeToLabel } from "@/lib/pttManager";
+import { resolveState, PttController, mapCodeToTauriShortcut, keyCodeToLabel } from "@/lib/pttManager";
 
 describe("resolveState", () => {
   it("returns muted when PTT enabled and no keys held", () => {

--- a/deny.toml
+++ b/deny.toml
@@ -16,9 +16,6 @@ ignore = [
     "RUSTSEC-2025-0008",
     # rsa crate Marvin Attack - no safe upgrade available, used by openidconnect
     "RUSTSEC-2023-0071",
-    # lru IterMut Stacked Borrows violation - transitive dep from aws-sdk-s3, we don't use IterMut
-    # TODO(2026-Q2): Re-check if aws-sdk-s3 has updated lru to >= 0.16.3
-    "RUSTSEC-2026-0002",
 ]
 
 # =============================================================================

--- a/server/src/api/channel_pins.rs
+++ b/server/src/api/channel_pins.rs
@@ -260,7 +260,8 @@ pub async fn pin_message(
 
         // Broadcast system message as MessageNew
         let sys_responses =
-            crate::chat::messages::build_message_responses(&state.db, auth_user.id, vec![sys_msg]).await
+            crate::chat::messages::build_message_responses(&state.db, auth_user.id, vec![sys_msg])
+                .await
                 .unwrap_or_default();
         if let Some(sys_response) = sys_responses.into_iter().next() {
             let message_json = serde_json::to_value(&sys_response).unwrap_or_default();
@@ -332,12 +333,11 @@ pub async fn unpin_message(
     .map_err(|_| ChannelPinsError::Forbidden)?;
 
     // Delete the pin
-    let result =
-        sqlx::query("DELETE FROM channel_pins WHERE channel_id = $1 AND message_id = $2")
-            .bind(channel_id)
-            .bind(message_id)
-            .execute(&state.db)
-            .await?;
+    let result = sqlx::query("DELETE FROM channel_pins WHERE channel_id = $1 AND message_id = $2")
+        .bind(channel_id)
+        .bind(message_id)
+        .execute(&state.db)
+        .await?;
 
     // Only broadcast if a pin was actually removed
     if result.rows_affected() == 0 {

--- a/server/src/auth/handlers.rs
+++ b/server/src/auth/handlers.rs
@@ -18,14 +18,14 @@ use validator::Validate;
 
 use super::backup_codes::{find_matching_backup_code, generate_backup_codes, BACKUP_CODE_COUNT};
 use super::cookies;
-use super::geoip;
 use super::error::{AuthError, AuthResult};
-use super::ua_parser;
+use super::geoip;
 use super::jwt::{generate_token_pair, validate_refresh_token};
 use super::mfa_crypto::{decrypt_mfa_secret, encrypt_mfa_secret};
 use super::middleware::AuthUser;
 use super::oidc::{append_collision_suffix, generate_username_from_claims, OidcFlowState};
 use super::password::{hash_password, verify_password};
+use super::ua_parser;
 use crate::api::AppState;
 use crate::db::{
     self, count_all_mfa_backup_codes, count_unused_mfa_backup_codes, create_password_reset_token,
@@ -68,7 +68,10 @@ fn extract_refresh_token(body_token: Option<String>, jar: &CookieJar) -> AuthRes
 /// (e.g. Tauri) omit `Origin` and receive the token in the response body.
 fn should_return_refresh_token(headers: &HeaderMap) -> bool {
     let has_origin = headers.contains_key(ORIGIN);
-    tracing::debug!(has_origin_header = has_origin, "Refresh token delivery decision");
+    tracing::debug!(
+        has_origin_header = has_origin,
+        "Refresh token delivery decision"
+    );
     !has_origin
 }
 
@@ -577,8 +580,7 @@ pub async fn register(
     let user_agent = extract_user_agent(&headers);
 
     let geo =
-        geoip::resolve_location(&state.http_client, &state.config.geoip_api_url, &addr.ip())
-            .await;
+        geoip::resolve_location(&state.http_client, &state.config.geoip_api_url, &addr.ip()).await;
     let city = geo.as_ref().and_then(|g| g.city.as_deref());
     let country = geo.as_ref().and_then(|g| g.country.as_deref());
 
@@ -797,8 +799,7 @@ pub async fn login(
     let user_agent = extract_user_agent(&headers);
 
     let geo =
-        geoip::resolve_location(&state.http_client, &state.config.geoip_api_url, &addr.ip())
-            .await;
+        geoip::resolve_location(&state.http_client, &state.config.geoip_api_url, &addr.ip()).await;
     let city = geo.as_ref().and_then(|g| g.city.as_deref());
     let country = geo.as_ref().and_then(|g| g.country.as_deref());
 
@@ -935,8 +936,7 @@ pub async fn refresh_token(
     let user_agent = extract_user_agent(&headers);
 
     let geo =
-        geoip::resolve_location(&state.http_client, &state.config.geoip_api_url, &addr.ip())
-            .await;
+        geoip::resolve_location(&state.http_client, &state.config.geoip_api_url, &addr.ip()).await;
     let city = geo.as_ref().and_then(|g| g.city.as_deref());
     let country = geo.as_ref().and_then(|g| g.country.as_deref());
 
@@ -2312,7 +2312,17 @@ pub async fn oidc_callback(
     // Store session
     let token_hash = hash_token(&tokens.refresh_token);
     let expires_at = Utc::now() + Duration::seconds(state.config.jwt_refresh_expiry);
-    create_session(&state.db, user.id, &token_hash, expires_at, None, None, None, None).await?;
+    create_session(
+        &state.db,
+        user.id,
+        &token_hash,
+        expires_at,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await?;
 
     let setup_complete = is_setup_complete(&state.db).await?;
 

--- a/server/src/chat/messages.rs
+++ b/server/src/chat/messages.rs
@@ -1320,13 +1320,12 @@ pub async fn delete(
 
     if deleted {
         // Clean up channel pin if message was pinned
-        let pin_deleted = sqlx::query(
-            "DELETE FROM channel_pins WHERE channel_id = $1 AND message_id = $2",
-        )
-        .bind(channel_id)
-        .bind(id)
-        .execute(&state.db)
-        .await;
+        let pin_deleted =
+            sqlx::query("DELETE FROM channel_pins WHERE channel_id = $1 AND message_id = $2")
+                .bind(channel_id)
+                .bind(id)
+                .execute(&state.db)
+                .await;
 
         if let Ok(result) = pin_deleted {
             if result.rows_affected() > 0 {

--- a/server/src/chat/screenshare.rs
+++ b/server/src/chat/screenshare.rs
@@ -31,7 +31,10 @@ impl IntoResponse for ScreenShareError {
             }
             Self::InternalError => (StatusCode::INTERNAL_SERVER_ERROR, "Internal error"),
             Self::InvalidSourceLabel => (StatusCode::BAD_REQUEST, "Invalid source label"),
-            Self::AlreadySharing => (StatusCode::CONFLICT, "Maximum 3 concurrent screen shares per user"),
+            Self::AlreadySharing => (
+                StatusCode::CONFLICT,
+                "Maximum 3 concurrent screen shares per user",
+            ),
         };
         (status, Json(serde_json::json!({ "error": msg }))).into_response()
     }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -413,9 +413,9 @@ impl Config {
             tempo_url: env::var("TEMPO_URL").ok(),
             loki_url: env::var("LOKI_URL").ok(),
             prometheus_url: env::var("PROMETHEUS_URL").ok(),
-            geoip_api_url: env::var("GEOIP_API_URL").ok().or_else(|| {
-                Some("http://ip-api.com/json/{ip}?fields=city,country".to_string())
-            }),
+            geoip_api_url: env::var("GEOIP_API_URL")
+                .ok()
+                .or_else(|| Some("http://ip-api.com/json/{ip}?fields=city,country".to_string())),
         };
 
         // SameSite=None requires the Secure flag — browsers reject the cookie otherwise

--- a/server/src/db/tests.rs
+++ b/server/src/db/tests.rs
@@ -271,9 +271,18 @@ mod postgres_tests {
 
         // Create valid session (1 hour future)
         let valid_time = Utc::now() + Duration::hours(1);
-        create_session(&pool, user.id, "valid_token", valid_time, None, None, None, None)
-            .await
-            .expect("Failed to create valid session");
+        create_session(
+            &pool,
+            user.id,
+            "valid_token",
+            valid_time,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("Failed to create valid session");
 
         // Cleanup expired sessions
         let cleaned = cleanup_expired_sessions(&pool)

--- a/server/src/guild/handlers.rs
+++ b/server/src/guild/handlers.rs
@@ -204,9 +204,9 @@ pub async fn create_guild(
         .tags
         .map(|t| t.into_iter().map(|s| s.to_lowercase()).collect())
         .unwrap_or_default();
-    let banner_url: Option<String> = body
-        .banner_url
-        .and_then(|u| if u.is_empty() { None } else { Some(u) });
+    let banner_url: Option<String> =
+        body.banner_url
+            .and_then(|u| if u.is_empty() { None } else { Some(u) });
 
     // Insert guild with discovery fields
     let guild_id = Uuid::now_v7();

--- a/server/src/voice/screen_share.rs
+++ b/server/src/voice/screen_share.rs
@@ -257,11 +257,7 @@ impl ScreenShareLimiter {
     }
 
     /// Check if a screen share slot is available (does not reserve it).
-    pub async fn check(
-        &self,
-        channel_id: Uuid,
-        max_shares: u32,
-    ) -> Result<(), ScreenShareError> {
+    pub async fn check(&self, channel_id: Uuid, max_shares: u32) -> Result<(), ScreenShareError> {
         let (allowed, _) = self.run_script(channel_id, max_shares, "check").await?;
         if allowed {
             Ok(())
@@ -271,11 +267,7 @@ impl ScreenShareLimiter {
     }
 
     /// Atomically reserve a screen share slot. Returns error if limit reached.
-    pub async fn start(
-        &self,
-        channel_id: Uuid,
-        max_shares: u32,
-    ) -> Result<(), ScreenShareError> {
+    pub async fn start(&self, channel_id: Uuid, max_shares: u32) -> Result<(), ScreenShareError> {
         let (allowed, _) = self.run_script(channel_id, max_shares, "start").await?;
         if allowed {
             Ok(())

--- a/server/src/voice/sfu.rs
+++ b/server/src/voice/sfu.rs
@@ -606,12 +606,16 @@ impl SfuServer {
 
                     let source_type = if is_secondary_simulcast {
                         // Find the source type from the High layer already stored.
-                        if let Some(st) = room.track_router.find_source_type_for_user(uid, Layer::High) {
+                        if let Some(st) = room
+                            .track_router
+                            .find_source_type_for_user(uid, Layer::High)
+                        {
                             st
                         } else {
                             // High layer hasn't arrived yet — stash and skip.
                             // When High arrives, store_simulcast_track will drain this.
-                            room.track_router.stash_pending_secondary(uid, layer, track.clone());
+                            room.track_router
+                                .stash_pending_secondary(uid, layer, track.clone());
                             return;
                         }
                     } else {
@@ -638,8 +642,12 @@ impl SfuServer {
                     // For video tracks with a valid RID, store in simulcast_tracks.
                     let is_simulcast = !rid.is_empty() && source_type.is_video();
                     if is_simulcast {
-                        room.track_router
-                            .store_simulcast_track(uid, source_type, layer, track.clone());
+                        room.track_router.store_simulcast_track(
+                            uid,
+                            source_type,
+                            layer,
+                            track.clone(),
+                        );
                         debug!(
                             source = %uid,
                             source_type = ?source_type,

--- a/server/src/voice/track.rs
+++ b/server/src/voice/track.rs
@@ -300,10 +300,8 @@ impl TrackRouter {
                 if let Some((_, pending_track)) =
                     self.pending_secondary.remove(&(user_id, pending_layer))
                 {
-                    self.simulcast_tracks.insert(
-                        (user_id, source_type, pending_layer),
-                        pending_track,
-                    );
+                    self.simulcast_tracks
+                        .insert((user_id, source_type, pending_layer), pending_track);
                     debug!(
                         source = %user_id,
                         source_type = ?source_type,
@@ -316,12 +314,7 @@ impl TrackRouter {
     }
 
     /// Stash a secondary simulcast layer that arrived before the High layer.
-    pub fn stash_pending_secondary(
-        &self,
-        user_id: Uuid,
-        layer: Layer,
-        track: Arc<TrackRemote>,
-    ) {
+    pub fn stash_pending_secondary(&self, user_id: Uuid, layer: Layer, track: Arc<TrackRemote>) {
         self.pending_secondary.insert((user_id, layer), track);
         debug!(
             source = %user_id,
@@ -711,10 +704,7 @@ mod simulcast_tests {
 
     #[test]
     fn test_select_layer_auto_medium_bandwidth() {
-        assert_eq!(
-            select_layer(LayerPreference::Auto, 800_000),
-            Layer::Medium
-        );
+        assert_eq!(select_layer(LayerPreference::Auto, 800_000), Layer::Medium);
     }
 
     #[test]
@@ -732,10 +722,7 @@ mod simulcast_tests {
 
     #[test]
     fn test_select_layer_manual_drops_below_ceiling() {
-        assert_eq!(
-            select_layer(LayerPreference::High, 200_000),
-            Layer::Low
-        );
+        assert_eq!(select_layer(LayerPreference::High, 200_000), Layer::Low);
     }
 
     #[test]

--- a/server/src/voice/track_types.rs
+++ b/server/src/voice/track_types.rs
@@ -498,15 +498,39 @@ mod layer_tests {
     #[test]
     fn layer_preference_serde_round_trip() {
         // Verify wire format matches what client sends
-        assert_eq!(serde_json::to_string(&LayerPreference::Auto).unwrap(), "\"auto\"");
-        assert_eq!(serde_json::to_string(&LayerPreference::High).unwrap(), "\"high\"");
-        assert_eq!(serde_json::to_string(&LayerPreference::Medium).unwrap(), "\"medium\"");
-        assert_eq!(serde_json::to_string(&LayerPreference::Low).unwrap(), "\"low\"");
+        assert_eq!(
+            serde_json::to_string(&LayerPreference::Auto).unwrap(),
+            "\"auto\""
+        );
+        assert_eq!(
+            serde_json::to_string(&LayerPreference::High).unwrap(),
+            "\"high\""
+        );
+        assert_eq!(
+            serde_json::to_string(&LayerPreference::Medium).unwrap(),
+            "\"medium\""
+        );
+        assert_eq!(
+            serde_json::to_string(&LayerPreference::Low).unwrap(),
+            "\"low\""
+        );
 
         // Verify deserialization from client-sent strings
-        assert_eq!(serde_json::from_str::<LayerPreference>("\"auto\"").unwrap(), LayerPreference::Auto);
-        assert_eq!(serde_json::from_str::<LayerPreference>("\"high\"").unwrap(), LayerPreference::High);
-        assert_eq!(serde_json::from_str::<LayerPreference>("\"medium\"").unwrap(), LayerPreference::Medium);
-        assert_eq!(serde_json::from_str::<LayerPreference>("\"low\"").unwrap(), LayerPreference::Low);
+        assert_eq!(
+            serde_json::from_str::<LayerPreference>("\"auto\"").unwrap(),
+            LayerPreference::Auto
+        );
+        assert_eq!(
+            serde_json::from_str::<LayerPreference>("\"high\"").unwrap(),
+            LayerPreference::High
+        );
+        assert_eq!(
+            serde_json::from_str::<LayerPreference>("\"medium\"").unwrap(),
+            LayerPreference::Medium
+        );
+        assert_eq!(
+            serde_json::from_str::<LayerPreference>("\"low\"").unwrap(),
+            LayerPreference::Low
+        );
     }
 }

--- a/server/src/voice/ws_handler.rs
+++ b/server/src/voice/ws_handler.rs
@@ -113,7 +113,16 @@ pub async fn handle_voice_event(
             track_source,
             preferred_layer,
         } => {
-            handle_set_layer_preference(sfu, user_id, channel_id, target_user_id, track_source, preferred_layer, tx).await
+            handle_set_layer_preference(
+                sfu,
+                user_id,
+                channel_id,
+                target_user_id,
+                track_source,
+                preferred_layer,
+                tx,
+            )
+            .await
         }
         _ => Ok(()), // Non-voice events handled elsewhere
     }
@@ -612,7 +621,9 @@ async fn handle_screen_share_start(
         const MAX_STREAMS_PER_USER: usize = 3;
         let count = room.get_user_stream_count(params.user_id).await;
         if count >= MAX_STREAMS_PER_USER {
-            return Err(VoiceError::Signaling("Maximum 3 concurrent screen shares per user".to_string()));
+            return Err(VoiceError::Signaling(
+                "Maximum 3 concurrent screen shares per user".to_string(),
+            ));
         }
     }
 

--- a/server/tests/integration/auth.rs
+++ b/server/tests/integration/auth.rs
@@ -263,13 +263,31 @@ async fn test_session_revocation() {
     let token2_hash = vc_server::auth::hash_token("token2");
     let expires_at = chrono::Utc::now() + chrono::Duration::hours(24);
 
-    vc_server::db::create_session(&pool, user.id, &token1_hash, expires_at, None, None, None, None)
-        .await
-        .expect("Session 1 should be created");
+    vc_server::db::create_session(
+        &pool,
+        user.id,
+        &token1_hash,
+        expires_at,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("Session 1 should be created");
 
-    vc_server::db::create_session(&pool, user.id, &token2_hash, expires_at, None, None, None, None)
-        .await
-        .expect("Session 2 should be created");
+    vc_server::db::create_session(
+        &pool,
+        user.id,
+        &token2_hash,
+        expires_at,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("Session 2 should be created");
 
     // Revoke all sessions
     let revoked = vc_server::db::delete_all_user_sessions(&pool, user.id)

--- a/server/tests/integration/channel_pins.rs
+++ b/server/tests/integration/channel_pins.rs
@@ -24,11 +24,13 @@ async fn pin_message(
     message_id: Uuid,
     token: &str,
 ) -> axum::http::Response<Body> {
-    let req =
-        TestApp::request(Method::PUT, &format!("/api/channels/{channel_id}/messages/{message_id}/pin"))
-            .header("Authorization", format!("Bearer {token}"))
-            .body(Body::empty())
-            .unwrap();
+    let req = TestApp::request(
+        Method::PUT,
+        &format!("/api/channels/{channel_id}/messages/{message_id}/pin"),
+    )
+    .header("Authorization", format!("Bearer {token}"))
+    .body(Body::empty())
+    .unwrap();
     app.oneshot(req).await
 }
 
@@ -50,11 +52,7 @@ async fn unpin_message(
 }
 
 /// List pinned messages in a channel.
-async fn list_pins(
-    app: &TestApp,
-    channel_id: Uuid,
-    token: &str,
-) -> serde_json::Value {
+async fn list_pins(app: &TestApp, channel_id: Uuid, token: &str) -> serde_json::Value {
     let req = TestApp::request(Method::GET, &format!("/api/channels/{channel_id}/pins"))
         .header("Authorization", format!("Bearer {token}"))
         .body(Body::empty())
@@ -65,11 +63,7 @@ async fn list_pins(
 }
 
 /// List messages in a channel via the messages API.
-async fn list_messages(
-    app: &TestApp,
-    channel_id: Uuid,
-    token: &str,
-) -> serde_json::Value {
+async fn list_messages(app: &TestApp, channel_id: Uuid, token: &str) -> serde_json::Value {
     let req = TestApp::request(Method::GET, &format!("/api/messages/channel/{channel_id}"))
         .header("Authorization", format!("Bearer {token}"))
         .body(Body::empty())
@@ -81,7 +75,9 @@ async fn list_messages(
 
 /// Default permissions for pin tests: view + send + pin.
 fn pin_perms() -> GuildPermissions {
-    GuildPermissions::VIEW_CHANNEL | GuildPermissions::SEND_MESSAGES | GuildPermissions::PIN_MESSAGES
+    GuildPermissions::VIEW_CHANNEL
+        | GuildPermissions::SEND_MESSAGES
+        | GuildPermissions::PIN_MESSAGES
 }
 
 // ============================================================================
@@ -198,14 +194,9 @@ async fn test_pin_limit_50() {
 
     // Create and pin 50 messages
     for i in 1..=50 {
-        let msg_id =
-            insert_message(&app.pool, channel_id, user_id, &format!("Message {i}")).await;
+        let msg_id = insert_message(&app.pool, channel_id, user_id, &format!("Message {i}")).await;
         let resp = pin_message(&app, channel_id, msg_id, &token).await;
-        assert_eq!(
-            resp.status(),
-            200,
-            "Pin #{i} should succeed (limit is 50)"
-        );
+        assert_eq!(resp.status(), 200, "Pin #{i} should succeed (limit is 50)");
     }
 
     // 51st pin should fail with 409 (PIN_LIMIT_REACHED)
@@ -334,7 +325,9 @@ async fn test_system_message_on_pin() {
     let msgs = list_messages(&app, channel_id, &token).await;
     let items = msgs["items"].as_array().expect("items should be an array");
 
-    let system_msg = items.iter().find(|m| m["message_type"].as_str() == Some("system"));
+    let system_msg = items
+        .iter()
+        .find(|m| m["message_type"].as_str() == Some("system"));
     assert!(
         system_msg.is_some(),
         "Should find a system message after pinning"
@@ -360,8 +353,7 @@ async fn test_pinned_field_in_message_list() {
     guard.add(move |pool| async move { delete_guild(&pool, guild_id).await });
     guard.delete_user(user_id);
 
-    let pinned_msg_id =
-        insert_message(&app.pool, channel_id, user_id, "I will be pinned").await;
+    let pinned_msg_id = insert_message(&app.pool, channel_id, user_id, "I will be pinned").await;
     let _unpinned_msg_id =
         insert_message(&app.pool, channel_id, user_id, "I will not be pinned").await;
 

--- a/server/tests/integration/global_search_http.rs
+++ b/server/tests/integration/global_search_http.rs
@@ -775,7 +775,10 @@ async fn test_global_search_channel_id_filter() {
     assert_eq!(resp.status(), 200);
 
     let json = body_to_json(resp).await;
-    assert_eq!(json["total"], 2, "Without filter, should find both messages");
+    assert_eq!(
+        json["total"], 2,
+        "Without filter, should find both messages"
+    );
 
     // With channel_id filter — should only find the one in ch_a
     let req = global_search_request(&format!("q=guava&channel_id={ch_a}"), &token);


### PR DESCRIPTION
## Summary
- Apply `cargo fmt` to server code (voice, auth, channel_pins, tests)
- Remove unused imports in `notifications.test.ts` and `pttManager.test.ts`
- Remove `RUSTSEC-2026-0002` from `deny.toml` (advisory no longer applies)
- Fix `CHANGELOG.md` roadmap last-updated date (2026-02-27 → 2026-03-11)

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [ ] CI checks should pass (these fixes address the currently failing checks)

🤖 Generated with [Claude Code](https://claude.ai/code)