### PR TITLE
feat(infra): beta deployment config for kaiku.pmind.de

### DIFF
--- a/client/.env.beta
+++ b/client/.env.beta
@@ -1,0 +1,2 @@
+# Client configuration for kaiku.pmind.de beta
+VITE_SERVER_URL=https://kaiku.pmind.de

--- a/docs/admin-guide/ops/deployment.md
+++ b/docs/admin-guide/ops/deployment.md
@@ -13,8 +13,8 @@ This guide covers deploying Kaiku on a self-hosted server.
 
 ```bash
 # Clone the repository
-git clone https://github.com/Wolftown-io/canis.git
-cd canis
+git clone https://github.com/Detair/kaiku.git
+cd kaiku
 
 # Copy and configure environment
 cp .env.example .env
@@ -26,6 +26,28 @@ docker compose up -d
 
 # Check logs
 docker compose logs -f server
+```
+
+### Beta Quick Start (kaiku.pmind.de)
+
+```bash
+cd infra/compose
+cp .env.beta .env
+nano .env  # Replace all CHANGEME values with generated secrets
+
+# Generate secrets:
+# POSTGRES_PASSWORD=$(openssl rand -base64 24)
+# JWT_SECRET=$(openssl rand -hex 32)
+# MFA_ENCRYPTION_KEY=$(openssl rand -hex 32)
+# VALKEY_PASSWORD=$(openssl rand -base64 16)
+# GRAFANA_ADMIN_PASSWORD=$(openssl rand -base64 16)
+
+# Start with monitoring
+docker compose --profile monitoring up -d
+
+# Set up daily backups
+crontab -e
+# Add: 0 3 * * * /opt/kaiku/infra/scripts/backup.sh >> /var/log/kaiku-backup.log 2>&1
 ```
 
 ## Configuration

--- a/infra/compose/.env.beta
+++ b/infra/compose/.env.beta
@@ -1,0 +1,84 @@
+# Kaiku Beta Deployment — kaiku.pmind.de
+#
+# Usage:
+#   1. Copy to .env:  cp .env.beta .env
+#   2. Fill in secrets (marked CHANGEME)
+#   3. docker compose --profile monitoring up -d
+#
+# Secrets to generate before first deploy:
+#   POSTGRES_PASSWORD=$(openssl rand -base64 24)
+#   JWT_SECRET=$(openssl rand -hex 32)
+#   MFA_ENCRYPTION_KEY=$(openssl rand -hex 32)
+#   GRAFANA_ADMIN_PASSWORD=$(openssl rand -base64 16)
+#   VALKEY_PASSWORD=$(openssl rand -base64 16)
+
+# =============================================================================
+# Domain & TLS
+# =============================================================================
+DOMAIN=kaiku.pmind.de
+ACME_EMAIL=CHANGEME@pmind.de
+
+# =============================================================================
+# Database
+# =============================================================================
+POSTGRES_PASSWORD=CHANGEME
+
+# =============================================================================
+# Authentication
+# =============================================================================
+JWT_SECRET=CHANGEME
+JWT_ACCESS_EXPIRY=900
+JWT_REFRESH_EXPIRY=604800
+MFA_ENCRYPTION_KEY=CHANGEME
+
+# =============================================================================
+# Valkey (Redis-compatible cache)
+# =============================================================================
+VALKEY_PASSWORD=CHANGEME
+ALLOW_EMPTY_PASSWORD=no
+
+# =============================================================================
+# WebRTC Voice
+# =============================================================================
+STUN_SERVER=stun:stun.l.google.com:19302
+RTP_PORT_MIN=10000
+RTP_PORT_MAX=10100
+# PUBLIC_IP=  # Set if auto-detection fails
+
+# TURN server (recommended for users behind restrictive NATs)
+# TURN_SERVER=turn:turn.pmind.de:3478
+# TURN_USERNAME=kaiku
+# TURN_CREDENTIAL=CHANGEME
+
+# =============================================================================
+# Rate Limiting
+# =============================================================================
+RATE_LIMIT_ENABLED=true
+RATE_LIMIT_TRUST_PROXY=true
+
+# =============================================================================
+# Observability
+# =============================================================================
+OBSERVABILITY_ENABLED=true
+OTEL_TRACES_SAMPLER_ARG=1.0
+RUST_LOG=vc_server=info
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=CHANGEME
+
+# =============================================================================
+# CORS (restrict to beta domain)
+# =============================================================================
+CORS_ALLOWED_ORIGINS=https://kaiku.pmind.de
+
+# =============================================================================
+# Storage (optional — leave empty to disable file uploads)
+# =============================================================================
+S3_ENDPOINT=
+S3_BUCKET=voicechat
+
+# =============================================================================
+# OIDC/SSO (optional)
+# =============================================================================
+OIDC_ISSUER_URL=
+OIDC_CLIENT_ID=
+OIDC_CLIENT_SECRET=


### PR DESCRIPTION
## Summary
- **`infra/compose/.env.beta`** — production env file for kaiku.pmind.de with all config pre-filled (secrets marked CHANGEME)
- **`client/.env.beta`** — client build config pointing to `https://kaiku.pmind.de`
- **Deployment docs** — added beta quickstart section with secret generation commands
- **CORS** — restricted to `https://kaiku.pmind.de`

### Deploy steps
```bash
cd infra/compose
cp .env.beta .env
nano .env  # replace CHANGEME values
docker compose --profile monitoring up -d
```

## Test plan
- [ ] Verify `.env.beta` has no real secrets (all marked CHANGEME)
- [ ] Verify CORS is set to `https://kaiku.pmind.de`
- [ ] Verify client `.env.beta` points to `https://kaiku.pmind.de`

🤖 Generated with [Claude Code](https://claude.ai/code)