### PR TITLE
fix(voice): register onIceCandidate handler for browser voice

### DIFF
--- a/client/src/stores/voice.ts
+++ b/client/src/stores/voice.ts
@@ -480,6 +480,15 @@ export async function joinVoice(channelId: string): Promise<void> {
           removeAvailableTrack(userId);
         });
       },
+      onIceCandidate: (candidate) => {
+        import("@/lib/tauri").then(({ wsSend }) => {
+          wsSend({
+            type: "voice_ice_candidate",
+            channel_id: channelId,
+            candidate,
+          });
+        });
+      },
     });
 
     const result = await adapter.join(channelId);


### PR DESCRIPTION
## Summary
The voice store's `setEventHandlers()` was missing the `onIceCandidate` handler. Browser-generated ICE candidates were silently discarded (the `?.()` optional call returned undefined), so they were never sent to the server via WebSocket. This caused ICE negotiation to timeout after 30 seconds for all browser voice connections.

The Tauri client was unaffected because it handles ICE candidates internally in the Rust backend.

## Root cause
`client/src/stores/voice.ts:419-483` — registered handlers for state, error, mute, speaking, screen share, webcam — but not `onIceCandidate`.

## Fix
Added `onIceCandidate` handler that sends `voice_ice_candidate` messages via WebSocket, matching the format the server expects.

## Test plan
- [ ] Join voice channel in browser — ICE candidates appear in server logs
- [ ] Voice connection establishes (no more "ICE failed" after 30s)
- [ ] Two browser users can hear each other

🤖 Generated with [Claude Code](https://claude.com/claude-code)