### PR TITLE
fix(client): use auth store token for favorites API calls

### DIFF
--- a/client/src/stores/favorites.ts
+++ b/client/src/stores/favorites.ts
@@ -100,8 +100,9 @@ async function apiCall<T>(endpoint: string, options?: RequestInit): Promise<T> {
   }
 
   // HTTP fallback for browser
-  const token = localStorage.getItem("vc:token");
-  const baseUrl = import.meta.env.VITE_API_URL || "";
+  const { getAccessToken, getServerUrl } = await import("@/lib/tauri");
+  const token = getAccessToken();
+  const baseUrl = getServerUrl();
 
   const response = await fetch(`${baseUrl}${endpoint}`, {
     ...options,


### PR DESCRIPTION
## Summary
- Favorites store was reading token from `localStorage.getItem('vc:token')` — a key that is **never written to** by the current auth system
- This caused 401 INVALID_TOKEN on every favorites API call in browser mode (load, add, remove, reorder)
- Now uses `getAccessToken()` from the shared auth module, matching all other stores

## Root cause
The favorites store had its own `apiCall` helper with a hardcoded localStorage key `vc:token` from an older auth implementation. The main auth system stores tokens in-memory via `browserState.accessToken`.

## Test plan
- [ ] Login in browser, navigate to a guild — no 401 errors on favorites
- [ ] Click favorite star on a channel — succeeds without error
- [ ] Hard refresh — favorites persist correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)