### PR TITLE
fix(voice): set TURN credential_type to Password in SFU config

### DIFF
--- a/server/src/voice/sfu.rs
+++ b/server/src/voice/sfu.rs
@@ -469,7 +469,7 @@ impl SfuServer {
                 urls: vec![turn.clone()],
                 username: self.config.turn_username.clone().unwrap_or_default(),
                 credential: self.config.turn_credential.clone().unwrap_or_default(),
-                ..Default::default()
+                credential_type: webrtc::ice_transport::ice_credential_type::RTCIceCredentialType::Password,
             });
         }
 


### PR DESCRIPTION
## Summary
One-line fix: the server-side SFU's `RTCIceServer` used `..Default::default()` for TURN, which sets `credential_type` to `Unspecified`. The `webrtc` crate rejects this with "invalid turn server credentials" because it only accepts `Password` or `Oauth` — not the default.

## Root cause
`webrtc-0.11.0/src/ice_transport/ice_server.rs:52`:
```rust
_ => return Err(Error::ErrTurnCredentials),
```
This catch-all rejects `Unspecified` even when username/credential are valid.

## Test plan
- [ ] Build: `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings`
- [ ] Join voice channel — no "invalid turn server credentials" error
- [ ] Server logs show successful TURN allocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)