### PR TITLE
feat(infra): beta launch — monitoring stack, backups, OTel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,3 +120,20 @@ RATE_LIMIT_ALLOWLIST=
 
 # Failed auth blocking (format: max_failures,block_duration_secs,window_secs)
 # RATE_LIMIT_FAILED_AUTH=10,900,300
+
+# =============================================================================
+# Observability (enable with: docker compose --profile monitoring up -d)
+# =============================================================================
+
+# Enable OpenTelemetry telemetry export
+OBSERVABILITY_ENABLED=true
+
+# Trace sampling ratio (1.0 = 100% for beta, 0.1 = 10% for production)
+OTEL_TRACES_SAMPLER_ARG=1.0
+
+# Log level
+RUST_LOG=vc_server=info
+
+# Grafana admin credentials (change in production!)
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=changeme_grafana_password

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Volume mute toggle now remembers pre-mute level and restores it on unmute
 
 ### Added
+- Monitoring stack — Grafana, Prometheus, Tempo, and Loki available via `docker compose --profile monitoring up -d`, with auto-provisioned datasources and Kaiku Overview dashboard (localhost-only, access via VPN)
+- Database backup script — daily pg_dump with 7-day retention (`infra/scripts/backup.sh`), configurable via environment variables
+- OpenTelemetry telemetry — server traces, metrics (RED via spanmetrics), and structured logs exported to the monitoring stack when `OBSERVABILITY_ENABLED=true`
 - QR code login — generate a QR code on desktop to instantly sign in on the Android app, no manual URL entry or credentials needed
 - Android app (Milestone 1) — native Jetpack Compose client with login/register (JWT + OIDC), guild navigation, text messaging with reactions, voice chat via WebRTC SFU, and screen share viewing with simulcast layer selection (#363)
 - Simulcast video — 3-layer adaptive quality (high/medium/low) for screen shares and webcam, with manual viewer override via right-click context menu, quality badge overlay on video tiles, and automatic REMB-based layer switching (SFU monitors viewer bandwidth and adjusts quality in real time with 3-second upgrade hysteresis)

--- a/docs/admin-guide/ops/deployment.md
+++ b/docs/admin-guide/ops/deployment.md
@@ -103,6 +103,47 @@ OIDC_CLIENT_ID=your-client-id
 OIDC_CLIENT_SECRET=your-client-secret
 ```
 
+## Monitoring (Optional)
+
+Start the full monitoring stack alongside core services:
+
+```bash
+cd infra/compose
+docker compose --profile monitoring up -d
+```
+
+This adds Grafana, Prometheus, Tempo, and Loki — all bound to `127.0.0.1` (localhost only). Access via VPN (e.g. Netbird) or SSH tunnel.
+
+**Access Grafana:** `http://localhost:3000` (default: admin / `GRAFANA_ADMIN_PASSWORD` from `.env`)
+
+The "Kaiku Overview" dashboard is auto-provisioned with:
+- Request rate, error rate, P95 latency (from OTel spanmetrics)
+- Request rate and latency by route
+- Server log stream (from Loki)
+
+Make sure `.env` has `OBSERVABILITY_ENABLED=true` (set by default in `.env.example`).
+
+## Database Backups
+
+Set up automated daily backups:
+
+```bash
+# Test the backup script
+./infra/scripts/backup.sh
+
+# Add to crontab (daily at 03:00)
+crontab -e
+# Add: 0 3 * * * /opt/kaiku/infra/scripts/backup.sh >> /var/log/kaiku-backup.log 2>&1
+```
+
+Backups are saved to `/var/lib/kaiku/backups/` with 7-day retention. Configure via environment variables — see the script header for options.
+
+**Restore from backup:**
+```bash
+gunzip -c /var/lib/kaiku/backups/kaiku-2026-03-15_030000.sql.gz | \
+  docker exec -i canis-postgres psql -U voicechat voicechat
+```
+
 ## Services
 
 | Service | Port | Description |
@@ -111,6 +152,11 @@ OIDC_CLIENT_SECRET=your-client-secret
 | Server | 8080 (internal) | Kaiku API + WebSocket |
 | PostgreSQL | 5432 (internal) | Database |
 | Valkey | 6379 (internal) | Cache + pub/sub |
+| Grafana | 127.0.0.1:3000 | Dashboards (monitoring profile) |
+| Prometheus | 127.0.0.1:9090 | Metrics (monitoring profile) |
+| Tempo | 127.0.0.1:3200 | Traces (monitoring profile) |
+| Loki | 127.0.0.1:3100 | Logs (monitoring profile) |
+| OTel Collector | 127.0.0.1:4317 | Telemetry receiver (monitoring profile) |
 
 ## Commands
 

--- a/docs/developer-guide/plans/2026-03-15-beta-launch-stabilization-design.md
+++ b/docs/developer-guide/plans/2026-03-15-beta-launch-stabilization-design.md
@@ -1,0 +1,117 @@
+# Beta Launch Stabilization — Design
+
+**Date:** 2026-03-15
+
+**Goal:** Add a complete monitoring stack to the production Docker Compose, enable built-in OTel telemetry, provision Grafana dashboards, and add automated database backups — enabling a single-VPS beta deployment with full observability from day one.
+
+## Deployment Target
+
+Single VPS (e.g. Hetzner/Contabo) running everything via Docker Compose. Monitoring services are localhost-only, accessible through Netbird VPN. No public exposure of Grafana/Prometheus/Tempo/Loki.
+
+## Architecture
+
+```
+Internet
+  │
+  ├─ TCP 80/443 ──► Traefik (Let's Encrypt TLS)
+  │                    └─► vc-server :8080
+  │
+  └─ UDP 10000-10100 ──► vc-server (WebRTC RTP)
+
+Netbird VPN (localhost only)
+  │
+  ├─ :3000 ──► Grafana (dashboards, logs, traces)
+  ├─ :9090 ──► Prometheus (metrics)
+  ├─ :3200 ──► Tempo (traces)
+  └─ :3100 ──► Loki (logs)
+
+Internal (not exposed)
+  │
+  ├─ vc-server ──OTLP gRPC──► OTel Collector :4317
+  │                              ├──► Tempo
+  │                              ├──► Prometheus (:8889 spanmetrics)
+  │                              └──► Loki
+  │
+  ├─ PostgreSQL :5432
+  └─ Valkey :6379
+```
+
+## Changes Required
+
+### 1. Production Compose — Add Monitoring Services
+
+Add to `infra/compose/docker-compose.yml` under a `monitoring` profile (already partially referenced):
+
+| Service | Image | Ports (localhost) | Volumes |
+|---------|-------|-------------------|---------|
+| otel-collector | `otel/opentelemetry-collector-contrib:0.96.0` | 127.0.0.1:4317 (gRPC), 127.0.0.1:4318 (HTTP) | `../monitoring/otel-collector.yaml` |
+| prometheus | `prom/prometheus:v2.51.0` | 127.0.0.1:9090 | `../monitoring/prometheus.yaml`, `prometheus-data` |
+| tempo | `grafana/tempo:2.4.0` | 127.0.0.1:3200 | `../monitoring/tempo.yaml`, `tempo-data` |
+| loki | `grafana/loki:2.9.0` | 127.0.0.1:3100 | `../monitoring/loki.yaml`, `loki-data` |
+| grafana | `grafana/grafana:10.4.0` | 127.0.0.1:3000 | `../monitoring/grafana/provisioning`, `grafana-data` |
+
+All services in `monitoring` profile so they're opt-in: `docker compose --profile monitoring up -d`.
+
+### 2. Monitoring Config Files
+
+**Already exist (verify/update):**
+- `infra/monitoring/otel-collector.yaml` — receivers, processors, exporters
+- `infra/monitoring/prometheus.yaml` — scrape configs
+
+**Need to create:**
+- `infra/monitoring/tempo.yaml` — Tempo config (local storage, 30-day retention)
+- `infra/monitoring/loki.yaml` — Loki config (local storage, 14-day retention)
+- `infra/monitoring/grafana/provisioning/datasources/datasources.yaml` — auto-provision Prometheus, Tempo, Loki
+- `infra/monitoring/grafana/provisioning/dashboards/dashboards.yaml` — dashboard provider config
+- `infra/monitoring/grafana/provisioning/dashboards/kaiku-overview.json` — pre-built overview dashboard
+
+### 3. Grafana Dashboard — "Kaiku Overview"
+
+Panels:
+- Request rate (req/s) from spanmetrics
+- Error rate (%) from spanmetrics
+- P95 latency (ms) from spanmetrics
+- Active WebSocket connections (gauge)
+- Voice sessions (gauge)
+- Recent logs (Loki log panel)
+- Trace search (Tempo)
+
+### 4. Server Config — Enable OTel
+
+Update `.env.example` and production compose environment:
+```
+OBSERVABILITY_ENABLED=true
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+OTEL_SERVICE_NAME=vc-server
+OTEL_TRACES_SAMPLER_ARG=1.0  # 100% sampling for beta (low traffic)
+```
+
+### 5. Database Backup Script
+
+Create `infra/scripts/backup.sh`:
+- pg_dump to `/backups/kaiku-YYYY-MM-DD.sql.gz`
+- Retain last 7 days
+- Run via host crontab: `0 3 * * * /path/to/backup.sh`
+
+Add backup volume to compose.
+
+### 6. .env.example Update
+
+Add monitoring-related variables with sensible beta defaults. Document which are required vs optional.
+
+## What We're NOT Doing (YAGNI)
+
+- No Sentry integration (Grafana + Loki covers errors)
+- No Kubernetes probes (compose only)
+- No Prometheus alerting rules (watch Grafana manually for beta)
+- No object storage backup (files replaceable for beta)
+- No custom app metrics endpoint (spanmetrics covers RED)
+- No Grafana SSO/OIDC (local admin auth sufficient)
+
+## Success Criteria
+
+1. `docker compose --profile monitoring up -d` starts all monitoring services
+2. Grafana at `localhost:3000` shows Kaiku Overview dashboard with live data
+3. Server logs appear in Loki, traces in Tempo, RED metrics in Prometheus
+4. Database backups run daily, 7-day retention
+5. Zero public exposure of monitoring services

--- a/docs/developer-guide/plans/2026-03-15-beta-launch-stabilization-plan.md
+++ b/docs/developer-guide/plans/2026-03-15-beta-launch-stabilization-plan.md
@@ -1,0 +1,505 @@
+# Beta Launch Stabilization Implementation Plan
+
+**Goal:** Add Grafana, Prometheus, Tempo, and Loki to the production compose file (localhost-only), enable OTel telemetry, provision a Kaiku overview dashboard, and add automated database backups.
+
+**Architecture:** Extend the existing `monitoring` profile in `infra/compose/docker-compose.yml` with downstream services. All monitoring binds to 127.0.0.1 (Netbird access only). Server already has OTel SDK — just needs `OBSERVABILITY_ENABLED=true`.
+
+**Tech Stack:** Docker Compose, Grafana 10.4, Prometheus 2.51, Grafana Tempo 2.4, Grafana Loki 2.9, OTel Collector 0.117
+
+**Design doc:** `docs/developer-guide/plans/2026-03-15-beta-launch-stabilization-design.md`
+
+---
+
+### Task 1: Create Tempo and Loki config files
+
+**Files:**
+- Create: `infra/monitoring/tempo.yaml`
+- Create: `infra/monitoring/loki.yaml`
+
+**Step 1: Create Tempo config**
+
+Create `infra/monitoring/tempo.yaml`:
+
+```yaml
+# Grafana Tempo — distributed trace storage for Kaiku
+# Receives traces from OTel Collector via OTLP gRPC.
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/traces
+    wal:
+      path: /var/tempo/wal
+
+compactor:
+  compaction:
+    block_retention: 720h  # 30 days
+
+metrics_generator:
+  storage:
+    path: /var/tempo/generator/wal
+```
+
+**Step 2: Create Loki config**
+
+Create `infra/monitoring/loki.yaml`:
+
+```yaml
+# Grafana Loki — log aggregation for Kaiku
+# Receives logs from OTel Collector via push API.
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+limits_config:
+  retention_period: 336h  # 14 days
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+```
+
+**Step 3: Commit**
+
+```
+feat(infra): add Tempo and Loki configs for monitoring stack
+```
+
+---
+
+### Task 2: Create Grafana provisioning files
+
+**Files:**
+- Create: `infra/monitoring/grafana/provisioning/datasources/datasources.yaml`
+- Create: `infra/monitoring/grafana/provisioning/dashboards/dashboards.yaml`
+
+**Step 1: Create datasources provisioning**
+
+```yaml
+# Auto-provisioned datasources for Grafana
+# Connects to Prometheus (metrics), Tempo (traces), and Loki (logs).
+
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    editable: false
+    jsonData:
+      tracesToMetrics:
+        datasourceUid: prometheus
+      nodeGraph:
+        enabled: true
+      serviceMap:
+        datasourceUid: prometheus
+
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false
+    jsonData:
+      derivedFields:
+        - datasourceUid: tempo
+          matcherRegex: "trace_id=(\\w+)"
+          name: TraceID
+          url: "$${__value.raw}"
+```
+
+**Step 2: Create dashboard provider config**
+
+```yaml
+# Dashboard provisioning — auto-loads JSON dashboards from /var/lib/grafana/dashboards
+
+apiVersion: 1
+
+providers:
+  - name: Kaiku
+    orgId: 1
+    folder: Kaiku
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false
+```
+
+**Step 3: Commit**
+
+```
+feat(infra): add Grafana datasource and dashboard provisioning
+```
+
+---
+
+### Task 3: Create Kaiku Overview dashboard
+
+**Files:**
+- Create: `infra/monitoring/grafana/provisioning/dashboards/kaiku-overview.json`
+
+**Step 1: Create the dashboard JSON**
+
+Create a Grafana dashboard JSON with these panels:
+- **Row 1 (RED metrics):** Request Rate (req/s), Error Rate (%), P95 Latency (ms) — all from `traces_span_metrics_*` via Prometheus
+- **Row 2 (System):** Active connections gauge, Voice sessions gauge
+- **Row 3 (Logs):** Loki log stream panel with severity filter
+
+The dashboard should use the provisioned datasource names (Prometheus, Tempo, Loki).
+
+Use `traces_span_metrics_calls_total` for request rate, `traces_span_metrics_duration_milliseconds_bucket` for latency histograms.
+
+**Step 2: Commit**
+
+```
+feat(infra): add Kaiku Overview Grafana dashboard
+```
+
+---
+
+### Task 4: Add monitoring services to production compose
+
+**Files:**
+- Modify: `infra/compose/docker-compose.yml`
+
+**Step 1: Bind OTel collector ports to localhost**
+
+Change the existing `otel-collector` ports from public to localhost-only:
+
+```yaml
+    ports:
+      - "127.0.0.1:4317:4317"
+      - "127.0.0.1:4318:4318"
+      - "127.0.0.1:8889:8889"
+```
+
+**Step 2: Add Prometheus service**
+
+Add after `otel-collector`:
+
+```yaml
+  prometheus:
+    image: prom/prometheus:v2.51.0
+    container_name: canis-prometheus
+    restart: unless-stopped
+    profiles: ["monitoring"]
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yaml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=90d"
+      - "--web.enable-lifecycle"
+    volumes:
+      - ../monitoring/prometheus.yaml:/etc/prometheus/prometheus.yaml:ro
+      - ../monitoring/alerts:/etc/prometheus/alerts:ro
+      - prometheus_data:/prometheus
+    ports:
+      - "127.0.0.1:9090:9090"
+    networks:
+      - voicechat
+```
+
+**Step 3: Add Tempo service**
+
+```yaml
+  tempo:
+    image: grafana/tempo:2.4.0
+    container_name: canis-tempo
+    restart: unless-stopped
+    profiles: ["monitoring"]
+    command: ["-config.file=/etc/tempo/tempo.yaml"]
+    volumes:
+      - ../monitoring/tempo.yaml:/etc/tempo/tempo.yaml:ro
+      - tempo_data:/var/tempo
+    ports:
+      - "127.0.0.1:3200:3200"
+    networks:
+      - voicechat
+```
+
+**Step 4: Add Loki service**
+
+```yaml
+  loki:
+    image: grafana/loki:2.9.0
+    container_name: canis-loki
+    restart: unless-stopped
+    profiles: ["monitoring"]
+    command: ["-config.file=/etc/loki/loki.yaml"]
+    volumes:
+      - ../monitoring/loki.yaml:/etc/loki/loki.yaml:ro
+      - loki_data:/loki
+    ports:
+      - "127.0.0.1:3100:3100"
+    networks:
+      - voicechat
+```
+
+**Step 5: Add Grafana service**
+
+```yaml
+  grafana:
+    image: grafana/grafana:10.4.0
+    container_name: canis-grafana
+    restart: unless-stopped
+    profiles: ["monitoring"]
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_SERVER_ROOT_URL=http://localhost:3000
+    volumes:
+      - ../monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ../monitoring/grafana/provisioning/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    ports:
+      - "127.0.0.1:3000:3000"
+    networks:
+      - voicechat
+    depends_on:
+      - prometheus
+      - tempo
+      - loki
+```
+
+**Step 6: Add volumes**
+
+Add to the `volumes:` section:
+
+```yaml
+  prometheus_data:
+  tempo_data:
+  loki_data:
+  grafana_data:
+  backups:
+```
+
+**Step 7: Commit**
+
+```
+feat(infra): add Grafana, Prometheus, Tempo, Loki to compose
+```
+
+---
+
+### Task 5: Enable OTel in server config and .env.example
+
+**Files:**
+- Modify: `infra/compose/docker-compose.yml` (server environment)
+- Modify: `.env.example`
+
+**Step 1: Add OTel env vars to server service**
+
+Add to the `server` service `environment` list in compose:
+
+```yaml
+      # Observability (enable with --profile monitoring)
+      - OBSERVABILITY_ENABLED=${OBSERVABILITY_ENABLED:-false}
+      - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-collector:4317}
+      - OTEL_SERVICE_NAME=vc-server
+      - OTEL_TRACES_SAMPLER_ARG=${OTEL_TRACES_SAMPLER_ARG:-1.0}
+      - RUST_LOG=${RUST_LOG:-vc_server=info}
+```
+
+**Step 2: Add monitoring section to .env.example**
+
+Add to `.env.example`:
+
+```bash
+# =============================================================================
+# Observability (enable with: docker compose --profile monitoring up -d)
+# =============================================================================
+
+# Enable OpenTelemetry telemetry export
+OBSERVABILITY_ENABLED=true
+
+# Trace sampling ratio (1.0 = 100% for beta, 0.1 = 10% for production)
+OTEL_TRACES_SAMPLER_ARG=1.0
+
+# Log level
+RUST_LOG=vc_server=info
+
+# Grafana admin credentials (change in production!)
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=changeme_grafana_password
+```
+
+**Step 3: Commit**
+
+```
+feat(infra): enable OTel in server config and .env.example
+```
+
+---
+
+### Task 6: Create database backup script
+
+**Files:**
+- Create: `infra/scripts/backup.sh`
+
+**Step 1: Create the backup script**
+
+```bash
+#!/usr/bin/env bash
+# Daily PostgreSQL backup for Kaiku
+# Usage: Add to crontab: 0 3 * * * /path/to/infra/scripts/backup.sh
+#
+# Retention: 7 days (older backups auto-deleted)
+
+set -euo pipefail
+
+BACKUP_DIR="${BACKUP_DIR:-/var/lib/kaiku/backups}"
+CONTAINER="${POSTGRES_CONTAINER:-canis-postgres}"
+DB_USER="${POSTGRES_USER:-voicechat}"
+DB_NAME="${POSTGRES_DB:-voicechat}"
+RETENTION_DAYS=7
+TIMESTAMP=$(date +%Y-%m-%d_%H%M%S)
+BACKUP_FILE="${BACKUP_DIR}/kaiku-${TIMESTAMP}.sql.gz"
+
+mkdir -p "$BACKUP_DIR"
+
+echo "[$(date)] Starting backup..."
+
+# Dump and compress
+docker exec "$CONTAINER" pg_dump -U "$DB_USER" "$DB_NAME" | gzip > "$BACKUP_FILE"
+
+# Verify
+if [ -s "$BACKUP_FILE" ]; then
+    SIZE=$(du -h "$BACKUP_FILE" | cut -f1)
+    echo "[$(date)] Backup complete: $BACKUP_FILE ($SIZE)"
+else
+    echo "[$(date)] ERROR: Backup file is empty!" >&2
+    rm -f "$BACKUP_FILE"
+    exit 1
+fi
+
+# Prune old backups
+find "$BACKUP_DIR" -name "kaiku-*.sql.gz" -mtime +$RETENTION_DAYS -delete
+REMAINING=$(find "$BACKUP_DIR" -name "kaiku-*.sql.gz" | wc -l)
+echo "[$(date)] Retained $REMAINING backup(s)"
+```
+
+**Step 2: Make executable**
+
+```bash
+chmod +x infra/scripts/backup.sh
+```
+
+**Step 3: Commit**
+
+```
+feat(infra): add daily database backup script with 7-day retention
+```
+
+---
+
+### Task 7: Update deployment docs and CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `docs/admin-guide/ops/deployment.md`
+
+**Step 1: Add CHANGELOG entry**
+
+Under `[Unreleased] → ### Added`:
+
+```
+- Monitoring stack — Grafana, Prometheus, Tempo, and Loki available via `--profile monitoring`, with auto-provisioned datasources and Kaiku Overview dashboard (localhost-only, access via VPN)
+- Database backup script — daily pg_dump with 7-day retention (`infra/scripts/backup.sh`)
+- OpenTelemetry telemetry — traces, metrics, and logs exported to monitoring stack when `OBSERVABILITY_ENABLED=true`
+```
+
+**Step 2: Add monitoring section to deployment docs**
+
+Add a "Monitoring" section to `docs/admin-guide/ops/deployment.md` explaining:
+- How to start with monitoring: `docker compose --profile monitoring up -d`
+- How to access Grafana (localhost:3000 via VPN)
+- How to set up the backup cron job
+- Default Grafana credentials
+
+**Step 3: Commit**
+
+```
+docs(infra): update deployment docs and CHANGELOG for beta
+```
+
+---
+
+### Task 8: Final verification
+
+**Step 1: Validate compose syntax**
+
+```bash
+cd infra/compose && docker compose --profile monitoring config --quiet
+```
+
+Expected: no errors.
+
+**Step 2: Verify all config files are valid YAML**
+
+```bash
+python3 -c "
+import yaml, sys
+for f in ['infra/monitoring/tempo.yaml', 'infra/monitoring/loki.yaml',
+          'infra/monitoring/grafana/provisioning/datasources/datasources.yaml',
+          'infra/monitoring/grafana/provisioning/dashboards/dashboards.yaml']:
+    try:
+        yaml.safe_load(open(f))
+        print(f'OK: {f}')
+    except Exception as e:
+        print(f'FAIL: {f}: {e}')
+        sys.exit(1)
+"
+```
+
+**Step 3: Verify .env.example has all referenced variables**
+
+```bash
+grep -oP '\$\{(\w+)' infra/compose/docker-compose.yml | sort -u | sed 's/\${//' | while read var; do
+  grep -q "^${var}=" .env.example || echo "MISSING: $var"
+done
+```

--- a/infra/compose/docker-compose.yml
+++ b/infra/compose/docker-compose.yml
@@ -2,7 +2,8 @@
 #
 # Usage:
 #   1. Copy .env.example to .env and configure
-#   2. docker compose up -d
+#   2. docker compose up -d                             (core services)
+#      docker compose --profile monitoring up -d        (with monitoring)
 #
 # Required environment variables (see .env.example):
 #   - DOMAIN: Your domain (e.g., chat.example.com)
@@ -45,6 +46,12 @@ services:
       - RATE_LIMIT_ENABLED=${RATE_LIMIT_ENABLED:-true}
       - RATE_LIMIT_TRUST_PROXY=${RATE_LIMIT_TRUST_PROXY:-true}
       - RATE_LIMIT_ALLOWLIST=${RATE_LIMIT_ALLOWLIST:-}
+      # Observability (enable with --profile monitoring)
+      - OBSERVABILITY_ENABLED=${OBSERVABILITY_ENABLED:-false}
+      - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-collector:4317}
+      - OTEL_SERVICE_NAME=vc-server
+      - OTEL_TRACES_SAMPLER_ARG=${OTEL_TRACES_SAMPLER_ARG:-1.0}
+      - RUST_LOG=${RUST_LOG:-vc_server=info}
     ports:
       # WebRTC UDP ports for voice
       - "${RTP_PORT_MIN:-10000}-${RTP_PORT_MAX:-10100}:${RTP_PORT_MIN:-10000}-${RTP_PORT_MAX:-10100}/udp"
