### PR TITLE
feat(voice): PUBLIC_IP NAT 1:1 for voice in Docker

### DIFF
--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -132,6 +132,11 @@ pub struct Config {
     /// WebRTC TURN credential (optional)
     pub turn_credential: Option<String>,
 
+    /// Public IP for WebRTC NAT traversal.
+    /// Required when the SFU runs behind NAT/Docker so ICE candidates
+    /// advertise the reachable IP instead of the container-internal IP.
+    pub public_ip: Option<String>,
+
     /// MFA secret encryption key (32-byte hex string)
     pub mfa_encryption_key: Option<String>,
 
@@ -308,6 +313,7 @@ impl Config {
             turn_server: env::var("TURN_SERVER").ok(),
             turn_username: env::var("TURN_USERNAME").ok(),
             turn_credential: env::var("TURN_CREDENTIAL").ok(),
+            public_ip: env::var("PUBLIC_IP").ok(),
             mfa_encryption_key: env::var("MFA_ENCRYPTION_KEY").ok(),
             require_e2ee_setup: env::var("REQUIRE_E2EE_SETUP")
                 .ok()
@@ -495,6 +501,7 @@ impl Config {
             turn_server: None,
             turn_username: None,
             turn_credential: None,
+            public_ip: None,
             mfa_encryption_key: Some(TEST_MFA_ENCRYPTION_KEY.into()),
             require_e2ee_setup: false,
             block_check_fail_open: false,

--- a/server/src/voice/sfu.rs
+++ b/server/src/voice/sfu.rs
@@ -10,7 +10,9 @@ use tracing::{debug, info, warn};
 use uuid::Uuid;
 use webrtc::api::interceptor_registry::register_default_interceptors;
 use webrtc::api::media_engine::MediaEngine;
+use webrtc::api::setting_engine::SettingEngine;
 use webrtc::api::{APIBuilder, API};
+use webrtc::ice::network_type::NetworkType;
 use webrtc::ice_transport::ice_server::RTCIceServer;
 use webrtc::interceptor::registry::Registry;
 use webrtc::peer_connection::configuration::RTCConfiguration;
@@ -419,10 +421,22 @@ impl SfuServer {
         registry = register_default_interceptors(registry, &mut media_engine)
             .map_err(|e| VoiceError::WebRtc(e.to_string()))?;
 
+        // Configure SettingEngine for NAT traversal behind Docker/VPS
+        let mut setting_engine = SettingEngine::default();
+        if let Some(ref public_ip) = config.public_ip {
+            setting_engine.set_nat_1to1_ips(
+                vec![public_ip.clone()],
+                webrtc::ice_transport::ice_candidate_type::RTCIceCandidateType::Host,
+            );
+            setting_engine.set_network_types(vec![NetworkType::Udp4, NetworkType::Udp6]);
+            info!(public_ip = %public_ip, "SFU NAT 1:1 IP configured");
+        }
+
         // Build WebRTC API
         let api = APIBuilder::new()
             .with_media_engine(media_engine)
             .with_interceptor_registry(registry)
+            .with_setting_engine(setting_engine)
             .build();
 
         info!("SFU server initialized");


### PR DESCRIPTION
SFU now uses PUBLIC_IP env var for ICE candidate NAT traversal. Fixes voice stuck on 'Connecting...' when deployed behind Docker/NAT.