### PR TITLE
fix(ws,auth): secure WS auth header and move GeoIP out of transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,10 +40,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Layout areas (ServerRail, Sidebar, Main Stage) now separated by solid border lines for clearer visual structure
 - Removed redundant source-side RTCP reader that spawned 3 extra tokio tasks per simulcast screen share (#370)
 
+### Security
+- WebSocket authentication now uses `Sec-WebSocket-Protocol` header instead of URL query parameter, preventing JWT token exposure in reverse proxy logs
+
 ### Fixed
 - WebSocket reconnect now restores channel subscriptions and reloads messages, preventing silent message loss after network interruptions
 - Added reconnection toast notification so users can see when the connection is being re-established
 - Server-side WebSocket heartbeat (30s ping/pong) now detects and cleans up dead connections that would otherwise leak resources
+- Token refresh and registration no longer hold database transactions during GeoIP HTTP calls, preventing connection pool exhaustion under slow network conditions
 - All 14 modals now dismiss on Escape key press
 - Fixed heading hierarchy skip (H1 → H3) in message list — now uses H2
 - Fixed onboarding completion image showing transparency checkerboard

--- a/client/src-tauri/src/network/websocket.rs
+++ b/client/src-tauri/src/network/websocket.rs
@@ -9,8 +9,9 @@ use futures::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter};
 use tokio::sync::{mpsc, RwLock};
-use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{connect_async, tungstenite};
 use tracing::{debug, error, info, warn};
 
 /// Client events sent to the server.
@@ -428,12 +429,9 @@ async fn connection_loop(
             return;
         }
 
