### PR TITLE
fix(client): code block and inline code styling

### DIFF
--- a/client/src/components/messages/MessageItem.tsx
+++ b/client/src/components/messages/MessageItem.tsx
@@ -436,7 +436,7 @@ const MessageItem: Component<MessageItemProps> = (props) => {
       const blocks: ContentBlock[] = [];
 
       // Split content by fenced code blocks
-      const codeBlockRegex = /```(\w+)?\n([\s\S]*?)```/g;
+      const codeBlockRegex = /```(\w+)?\s*\n?([\s\S]*?)```/g;
       let lastIndex = 0;
       let match;
 

--- a/client/src/styles/global.css
+++ b/client/src/styles/global.css
@@ -129,6 +129,34 @@ textarea.bg-transparent {
   color: inherit;
 }
 
+/* Inline code (single backticks) — Slack-style */
+code {
+  font-family: "JetBrains Mono", "Fira Code", "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.85em;
+  background-color: var(--color-surface-layer2);
+  border: 1px solid var(--color-border-default);
+  border-radius: 4px;
+  padding: 1px 5px;
+}
+
+/* Fenced code blocks (triple backticks) — rendered by marked as <pre><code> */
+pre {
+  background-color: var(--color-surface-layer2);
+  border: 1px solid var(--color-border-default);
+  border-radius: 8px;
+  padding: 12px 16px;
+  margin: 8px 0;
+  overflow-x: auto;
+}
+
+pre code {
+  background-color: transparent;
+  border: none;
+  padding: 0;
+  font-size: 0.85em;
+  line-height: 1.5;
+}
+
 /* Message highlight (search result scroll-to) */
 .message-highlight {
   animation: highlight-fade 2s ease-out forwards;


### PR DESCRIPTION
Slack-style inline code and fenced code block styling. Fixes flaky triple-backtick parsing.