### PR TITLE
perf(infra): fix 2s HTTP delay — dedicated Redis client for webhook BRPOP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed REMB bitrate conversion that could produce incorrect values from NaN or infinite f32, potentially disrupting simulcast layer switching (#368)
-- Fixed 2-second delay on HTTP requests caused by missing Redis reconnect policy (#390)
+- Fixed 2-second delay on every HTTP request caused by webhook worker BRPOP blocking the shared Redis connection (#390)
 - Fixed noisy OIDC error logs on server startup when no provider is configured (#387)
 - Fixed poor text contrast on accent-colored backgrounds by introducing a `text-on-accent` design token across all themes (#386)
 - Admin Settings panel now checks elevation state on mount, hiding the warning when session is already elevated (#389)

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -53,8 +53,10 @@ async fn main() -> Result<()> {
     let voice_health_handle =
         vc_server::observability::voice::spawn_voice_health_task(db_pool.clone());
 
-    // Initialize Redis
+    // Initialize Redis (two clients: one for the app, one for the webhook
+    // delivery worker whose BRPOP blocks the connection)
     let redis = db::create_redis_client(&config.redis_url).await?;
+    let redis_webhook = db::create_redis_client(&config.redis_url).await?;
 
     // Initialize S3 client (optional - file uploads will be disabled if not configured)
     // Skip initialization if S3 credentials aren't available (Config fields or env vars)
@@ -343,7 +345,7 @@ async fn main() -> Result<()> {
         .map(std::sync::Arc::new);
     let webhook_worker_handle = tokio::spawn(vc_server::webhooks::delivery::spawn_delivery_worker(
         db_pool.clone(),
-        redis.clone(),
+        redis_webhook,
         webhook_http_client,
         webhook_encryption_key,
     ));


### PR DESCRIPTION
## Summary
- The webhook delivery worker's `BRPOP` (2s timeout) was monopolizing the shared Redis connection, causing every other Redis command to queue behind it
- Created a dedicated Redis client for the webhook worker so its blocking operation doesn't starve the main application

## Root cause
fred uses a single TCP connection per `Client`. The webhook worker calls `redis.brpop(key, 2.0)` in a loop, blocking the connection for up to 2 seconds per iteration. All other Redis operations (health checks, rate limiting, Lua scripts) had to wait.

## Before / After
| Metric | Before | After |
|--------|--------|-------|
| Health endpoint (2nd+ request) | **2.000s** | **0.070s** |
| Valkey connections | 1 (shared) | 2 (app + webhook) |

## Test plan
- [x] Verified on production: 5 rapid requests all <100ms
- [x] Verified Valkey CLIENT LIST shows 2 connections (app=ping, webhook=brpop)
- [x] `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings` passes

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)