-        // Build WebSocket URL
-        let ws_url = build_ws_url(&server_url, &token);
-        info!(
-            "Connecting to WebSocket: {}",
-            ws_url.split('?').next().unwrap_or(&ws_url)
-        );
+        // Build WebSocket URL and request with token in Sec-WebSocket-Protocol header
+        let ws_url = build_ws_url(&server_url);
+        info!("Connecting to WebSocket: {}", ws_url);
 
         if attempt > 0 {
             *status.write().await = ConnectionStatus::Reconnecting { attempt };
@@ -443,8 +441,15 @@ async fn connection_loop(
             let _ = app.emit("ws:connecting", ());
         }
 
-        // Try to connect
-        match connect_async(&ws_url).await {
+        // Try to connect with token in Sec-WebSocket-Protocol header (not URL)
+        let request = match build_ws_request(&ws_url, &token) {
+            Ok(req) => req,
+            Err(e) => {
+                error!("Failed to build WebSocket request: {}", e);
+                continue;
+            }
+        };
+        match connect_async(request).await {
             Ok((ws_stream, _)) => {
                 info!("WebSocket connected");
                 attempt = 0;
@@ -534,12 +539,32 @@ async fn connection_loop(
     }
 }
 
-/// Build the WebSocket URL with authentication token.
-fn build_ws_url(server_url: &str, token: &str) -> String {
+/// Build the WebSocket URL (without token — token goes in protocol header).
+fn build_ws_url(server_url: &str) -> String {
     let base = server_url
         .replace("http://", "ws://")
         .replace("https://", "wss://");
-    format!("{}/ws?token={}", base.trim_end_matches('/'), token)
+    format!("{}/ws", base.trim_end_matches('/'))
+}
+
+/// Build a WebSocket handshake request with the JWT in the Sec-WebSocket-Protocol header.
+/// This avoids exposing the token in URL query parameters (which get logged by proxies).
+fn build_ws_request(
+    ws_url: &str,
+    token: &str,
+) -> Result<tungstenite::http::Request<()>, tungstenite::error::Error> {
+    let mut request = ws_url.into_client_request()?;
+    request.headers_mut().insert(
+        "Sec-WebSocket-Protocol",
+        format!("access_token.{}, access_token", token)
+            .parse()
+            .map_err(|_| {
+                tungstenite::error::Error::Url(
+                    tungstenite::error::UrlError::NoPathOrQuery,
+                )
+            })?,
+    );
+    Ok(request)
 }
 
 /// Handle a message from the server.

--- a/server/src/auth/handlers.rs
+++ b/server/src/auth/handlers.rs
@@ -472,6 +472,11 @@ pub async fn register(
     crate::presence::validate_unicode_text(display_name, 64)
         .map_err(|e| AuthError::Validation(format!("display_name: {e}")))?;
 
+    // Resolve GeoIP before the transaction to avoid holding a connection during HTTP call
+    let user_agent = extract_user_agent(&headers);
+    let geo =
+        geoip::resolve_location(&state.http_client, &state.config.geoip_api_url, &addr.ip()).await;
+
     // Start transaction for atomic first-user detection and admin grant
     let mut tx = state.db.begin().await.map_err(|e| {
         tracing::error!(
@@ -580,10 +585,6 @@ pub async fn register(
     // Store refresh token session (inline to use transaction)
     let token_hash = hash_token(&tokens.refresh_token);
     let expires_at = Utc::now() + Duration::seconds(state.config.jwt_refresh_expiry);
-    let user_agent = extract_user_agent(&headers);
-
-    let geo =
-        geoip::resolve_location(&state.http_client, &state.config.geoip_api_url, &addr.ip()).await;
     let city = geo.as_ref().and_then(|g| g.city.as_deref());
     let country = geo.as_ref().and_then(|g| g.country.as_deref());
 
@@ -886,6 +887,11 @@ pub async fn refresh_token(
 
     let token_hash = hash_token(&raw_token);
 
+    // Resolve GeoIP before the transaction to avoid holding a connection during HTTP call
+    let user_agent = extract_user_agent(&headers);
+    let geo =
+        geoip::resolve_location(&state.http_client, &state.config.geoip_api_url, &addr.ip()).await;
+
     // Wrap session lookup, deletion, and creation in a transaction with FOR UPDATE
     // to prevent race conditions in token rotation.
     let mut tx = state.db.begin().await?;
@@ -936,10 +942,6 @@ pub async fn refresh_token(
     // Store new refresh token session within the transaction
     let new_token_hash = hash_token(&new_tokens.refresh_token);
     let expires_at = Utc::now() + Duration::seconds(state.config.jwt_refresh_expiry);
-    let user_agent = extract_user_agent(&headers);
-
-    let geo =
-        geoip::resolve_location(&state.http_client, &state.config.geoip_api_url, &addr.ip()).await;
     let city = geo.as_ref().and_then(|g| g.city.as_deref());
     let country = geo.as_ref().and_then(|g| g.country.as_deref());
 


### PR DESCRIPTION
## Summary
- **Security**: WebSocket auth now uses `Sec-WebSocket-Protocol` header instead of `?token=` URL query parameter, preventing JWT exposure in reverse proxy logs
- **Performance**: GeoIP HTTP calls moved before database transactions in register and token refresh handlers, preventing connection pool exhaustion under slow network conditions

## Details

**WebSocket auth (`client/src-tauri/src/network/websocket.rs`):**
- Replaced `build_ws_url` — URL no longer contains the token
- Added `build_ws_request` that constructs an HTTP request with `Sec-WebSocket-Protocol: access_token.<jwt>, access_token` header
- Matches the server's existing `extract_token_from_protocol()` and the browser-mode client's approach

**GeoIP transaction fix (`server/src/auth/handlers.rs`):**
- `register`: moved `user_agent` extraction and `geoip::resolve_location()` before `state.db.begin()` — previously held a `FOR UPDATE` lock on `setup_complete` during the HTTP call
- `refresh_token`: same pattern — previously held a `FOR UPDATE` lock on the session row during the HTTP call
- `login`: already correct (no open transaction during GeoIP call)

## Test plan
- [x] `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings` — clean
- [ ] Manual: connect Tauri client, verify WS upgrade uses `Sec-WebSocket-Protocol` header (no `?token=` in Caddy access logs)
- [ ] Manual: register new user with slow/disabled GeoIP — verify no connection pool timeout
- [ ] Manual: refresh token with slow/disabled GeoIP — verify no connection pool timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)