@@ -138,11 +145,94 @@ services:
     volumes:
       - ../monitoring/otel-collector.yaml:/etc/otelcol-contrib/config.yaml:ro
     ports:
-      - "4317:4317"   # OTLP gRPC
-      - "4318:4318"   # OTLP HTTP
-      - "8889:8889"   # Prometheus metrics scrape endpoint
+      - "127.0.0.1:4317:4317"   # OTLP gRPC (localhost only)
+      - "127.0.0.1:4318:4318"   # OTLP HTTP (localhost only)
+      - "127.0.0.1:8889:8889"   # Prometheus scrape endpoint
     networks:
       - voicechat
+
+  # ==========================================================================
+  # Prometheus (monitoring profile)
+  # ==========================================================================
+  prometheus:
+    image: prom/prometheus:v2.51.0
+    container_name: canis-prometheus
+    restart: unless-stopped
+    profiles: ["monitoring"]
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yaml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=90d"
+      - "--web.enable-lifecycle"
+    volumes:
+      - ../monitoring/prometheus.yaml:/etc/prometheus/prometheus.yaml:ro
+      - ../monitoring/alerts:/etc/prometheus/alerts:ro
+      - prometheus_data:/prometheus
+    ports:
+      - "127.0.0.1:9090:9090"
+    networks:
+      - voicechat
+
+  # ==========================================================================
+  # Grafana Tempo — Trace Storage (monitoring profile)
+  # ==========================================================================
+  tempo:
+    image: grafana/tempo:2.4.0
+    container_name: canis-tempo
+    restart: unless-stopped
+    profiles: ["monitoring"]
+    command: ["-config.file=/etc/tempo/tempo.yaml"]
+    volumes:
+      - ../monitoring/tempo.yaml:/etc/tempo/tempo.yaml:ro
+      - tempo_data:/var/tempo
+    ports:
+      - "127.0.0.1:3200:3200"
+    networks:
+      - voicechat
+
+  # ==========================================================================
+  # Grafana Loki — Log Aggregation (monitoring profile)
+  # ==========================================================================
+  loki:
+    image: grafana/loki:2.9.0
+    container_name: canis-loki
+    restart: unless-stopped
+    profiles: ["monitoring"]
+    command: ["-config.file=/etc/loki/loki.yaml"]
+    volumes:
+      - ../monitoring/loki.yaml:/etc/loki/loki.yaml:ro
+      - loki_data:/loki
+    ports:
+      - "127.0.0.1:3100:3100"
+    networks:
+      - voicechat
+
+  # ==========================================================================
+  # Grafana — Dashboards (monitoring profile)
+  # Access via Netbird VPN at http://localhost:3000
+  # ==========================================================================
+  grafana:
+    image: grafana/grafana:10.4.0
+    container_name: canis-grafana
+    restart: unless-stopped
+    profiles: ["monitoring"]
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_SERVER_ROOT_URL=http://localhost:3000
+    volumes:
+      - ../monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ../monitoring/grafana/provisioning/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    ports:
+      - "127.0.0.1:3000:3000"
+    networks:
+      - voicechat
+    depends_on:
+      - prometheus
+      - tempo
+      - loki
 
 networks:
   voicechat:
