### PR TITLE
fix(infra): generate Ed25519 JWT key pair in beta setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WebSocket authentication now uses `Sec-WebSocket-Protocol` header instead of URL query parameter, preventing JWT token exposure in reverse proxy logs
 
 ### Fixed
+- Beta deployment now correctly generates Ed25519 JWT key pair instead of unused HMAC secret — fresh deployments no longer fail on startup
 - WebSocket reconnect now restores channel subscriptions and reloads messages, preventing silent message loss after network interruptions
 - Added reconnection toast notification so users can see when the connection is being re-established
 - Server-side WebSocket heartbeat (30s ping/pong) now detects and cleans up dead connections that would otherwise leak resources

--- a/infra/compose/.env.beta
+++ b/infra/compose/.env.beta
@@ -7,7 +7,9 @@
 #
 # Secrets to generate before first deploy:
 #   POSTGRES_PASSWORD=$(openssl rand -base64 24)
-#   JWT_SECRET=$(openssl rand -hex 32)
+#   openssl genpkey -algorithm Ed25519 -out /tmp/jwt.pem
+#   JWT_PRIVATE_KEY=$(base64 -w0 < /tmp/jwt.pem)
+#   JWT_PUBLIC_KEY=$(openssl pkey -in /tmp/jwt.pem -pubout | base64 -w0)
 #   MFA_ENCRYPTION_KEY=$(openssl rand -hex 32)
 #   GRAFANA_ADMIN_PASSWORD=$(openssl rand -base64 16)
 #   VALKEY_PASSWORD=$(openssl rand -base64 16)
@@ -24,9 +26,10 @@ ACME_EMAIL=CHANGEME@pmind.de
 POSTGRES_PASSWORD=CHANGEME
 
 # =============================================================================
-# Authentication
+# Authentication (Ed25519 key pair, base64-encoded PEM)
 # =============================================================================
-JWT_SECRET=CHANGEME
+JWT_PRIVATE_KEY=CHANGEME
+JWT_PUBLIC_KEY=CHANGEME
 JWT_ACCESS_EXPIRY=900
 JWT_REFRESH_EXPIRY=604800
 MFA_ENCRYPTION_KEY=CHANGEME

--- a/infra/compose/docker-compose.yml
+++ b/infra/compose/docker-compose.yml
@@ -8,7 +8,7 @@
 # Required environment variables (see .env.example):
 #   - DOMAIN: Your domain (e.g., chat.example.com)
 #   - POSTGRES_PASSWORD: Strong database password
-#   - JWT_SECRET: Strong secret for JWT signing
+#   - JWT_PRIVATE_KEY/JWT_PUBLIC_KEY: Ed25519 key pair (base64-encoded PEM)
 #   - ACME_EMAIL: Email for Let's Encrypt certificates
 
 services:
@@ -31,7 +31,8 @@ services:
       - BIND_ADDRESS=0.0.0.0:8080
       - DATABASE_URL=postgres://voicechat:${POSTGRES_PASSWORD}@postgres:5432/voicechat
       - REDIS_URL=redis://valkey:6379
-      - JWT_SECRET=${JWT_SECRET}
+      - JWT_PRIVATE_KEY=${JWT_PRIVATE_KEY}
+      - JWT_PUBLIC_KEY=${JWT_PUBLIC_KEY}
       - S3_ENDPOINT=${S3_ENDPOINT:-}
       - S3_BUCKET=${S3_BUCKET:-voicechat}
       - OIDC_ISSUER_URL=${OIDC_ISSUER_URL:-}

--- a/infra/scripts/setup-beta.sh
+++ b/infra/scripts/setup-beta.sh
@@ -120,7 +120,14 @@ fi
 if [[ "${SKIP_ENV:-0}" != "1" ]]; then
     log "Generating secrets..."
     POSTGRES_PASSWORD=$(openssl rand -base64 24)
-    JWT_SECRET=$(openssl rand -hex 32)
+
+    # Generate Ed25519 key pair for JWT signing (EdDSA)
+    JWT_PEM_FILE=$(mktemp)
+    openssl genpkey -algorithm Ed25519 -out "$JWT_PEM_FILE" 2>/dev/null
+    JWT_PRIVATE_KEY=$(base64 -w0 < "$JWT_PEM_FILE")
+    JWT_PUBLIC_KEY=$(openssl pkey -in "$JWT_PEM_FILE" -pubout 2>/dev/null | base64 -w0)
+    rm -f "$JWT_PEM_FILE"
+
     MFA_ENCRYPTION_KEY=$(openssl rand -hex 32)
     VALKEY_PASSWORD=$(openssl rand -base64 16)
     GRAFANA_ADMIN_PASSWORD=$(openssl rand -base64 16)
@@ -132,7 +139,8 @@ if [[ "${SKIP_ENV:-0}" != "1" ]]; then
     # Replace CHANGEME placeholders with generated secrets
     sed -i "s|ACME_EMAIL=CHANGEME@pmind.de|ACME_EMAIL=${ACME_EMAIL}|" "$ENV_FILE"
     sed -i "s|POSTGRES_PASSWORD=CHANGEME|POSTGRES_PASSWORD=${POSTGRES_PASSWORD}|" "$ENV_FILE"
-    sed -i "s|JWT_SECRET=CHANGEME|JWT_SECRET=${JWT_SECRET}|" "$ENV_FILE"
+    sed -i "s|JWT_PRIVATE_KEY=CHANGEME|JWT_PRIVATE_KEY=${JWT_PRIVATE_KEY}|" "$ENV_FILE"
+    sed -i "s|JWT_PUBLIC_KEY=CHANGEME|JWT_PUBLIC_KEY=${JWT_PUBLIC_KEY}|" "$ENV_FILE"
     sed -i "s|MFA_ENCRYPTION_KEY=CHANGEME|MFA_ENCRYPTION_KEY=${MFA_ENCRYPTION_KEY}|" "$ENV_FILE"
     sed -i "s|VALKEY_PASSWORD=CHANGEME|VALKEY_PASSWORD=${VALKEY_PASSWORD}|" "$ENV_FILE"
     sed -i "s|GRAFANA_ADMIN_PASSWORD=CHANGEME|GRAFANA_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}|" "$ENV_FILE"


### PR DESCRIPTION
## Summary
- Beta deployment setup script now generates an Ed25519 key pair for JWT signing instead of an unused HMAC secret
- Compose config passes correct `JWT_PRIVATE_KEY`/`JWT_PUBLIC_KEY` env vars to the server container
- Fresh beta deployments will no longer fail on startup

## Details
The server was upgraded to EdDSA (Ed25519) JWT signing but the deployment infra was never updated — it still generated `JWT_SECRET` (a hex string for HMAC) which the server completely ignores. The server requires `JWT_PRIVATE_KEY` and `JWT_PUBLIC_KEY` (base64-encoded PEM), and fails to start without them.

**Files changed:**
- `infra/scripts/setup-beta.sh` — generates Ed25519 key pair via `openssl genpkey`
- `infra/compose/.env.beta` — template now has `JWT_PRIVATE_KEY`/`JWT_PUBLIC_KEY` placeholders
- `infra/compose/docker-compose.yml` — passes correct env vars to server container

## Test plan
- [ ] Run `setup-beta.sh` on a clean system, verify `.env` contains valid base64-encoded PEM keys
- [ ] `docker compose config` shows `JWT_PRIVATE_KEY` and `JWT_PUBLIC_KEY` in server environment
- [ ] Server starts successfully with generated keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)