### PR TITLE
fix(ws): restore subscriptions and add heartbeat on reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed redundant source-side RTCP reader that spawned 3 extra tokio tasks per simulcast screen share (#370)
 
 ### Fixed
+- WebSocket reconnect now restores channel subscriptions and reloads messages, preventing silent message loss after network interruptions
+- Added reconnection toast notification so users can see when the connection is being re-established
+- Server-side WebSocket heartbeat (30s ping/pong) now detects and cleans up dead connections that would otherwise leak resources
 - All 14 modals now dismiss on Escape key press
 - Fixed heading hierarchy skip (H1 → H3) in message list — now uses H2
 - Fixed onboarding completion image showing transparency checkerboard

--- a/client/src/stores/websocket.ts
+++ b/client/src/stores/websocket.ts
@@ -24,7 +24,9 @@ import {
   removeMessage,
   messagesState,
   setMessagesState,
+  loadInitialMessages,
 } from "./messages";
+import { showToast, dismissToast } from "@/components/ui/Toast";
 import {
   addThreadReply,
   removeThreadReply,
@@ -211,8 +213,12 @@ export async function initWebSocket(): Promise<void> {
       listen("ws:connected", () => {
         const connectDuration = Date.now() - connectStartTime;
         Sentry.addBreadcrumb({ category: "ws", message: "connected", data: { duration_ms: connectDuration }, level: "info" });
-        setWsState({ status: "connected", reconnectAttempt: 0, error: null });
-        window.dispatchEvent(new Event("ws-connected"));
+        if (wsState.reconnectAttempt > 0) {
+          handleReconnect();
+        } else {
+          setWsState({ status: "connected", reconnectAttempt: 0, error: null });
+          window.dispatchEvent(new Event("ws-connected"));
+        }
       }),
     );
 
@@ -225,6 +231,13 @@ export async function initWebSocket(): Promise<void> {
     pending.push(
       listen<number>("ws:reconnecting", (event) => {
         setWsState({ status: "reconnecting", reconnectAttempt: event.payload });
+        showToast({
+          type: "warning",
+          title: "Reconnecting...",
+          message: `Attempt ${event.payload}`,
+          id: "ws-reconnect",
+          duration: 0,
+        });
       }),
     );
 
@@ -1450,6 +1463,47 @@ export async function reinitWebSocketListeners(): Promise<void> {
 }
 
 /**
+ * Handle post-reconnect recovery: re-subscribe channels, reload messages, dismiss toast.
+ * Snapshots current subscribed channels before resetting state, then re-subscribes and reloads.
+ */
+async function handleReconnect(): Promise<void> {
+  const channelsToResubscribe = [...wsState.subscribedChannels];
+  const channelsToReload = Object.keys(messagesState.byChannel).filter(
+    (id) => (messagesState.byChannel[id]?.length ?? 0) > 0,
+  );
+
+  // Clear subscribed set so subscribeChannel() early-return guard allows re-subscription
+  setWsState("subscribedChannels", new Set());
+  setWsState({ status: "connected", reconnectAttempt: 0, error: null });
+
+  // Re-subscribe and reload in parallel
+  await Promise.all([
+    Promise.all(
+      channelsToResubscribe.map((id) =>
+        subscribeChannel(id).catch((err) =>
+          console.error("[WS] Failed to re-subscribe channel", id, err),
+        ),
+      ),
+    ),
+    Promise.all(
+      channelsToReload.map((id) =>
+        loadInitialMessages(id).catch((err) =>
+          console.error("[WS] Failed to reload messages for channel", id, err),
+        ),
+      ),
+    ),
+  ]);
+
+  console.info(
+    `[WS] Reconnect recovery complete: ${channelsToResubscribe.length} channels re-subscribed, ${channelsToReload.length} channels reloaded`,
+  );
+
+  // Signal connection ready after subscriptions are restored
+  window.dispatchEvent(new Event("ws-connected"));
+  dismissToast("ws-reconnect");
+}
+
+/**
  * Connect to the WebSocket server.
  */
 export async function connect(): Promise<void> {
@@ -1460,7 +1514,11 @@ export async function connect(): Promise<void> {
     // In browser mode, wsConnect resolves after onopen; update store state here
     // (Tauri mode updates via the ws:connected event listener instead)
     if (!isTauri) {
-      setWsState({ status: "connected", reconnectAttempt: 0, error: null });
+      if (wsState.subscribedChannels.size > 0) {
+        await handleReconnect();
+      } else {
+        setWsState({ status: "connected", reconnectAttempt: 0, error: null });
+      }
     }
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);

--- a/server/src/voice/peer.rs
+++ b/server/src/voice/peer.rs
@@ -22,7 +22,7 @@ use webrtc::track::track_remote::TrackRemote;
 
 use super::error::VoiceError;
 use super::track_types::TrackSource;
-use crate::ws::ServerEvent;
+use crate::ws::OutboundMsg;
 
 /// Represents a user's WebRTC connection to the SFU.
 pub struct Peer {
@@ -45,7 +45,7 @@ pub struct Peer {
     /// Whether the user is muted.
     pub muted: RwLock<bool>,
     /// Channel to send signaling messages back to the user.
-    pub signal_tx: mpsc::Sender<ServerEvent>,
+    pub signal_tx: mpsc::Sender<OutboundMsg>,
     /// Unique session identifier for this connection.
     pub session_id: Uuid,
     /// Timestamp when this peer connected.
@@ -65,7 +65,7 @@ impl Peer {
         channel_id: Uuid,
         api: &API,
         config: RTCConfiguration,
-        signal_tx: mpsc::Sender<ServerEvent>,
+        signal_tx: mpsc::Sender<OutboundMsg>,
     ) -> Result<Self, VoiceError> {
         let peer_connection = api.new_peer_connection(config).await?;
 

--- a/server/src/voice/sfu.rs
+++ b/server/src/voice/sfu.rs
@@ -32,7 +32,7 @@ use super::track_types::{Layer, TrackSource};
 use super::webcam::WebcamInfo;
 use crate::config::Config;
 use crate::ratelimit::{RateLimitCategory, RateLimiter};
-use crate::ws::ServerEvent;
+use crate::ws::{OutboundMsg, ServerEvent};
 
 /// Default maximum participants per room.
 const DEFAULT_MAX_PARTICIPANTS: usize = 25;
@@ -220,7 +220,7 @@ impl Room {
     /// which could delay peer additions/removals during broadcasts.
     pub async fn broadcast_except(&self, exclude_user_id: Uuid, event: ServerEvent) {
         // Clone sender handles to release lock before I/O
-        let senders: Vec<(Uuid, mpsc::Sender<ServerEvent>)> = {
+        let senders: Vec<(Uuid, mpsc::Sender<OutboundMsg>)> = {
             let peers = self.peers.read().await;
             peers
                 .iter()
@@ -231,7 +231,7 @@ impl Room {
 
         // Send without holding the lock
         for (user_id, tx) in senders {
-            if let Err(e) = tx.send(event.clone()).await {
+            if let Err(e) = tx.send(OutboundMsg::Event(event.clone())).await {
                 warn!(user_id = %user_id, error = %e, "Failed to send event to peer");
             }
         }
@@ -242,7 +242,7 @@ impl Room {
     /// Clones the peer list before sending to avoid holding the lock during I/O.
     pub async fn broadcast_all(&self, event: ServerEvent) {
         // Clone sender handles to release lock before I/O
-        let senders: Vec<(Uuid, mpsc::Sender<ServerEvent>)> = {
+        let senders: Vec<(Uuid, mpsc::Sender<OutboundMsg>)> = {
             let peers = self.peers.read().await;
             peers
                 .iter()
@@ -252,7 +252,7 @@ impl Room {
 
         // Send without holding the lock
         for (user_id, tx) in senders {
-            if let Err(e) = tx.send(event.clone()).await {
+            if let Err(e) = tx.send(OutboundMsg::Event(event.clone())).await {
                 warn!(user_id = %user_id, error = %e, "Failed to send event to peer");
             }
         }
@@ -521,7 +521,7 @@ impl SfuServer {
         username: String,
         display_name: String,
         channel_id: Uuid,
-        signal_tx: mpsc::Sender<ServerEvent>,
+        signal_tx: mpsc::Sender<OutboundMsg>,
     ) -> Result<Arc<Peer>, VoiceError> {
         let config = self.rtc_config();
         let peer = Peer::new(
@@ -756,10 +756,10 @@ impl SfuServer {
                             Ok(json) => {
                                 if let Ok(candidate_str) = serde_json::to_string(&json) {
                                     if let Err(e) = tx
-                                        .send(ServerEvent::VoiceIceCandidate {
+                                        .send(OutboundMsg::Event(ServerEvent::VoiceIceCandidate {
                                             channel_id: cid,
                                             candidate: candidate_str,
-                                        })
+                                        }))
                                         .await
                                     {
                                         tracing::error!(
@@ -787,10 +787,10 @@ impl SfuServer {
             .set_local_description(offer.clone())
             .await?;
         peer.signal_tx
-            .send(ServerEvent::VoiceOffer {
+            .send(OutboundMsg::Event(ServerEvent::VoiceOffer {
                 channel_id: peer.channel_id,
                 sdp: offer.sdp,
-            })
+            }))
             .await
             .map_err(|e| VoiceError::Signaling(e.to_string()))?;
         Ok(())

--- a/server/src/voice/track.rs
+++ b/server/src/voice/track.rs
@@ -465,7 +465,7 @@ pub fn spawn_subscriber_remb_reader(
     source_user_id: Uuid,
     source_type: TrackSource,
     sender: Arc<webrtc::rtp_transceiver::rtp_sender::RTCRtpSender>,
-    signal_tx: mpsc::Sender<crate::ws::ServerEvent>,
+    signal_tx: mpsc::Sender<crate::ws::OutboundMsg>,
     channel_id: Uuid,
 ) {
     tokio::spawn(async move {
@@ -505,12 +505,12 @@ pub fn spawn_subscriber_remb_reader(
                         );
 
                         let _ = signal_tx
-                            .send(crate::ws::ServerEvent::VoiceLayerChanged {
+                            .send(crate::ws::OutboundMsg::Event(crate::ws::ServerEvent::VoiceLayerChanged {
                                 channel_id,
                                 source_user_id,
                                 track_source: source_type,
                                 active_layer: new_layer,
-                            })
+                            }))
                             .await;
                     }
                 }

--- a/server/src/voice/ws_handler.rs
+++ b/server/src/voice/ws_handler.rs
@@ -22,7 +22,7 @@ use super::track::spawn_subscriber_remb_reader;
 use super::track_types::{LayerPreference, TrackSource};
 use super::webcam::WebcamInfo;
 use super::Quality;
-use crate::ws::{ClientEvent, ServerEvent, VoiceParticipant};
+use crate::ws::{ClientEvent, OutboundMsg, ServerEvent, VoiceParticipant};
 
 /// Handle a voice-related client event.
 pub async fn handle_voice_event(
@@ -30,7 +30,7 @@ pub async fn handle_voice_event(
     pool: &PgPool,
     user_id: Uuid,
     event: ClientEvent,
-    tx: &mpsc::Sender<ServerEvent>,
+    tx: &mpsc::Sender<OutboundMsg>,
     screen_share_limiter: Option<&ScreenShareLimiter>,
 ) -> Result<(), VoiceError> {
     match event {
@@ -135,7 +135,7 @@ async fn handle_join(
     pool: &PgPool,
     user_id: Uuid,
     channel_id: Uuid,
-    tx: &mpsc::Sender<ServerEvent>,
+    tx: &mpsc::Sender<OutboundMsg>,
 ) -> Result<(), VoiceError> {
     info!(user_id = %user_id, channel_id = %channel_id, "User joining voice channel");
 
@@ -231,10 +231,10 @@ async fn handle_join(
     }
 
     let offer = sfu.create_offer(&peer).await?;
-    tx.send(ServerEvent::VoiceOffer {
+    tx.send(OutboundMsg::Event(ServerEvent::VoiceOffer {
         channel_id,
         sdp: offer.sdp,
-    })
+    }))
     .await
     .map_err(|e| VoiceError::Signaling(e.to_string()))?;
 
@@ -255,12 +255,12 @@ async fn handle_join(
     let screen_shares = room.get_screen_shares().await;
     let webcams = room.get_webcams().await;
 
-    tx.send(ServerEvent::VoiceRoomState {
+    tx.send(OutboundMsg::Event(ServerEvent::VoiceRoomState {
         channel_id,
         participants,
         screen_shares,
         webcams,
-    })
+    }))
     .await
     .map_err(|e| VoiceError::Signaling(e.to_string()))?;
 
@@ -997,7 +997,7 @@ async fn handle_set_layer_preference(
     target_user_id: Uuid,
     track_source: TrackSource,
     preferred_layer: LayerPreference,
-    tx: &mpsc::Sender<ServerEvent>,
+    tx: &mpsc::Sender<OutboundMsg>,
 ) -> Result<(), VoiceError> {
     debug!(
         user_id = %user_id,
@@ -1025,12 +1025,12 @@ async fn handle_set_layer_preference(
         preferred_layer,
     ) {
         // Notify the viewer of the layer change
-        tx.send(ServerEvent::VoiceLayerChanged {
+        tx.send(OutboundMsg::Event(ServerEvent::VoiceLayerChanged {
             channel_id,
             source_user_id: target_user_id,
             track_source,
             active_layer: new_layer,
-        })
+        }))
         .await
         .map_err(|e| VoiceError::Signaling(e.to_string()))?;
     }

--- a/server/src/voice/ws_handler_test.rs
+++ b/server/src/voice/ws_handler_test.rs
@@ -13,7 +13,7 @@ mod tests {
     use crate::config::Config;
     use crate::ratelimit::{LimitConfig, RateLimitConfig, RateLimiter, RateLimits};
     use crate::voice::{error, sfu, ws_handler};
-    use crate::ws::{ClientEvent, ServerEvent};
+    use crate::ws::{ClientEvent, OutboundMsg, ServerEvent};
 
     /// Helper to create a test Redis client.
     async fn create_test_redis() -> Client {
@@ -167,7 +167,7 @@ mod tests {
         let _redis = create_test_redis().await;
 
         // Create channel for server events
-        let (tx, mut rx) = mpsc::channel::<ServerEvent>(10);
+        let (tx, mut rx) = mpsc::channel::<OutboundMsg>(10);
 
         // Join voice channel
         ws_handler::handle_voice_event(
@@ -181,11 +181,13 @@ mod tests {
         .await?;
 
         // Verify VoiceOffer was sent
-        let event = rx.recv().await.expect("Should receive VoiceOffer");
+        let msg = rx.recv().await.expect("Should receive VoiceOffer");
+        let OutboundMsg::Event(event) = msg else { panic!("Expected Event") };
         assert!(matches!(event, ServerEvent::VoiceOffer { .. }));
 
         // Verify VoiceRoomState includes username
-        let event = rx.recv().await.expect("Should receive VoiceRoomState");
+        let msg = rx.recv().await.expect("Should receive VoiceRoomState");
+        let OutboundMsg::Event(event) = msg else { panic!("Expected Event") };
         match event {
             ServerEvent::VoiceRoomState { participants, .. } => {
                 assert_eq!(participants.len(), 1);
@@ -236,7 +238,7 @@ mod tests {
         let sfu = Arc::new(sfu::SfuServer::new(config, Some(rate_limiter))?);
 
         // Create channel for server events
-        let (tx, _rx) = mpsc::channel::<ServerEvent>(10);
+        let (tx, _rx) = mpsc::channel::<OutboundMsg>(10);
 
         // First join should succeed (1/1 voice_join budget consumed)
         ws_handler::handle_voice_event(
@@ -296,8 +298,8 @@ mod tests {
         let _redis = create_test_redis().await;
 
         // Create channels for server events
-        let (tx1, _rx1) = mpsc::channel::<ServerEvent>(10);
-        let (tx2, _rx2) = mpsc::channel::<ServerEvent>(10);
+        let (tx1, _rx1) = mpsc::channel::<OutboundMsg>(10);
+        let (tx2, _rx2) = mpsc::channel::<OutboundMsg>(10);
 
         // Both users should be able to join
         ws_handler::handle_voice_event(

--- a/server/src/ws/mod.rs
+++ b/server/src/ws/mod.rs
@@ -1162,6 +1162,14 @@ pub async fn handler(
         .on_upgrade(move |socket| handle_socket(socket, state, user_id))
 }
 
+/// Internal outbound message envelope for the WebSocket sender task.
+/// Separates serializable server events from raw WS control frames (Ping).
+#[derive(Debug)]
+pub enum OutboundMsg {
+    Event(ServerEvent),
+    Ping,
+}
+
 /// Handle WebSocket connection.
 async fn handle_socket(socket: WebSocket, state: AppState, user_id: Uuid) {
     use futures::stream::{SplitSink, SplitStream};
@@ -1169,7 +1177,7 @@ async fn handle_socket(socket: WebSocket, state: AppState, user_id: Uuid) {
         socket.split();
 
     // Channel for sending messages to the WebSocket
-    let (tx, mut rx) = mpsc::channel::<ServerEvent>(100);
+    let (tx, mut rx) = mpsc::channel::<OutboundMsg>(100);
 
     // Track subscribed channels
     let subscribed_channels: Arc<tokio::sync::RwLock<HashSet<Uuid>>> =
@@ -1188,7 +1196,7 @@ async fn handle_socket(socket: WebSocket, state: AppState, user_id: Uuid) {
     crate::observability::metrics::record_ws_connect();
 
     // Send ready event
-    let _ = tx.send(ServerEvent::Ready { user_id }).await;
+    let _ = tx.send(OutboundMsg::Event(ServerEvent::Ready { user_id })).await;
 
     // Fetch user's friends for presence subscriptions
     let friend_ids = match get_user_friends(&state.db, user_id).await {
@@ -1214,7 +1222,7 @@ async fn handle_socket(socket: WebSocket, state: AppState, user_id: Uuid) {
                     user_id: snap.user_id,
                     status: snap.status.clone(),
                 };
-                if tx.send(presence_event).await.is_err() {
+                if tx.send(OutboundMsg::Event(presence_event)).await.is_err() {
                     break;
                 }
 
@@ -1230,7 +1238,7 @@ async fn handle_socket(socket: WebSocket, state: AppState, user_id: Uuid) {
                                 user_id: snap.user_id,
                                 activity: Some(activity),
                             };
-                            if tx.send(activity_event).await.is_err() {
+                            if tx.send(OutboundMsg::Event(activity_event)).await.is_err() {
                                 break;
                             }
                         }
@@ -1245,7 +1253,7 @@ async fn handle_socket(socket: WebSocket, state: AppState, user_id: Uuid) {
                                 user_id: snap.user_id,
                                 custom_status: Some(cs),
                             };
-                            if tx.send(cs_event).await.is_err() {
+                            if tx.send(OutboundMsg::Event(cs_event)).await.is_err() {
                                 break;
                             }
                         }
@@ -1329,17 +1337,17 @@ async fn handle_socket(socket: WebSocket, state: AppState, user_id: Uuid) {
 
     // Spawn task to forward events to WebSocket
     let sender_handle: tokio::task::JoinHandle<()> = tokio::spawn(async move {
-        while let Some(event) = rx.recv().await {
-            let msg = match serde_json::to_string(&event) {
-                Ok(json) => json,
-                Err(e) => {
-                    error!("Failed to serialize event: {}", e);
-                    continue;
-                }
+        while let Some(msg) = rx.recv().await {
+            let send_result = match msg {
+                OutboundMsg::Event(event) => match serde_json::to_string(&event) {
+                    Ok(json) => ws_sender.send(Message::Text(json.into())).await,
+                    Err(e) => {
+                        error!("Failed to serialize event: {}", e);
+                        continue;
+                    }
+                },
+                OutboundMsg::Ping => ws_sender.send(Message::Ping(vec![].into())).await,
             };
-
-            let send_result: Result<(), axum::Error> =
-                ws_sender.send(Message::Text(msg.into())).await;
             if send_result.is_err() {
                 break;
             }
@@ -1349,43 +1357,68 @@ async fn handle_socket(socket: WebSocket, state: AppState, user_id: Uuid) {
     // Per-connection mutable state for rate limiting and deduplication
     let mut msg_state = ClientMessageState::default();
 
-    // Handle incoming messages
-    while let Some(msg) = ws_receiver.next().await {
-        match msg {
-            Ok(Message::Text(text)) => {
-                if let Err(e) = handle_client_message(
-                    &text,
-                    user_id,
-                    &state,
-                    &tx,
-                    &subscribed_channels,
-                    &admin_subscribed,
-                    &mut msg_state,
-                )
-                .await
-                {
-                    warn!("Error handling message: {}", e);
-                    let _ = tx
-                        .send(ServerEvent::Error {
-                            code: "message_error".to_string(),
-                            message: e.to_string(),
-                        })
-                        .await;
+    // Server-side heartbeat: detect dead connections via Ping/Pong
+    let mut ping_interval = tokio::time::interval(Duration::from_secs(30));
+    ping_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    ping_interval.tick().await; // consume the immediate first tick
+    let mut awaiting_pong = false;
+
+    // Handle incoming messages with heartbeat
+    loop {
+        tokio::select! {
+            msg = ws_receiver.next() => {
+                match msg {
+                    Some(Ok(Message::Text(text))) => {
+                        if let Err(e) = handle_client_message(
+                            &text,
+                            user_id,
+                            &state,
+                            &tx,
+                            &subscribed_channels,
+                            &admin_subscribed,
+                            &mut msg_state,
+                        )
+                        .await
+                        {
+                            warn!("Error handling message: {}", e);
+                            let _ = tx
+                                .send(OutboundMsg::Event(ServerEvent::Error {
+                                    code: "message_error".to_string(),
+                                    message: e.to_string(),
+                                }))
+                                .await;
+                        }
+                    }
+                    Some(Ok(Message::Ping(_data))) => {
+                        // Axum handles pong automatically
+                        debug!("Received ping from user={}", user_id);
+                    }
+                    Some(Ok(Message::Pong(_))) => {
+                        awaiting_pong = false;
+                    }
+                    Some(Ok(Message::Close(_))) => {
+                        info!("WebSocket closed: user={}", user_id);
+                        break;
+                    }
+                    Some(Err(e)) => {
+                        warn!("WebSocket error: {}", e);
+                        break;
+                    }
+                    None => break,
+                    _ => {}
                 }
             }
-            Ok(Message::Ping(_data)) => {
-                // Axum handles pong automatically, but we can respond too
-                debug!("Received ping from user={}", user_id);
+
+            _ = ping_interval.tick() => {
+                if awaiting_pong || sender_handle.is_finished() {
+                    info!("WebSocket ping timeout: user={}", user_id);
+                    break;
+                }
+                awaiting_pong = true;
+                if tx.send(OutboundMsg::Ping).await.is_err() {
+                    break;
+                }
             }
-            Ok(Message::Close(_)) => {
-                info!("WebSocket closed: user={}", user_id);
-                break;
-            }
-            Err(e) => {
-                warn!("WebSocket error: {}", e);
-                break;
-            }
-            _ => {}
         }
     }
 
@@ -1414,7 +1447,7 @@ pub async fn handle_client_message(
     text: &str,
     user_id: Uuid,
     state: &AppState,
-    tx: &mpsc::Sender<ServerEvent>,
+    tx: &mpsc::Sender<OutboundMsg>,
     subscribed_channels: &Arc<tokio::sync::RwLock<HashSet<Uuid>>>,
     admin_subscribed: &Arc<tokio::sync::RwLock<bool>>,
     msg_state: &mut ClientMessageState,
@@ -1424,7 +1457,7 @@ pub async fn handle_client_message(
 
     match event {
         ClientEvent::Ping => {
-            tx.send(ServerEvent::Pong).await?;
+            tx.send(OutboundMsg::Event(ServerEvent::Pong)).await?;
         }
 
         ClientEvent::Subscribe { channel_id } => {
@@ -1433,10 +1466,10 @@ pub async fn handle_client_message(
                 .await?
                 .is_none()
             {
-                tx.send(ServerEvent::Error {
+                tx.send(OutboundMsg::Event(ServerEvent::Error {
                     code: "channel_not_found".to_string(),
                     message: "Channel not found".to_string(),
-                })
+                }))
                 .await?;
                 return Ok(());
             }
@@ -1446,10 +1479,10 @@ pub async fn handle_client_message(
                 .await
                 .is_err()
             {
-                tx.send(ServerEvent::Error {
+                tx.send(OutboundMsg::Event(ServerEvent::Error {
                     code: "forbidden".to_string(),
                     message: "You don't have permission to view this channel".to_string(),
-                })
+                }))
                 .await?;
                 return Ok(());
             }
@@ -1457,13 +1490,13 @@ pub async fn handle_client_message(
             // Add to subscribed channels
             subscribed_channels.write().await.insert(channel_id);
 
-            tx.send(ServerEvent::Subscribed { channel_id }).await?;
+            tx.send(OutboundMsg::Event(ServerEvent::Subscribed { channel_id })).await?;
             debug!("User {} subscribed to channel {}", user_id, channel_id);
         }
 
         ClientEvent::Unsubscribe { channel_id } => {
             subscribed_channels.write().await.remove(&channel_id);
-            tx.send(ServerEvent::Unsubscribed { channel_id }).await?;
+            tx.send(OutboundMsg::Event(ServerEvent::Unsubscribed { channel_id })).await?;
             debug!("User {} unsubscribed from channel {}", user_id, channel_id);
         }
 
@@ -1538,10 +1571,10 @@ pub async fn handle_client_message(
             .await
             {
                 warn!("Voice event error: {}", e);
-                tx.send(ServerEvent::VoiceError {
+                tx.send(OutboundMsg::Event(ServerEvent::VoiceError {
                     code: "voice_error".to_string(),
                     message: e.to_string(),
-                })
+                }))
                 .await?;
             }
         }
@@ -1676,10 +1709,10 @@ pub async fn handle_client_message(
             let is_elevated =
                 crate::admin::is_elevated_admin(&state.redis, &state.db, user_id).await;
             if !is_elevated {
-                tx.send(ServerEvent::Error {
+                tx.send(OutboundMsg::Event(ServerEvent::Error {
                     code: "admin_not_elevated".to_string(),
                     message: "Must be an elevated admin to subscribe to admin events".to_string(),
-                })
+                }))
                 .await?;
                 return Ok(());
             }
@@ -1699,7 +1732,7 @@ pub async fn handle_client_message(
 
 /// Parameters for the Redis pub/sub handler.
 struct HandlePubsubParams {
-    tx: mpsc::Sender<ServerEvent>,
+    tx: mpsc::Sender<OutboundMsg>,
     subscribed_channels: Arc<tokio::sync::RwLock<HashSet<Uuid>>>,
     admin_subscribed: Arc<tokio::sync::RwLock<bool>>,
     blocked_users: Arc<tokio::sync::RwLock<HashSet<Uuid>>>,
@@ -1808,7 +1841,7 @@ async fn handle_pubsub(redis: Client, params: HandlePubsubParams) {
                             };
                             drop(blocked);
 
-                            if !should_filter && params.tx.send(event).await.is_err() {
+                            if !should_filter && params.tx.send(OutboundMsg::Event(event)).await.is_err() {
                                 break;
                             }
                         }
@@ -1835,7 +1868,7 @@ async fn handle_pubsub(redis: Client, params: HandlePubsubParams) {
                         _ => {}
                     }
 
-                    if params.tx.send(event).await.is_err() {
+                    if params.tx.send(OutboundMsg::Event(event)).await.is_err() {
                         break;
                     }
                 }
@@ -1847,7 +1880,7 @@ async fn handle_pubsub(redis: Client, params: HandlePubsubParams) {
             if *params.admin_subscribed.read().await {
                 if let Some(payload) = message.value.as_str() {
                     if let Ok(event) = serde_json::from_str::<ServerEvent>(&payload) {
-                        if params.tx.send(event).await.is_err() {
+                        if params.tx.send(OutboundMsg::Event(event)).await.is_err() {
                             break;
                         }
                     }
@@ -1868,7 +1901,7 @@ async fn handle_pubsub(redis: Client, params: HandlePubsubParams) {
                         _ => false,
                     };
 
-                    if !should_filter && params.tx.send(event).await.is_err() {
+                    if !should_filter && params.tx.send(OutboundMsg::Event(event)).await.is_err() {
                         break;
                     }
                 }
@@ -1879,7 +1912,7 @@ async fn handle_pubsub(redis: Client, params: HandlePubsubParams) {
             // Forward all user-targeted events (read sync, etc.)
             if let Some(payload) = message.value.as_str() {
                 if let Ok(event) = serde_json::from_str::<ServerEvent>(&payload) {
-                    if params.tx.send(event).await.is_err() {
+                    if params.tx.send(OutboundMsg::Event(event)).await.is_err() {
                         break;
                     }
                 }
@@ -1890,7 +1923,7 @@ async fn handle_pubsub(redis: Client, params: HandlePubsubParams) {
             // Forward guild/member patch events to all guild members
             if let Some(payload) = message.value.as_str() {
                 if let Ok(event) = serde_json::from_str::<ServerEvent>(&payload) {
-                    if params.tx.send(event).await.is_err() {
+                    if params.tx.send(OutboundMsg::Event(event)).await.is_err() {
                         break;
                     }
                 }


### PR DESCRIPTION
## Summary
- After a WebSocket reconnect, channel subscriptions are now restored and messages reloaded for all loaded channels, preventing silent message loss
- Added persistent "Reconnecting..." toast notification so users can see connection state
- Added server-side 30s ping/pong heartbeat to detect and clean up dead connections that would otherwise leak resources indefinitely

## Details

**Client (`websocket.ts`):**
- `handleReconnect()` snapshots `subscribedChannels`, clears the set, re-subscribes all channels, and reloads messages in parallel
- `ws:reconnecting` handler shows a persistent warning toast with stable ID (prevents duplicates)
- Toast dismissed after subscriptions and messages are restored
- Works in both Tauri and browser modes

**Server (`ws/mod.rs` + `voice/*`):**
- Introduced `OutboundMsg` enum to multiplex `ServerEvent` and WS `Ping` frames through the existing mpsc channel
- Replaced bare `while let` read loop with `tokio::select!` racing message reads against a 30s ping interval
- Tracks `awaiting_pong` flag — breaks on timeout or sender task death (`is_finished()`)
- Updated all `tx.send()` call sites across 6 files

## Test plan
- [x] `cargo clippy -D warnings` — clean
- [x] 541/541 vitest client tests passing
- [ ] Manual: connect, open channel, kill server, verify toast appears, restore server, verify toast dismisses and messages reload
- [ ] Manual: connect, verify Ping frames every 30s in network inspector
- [ ] Manual: block Pong responses, verify connection closes after ~60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)