@@ -152,3 +242,7 @@ volumes:
   postgres_data:
   valkey_data:
   letsencrypt:
+  prometheus_data:
+  tempo_data:
+  loki_data:
+  grafana_data:

--- a/infra/monitoring/grafana/provisioning/dashboards/dashboards.yaml
+++ b/infra/monitoring/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,14 @@
+# Dashboard provisioning — auto-loads JSON dashboards
+
+apiVersion: 1
+
+providers:
+  - name: Kaiku
+    orgId: 1
+    folder: Kaiku
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/infra/monitoring/grafana/provisioning/dashboards/kaiku-overview.json
+++ b/infra/monitoring/grafana/provisioning/dashboards/kaiku-overview.json
@@ -1,0 +1,171 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "title": "RED Metrics (from Traces)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 20, "lineWidth": 2 },
+          "unit": "reqps"
+        }
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 1 },
+      "id": 2,
+      "options": { "legend": { "displayMode": "list" }, "tooltip": { "mode": "multi" } },
+      "title": "Request Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(traces_span_metrics_calls_total{service_name=\"vc-server\", span_kind=\"SPAN_KIND_SERVER\"}[5m]))",
+          "legendFormat": "req/s"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "fixedColor": "red", "mode": "fixed" },
+          "custom": { "fillOpacity": 20, "lineWidth": 2 },
+          "unit": "percentunit",
+          "max": 1, "min": 0
+        }
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 1 },
+      "id": 3,
+      "title": "Error Rate",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(traces_span_metrics_calls_total{service_name=\"vc-server\", span_kind=\"SPAN_KIND_SERVER\", status_code=\"STATUS_CODE_ERROR\"}[5m])) / sum(rate(traces_span_metrics_calls_total{service_name=\"vc-server\", span_kind=\"SPAN_KIND_SERVER\"}[5m]))",
+          "legendFormat": "error %"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "fixedColor": "yellow", "mode": "fixed" },
+          "custom": { "fillOpacity": 20, "lineWidth": 2 },
+          "unit": "ms"
+        }
+      },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 1 },
+      "id": 4,
+      "title": "P95 Latency",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum(rate(traces_span_metrics_duration_milliseconds_bucket{service_name=\"vc-server\", span_kind=\"SPAN_KIND_SERVER\"}[5m])) by (le))",
+          "legendFormat": "p95"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 9 },
+      "id": 5,
+      "title": "Top Routes",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 20, "lineWidth": 2, "stacking": { "mode": "normal" } },
+          "unit": "reqps"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 10 },
+      "id": 6,
+      "title": "Request Rate by Route",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (http_route) (rate(traces_span_metrics_calls_total{service_name=\"vc-server\", span_kind=\"SPAN_KIND_SERVER\", http_route!=\"\"}[5m]))",
+          "legendFormat": "{{ http_route }}"
+        }
+      ]
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 20, "lineWidth": 2, "stacking": { "mode": "normal" } },
+          "unit": "ms"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 10 },
+      "id": 7,
+      "title": "P95 Latency by Route",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum by (le, http_route) (rate(traces_span_metrics_duration_milliseconds_bucket{service_name=\"vc-server\", span_kind=\"SPAN_KIND_SERVER\", http_route!=\"\"}[5m])))",
+          "legendFormat": "{{ http_route }}"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 18 },
+      "id": 8,
+      "title": "Logs",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "loki", "uid": "loki" },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 19 },
+      "id": 9,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "title": "Server Logs",
+      "type": "logs",
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "{service_name=\"vc-server\"} |= ``",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["kaiku", "overview"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Kaiku Overview",
+  "uid": "kaiku-overview",
+  "version": 1
+}

