### PR TITLE
style(docs): fix markdown lints

### DIFF
--- a/client/public/wallpapers/prompts.md
+++ b/client/public/wallpapers/prompts.md
@@ -1,18 +1,23 @@
 # Kaiku High-Resolution Wallpapers
+
 This directory contains wide 16:9 panoramic desktop wallpapers generated for Kaiku.
 
 The original AI image generations max out at around 1-2 MP. To use these as true 4K desktop Wallpapers perfectly crisp, run them through an AI upscaler like Real-ESRGAN or Upscayl.
 
 Below are the base prompts used to generate the images.
 
-### 1. Nordic: Floki with Aurora Borealis (`nordic_aurora.png`)
+## 1. Nordic: Floki with Aurora Borealis (`nordic_aurora.png`)
+
 > Wide 16:9 panoramic cinematic illustration of a fluffy black-and-tan Finnish Lapphund in a stunning Nordic winter landscape. Above, a brilliant teal and cyan aurora borealis lights up the starry night sky over snow-capped mountains and pine trees. The scene uses the serene 'Nord' color palette (deep slate blues, muted aquas, frosty teals, soft whites). Subtle, atmospheric, elegant, highly detailed masterpiece desktop wallpaper. No text.
 
-### 2. Nordic: Cozy Cabin Setup (`nordic_cabin.png`)
+## 2. Nordic: Cozy Cabin Setup (`nordic_cabin.png`)
+
 > Wide 16:9 panoramic illustration using the 'Nord' color palette (slate blues, icy teals, muted grays). A cozy, warmly lit modern minimalist wooden cabin interior looking out through a large glass window into a serene snowy pine forest. On a sleek desk sits a high-end glowing streaming microphone, headphones, and a mechanical keyboard. Most importantly, front and center on the desk is a large high-resolution glowing glowing computer monitor clearly displaying an elegant modern dark-mode chat application interface (representing Kaiku) with a sidebar and chat bubbles. A fluffy black-and-tan Finnish Lapphund is sleeping peacefully on a soft rug nearby. Atmospheric, relaxing, highly detailed, lo-fi chill vibes desktop wallpaper. No large text.
 
-### 3. Pixel: Brown Lapphund in Village (`pixel_village.png`)
+## 3. Pixel: Brown Lapphund in Village (`pixel_village.png`)
+
 > Wide 16:9 panoramic modern pixel art scene. A charming, cozy snowy alpine village at dusk. Warm yellow and orange firelight spills from the windows of small cozy wooden cottages into the bluish twilight. A fluffy brown-toned Finnish Lapphund sits on a snow-covered cobblestone path, looking peacefully at the beautiful scenery. High-quality 16-bit aesthetic, detailed shading, atmospheric lighting, beautiful cosy pixel art desktop wallpaper. No text.
 
-### 4. Pixel: Pack of Brown Lapphunds by Forest River (`pixel_forest.png`)
+## 4. Pixel: Pack of Brown Lapphunds by Forest River (`pixel_forest.png`)
+
 > Wide 16:9 panoramic modern pixel art scene. A beautiful, lush green forest with golden sunlight filtering through the canopy, illuminating a gently flowing, sparkling crystal clear river. A pack of three playful, fluffy brown-toned Finnish Lapphunds are exploring the mossy riverbank together. Vibrant, cozy, adventurous atmosphere. High-quality 16-bit aesthetic, intricate pixel detailing, beautiful lighting, top-tier pixel art desktop wallpaper. No text.


### PR DESCRIPTION
Fixes formatting warnings regarding missing blank lines around headings in prompts.md.