--- a/infra/monitoring/grafana/provisioning/datasources/datasources.yaml
+++ b/infra/monitoring/grafana/provisioning/datasources/datasources.yaml
@@ -1,0 +1,37 @@
+# Auto-provisioned datasources for Grafana
+# Connects to Prometheus (metrics), Tempo (traces), and Loki (logs).
+
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    editable: false
+    jsonData:
+      tracesToMetrics:
+        datasourceUid: prometheus
+      nodeGraph:
+        enabled: true
+      serviceMap:
+        datasourceUid: prometheus
+
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false
+    jsonData:
+      derivedFields:
+        - datasourceUid: tempo
+          matcherRegex: "trace_id=(\\w+)"
+          name: TraceID
+          url: "$${__value.raw}"

--- a/infra/monitoring/loki.yaml
+++ b/infra/monitoring/loki.yaml
@@ -1,0 +1,37 @@
+# Grafana Loki — log aggregation for Kaiku
+# Receives logs from OTel Collector via push API.
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+limits_config:
+  retention_period: 336h  # 14 days
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true

--- a/infra/monitoring/tempo.yaml
+++ b/infra/monitoring/tempo.yaml
@@ -1,0 +1,28 @@
+# Grafana Tempo — distributed trace storage for Kaiku
+# Receives traces from OTel Collector via OTLP gRPC.
+
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/traces
+    wal:
+      path: /var/tempo/wal
+
+compactor:
+  compaction:
+    block_retention: 720h  # 30 days
+
+metrics_generator:
+  storage:
+    path: /var/tempo/generator/wal

--- a/infra/scripts/backup.sh
+++ b/infra/scripts/backup.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Daily PostgreSQL backup for Kaiku
+#
+# Usage:
+#   ./infra/scripts/backup.sh
+#
+# Crontab (daily at 03:00):
+#   0 3 * * * /opt/kaiku/infra/scripts/backup.sh >> /var/log/kaiku-backup.log 2>&1
+#
+# Environment variables (all optional, defaults shown):
+#   BACKUP_DIR=/var/lib/kaiku/backups
+#   POSTGRES_CONTAINER=canis-postgres
+#   POSTGRES_USER=voicechat
+#   POSTGRES_DB=voicechat
+#   RETENTION_DAYS=7
+
+set -euo pipefail
+
+BACKUP_DIR="${BACKUP_DIR:-/var/lib/kaiku/backups}"
+CONTAINER="${POSTGRES_CONTAINER:-canis-postgres}"
+DB_USER="${POSTGRES_USER:-voicechat}"
+DB_NAME="${POSTGRES_DB:-voicechat}"
+RETENTION_DAYS="${RETENTION_DAYS:-7}"
+TIMESTAMP=$(date +%Y-%m-%d_%H%M%S)
+BACKUP_FILE="${BACKUP_DIR}/kaiku-${TIMESTAMP}.sql.gz"
+
+mkdir -p "$BACKUP_DIR"
+
+echo "[$(date)] Starting backup..."
+
+# Dump and compress
+docker exec "$CONTAINER" pg_dump -U "$DB_USER" "$DB_NAME" | gzip > "$BACKUP_FILE"
+
+# Verify
+if [ -s "$BACKUP_FILE" ]; then
+    SIZE=$(du -h "$BACKUP_FILE" | cut -f1)
+    echo "[$(date)] Backup complete: $BACKUP_FILE ($SIZE)"
+else
+    echo "[$(date)] ERROR: Backup file is empty!" >&2
+    rm -f "$BACKUP_FILE"
+    exit 1
+fi
+
+# Prune old backups
+find "$BACKUP_DIR" -name "kaiku-*.sql.gz" -mtime +"$RETENTION_DAYS" -delete
+REMAINING=$(find "$BACKUP_DIR" -name "kaiku-*.sql.gz" | wc -l)
+echo "[$(date)] Retained $REMAINING backup(s)"


### PR DESCRIPTION
## Summary
- **Monitoring stack** under `--profile monitoring`: Grafana (dashboards), Prometheus (metrics), Tempo (traces), Loki (logs), OTel Collector (telemetry receiver)
- **All monitoring services bind to 127.0.0.1** — no public exposure, access via Netbird VPN only
- **Kaiku Overview dashboard** auto-provisioned in Grafana with: request rate, error rate, P95 latency, rate/latency by route, server log stream
- **OTel telemetry** enabled via `OBSERVABILITY_ENABLED=true` in `.env.example` — server traces, RED metrics (via spanmetrics), and structured logs
- **Database backup script** (`infra/scripts/backup.sh`) — daily pg_dump with 7-day retention, add to crontab
- **Deployment docs updated** with monitoring setup, backup configuration, and expanded services table

### Quick start
```bash
cp .env.example .env && nano .env
cd infra/compose
docker compose --profile monitoring up -d
# Grafana at http://localhost:3000 (via VPN)
```

## Test plan
- [ ] `docker compose --profile monitoring config` validates without errors
- [ ] All YAML configs parse correctly (tempo, loki, otel-collector, prometheus, grafana provisioning)
- [ ] Dashboard JSON is valid
- [ ] Start monitoring stack — all services come up healthy
- [ ] Grafana shows Kaiku Overview dashboard with datasources connected
- [ ] Server with `OBSERVABILITY_ENABLED=true` sends traces/logs to collector
- [ ] Backup script produces valid gzipped SQL dump
- [ ] Old backups pruned after retention period

🤖 Generated with [Claude Code](https://claude.ai/code)