### PR TITLE
fix(client,api): address code review followups

### DIFF
--- a/client/src-tauri/src/network/websocket.rs
+++ b/client/src-tauri/src/network/websocket.rs
@@ -494,8 +494,11 @@ async fn connection_loop(
         let request = match build_ws_request(&ws_url, &token) {
             Ok(req) => req,
             Err(e) => {
-                error!("Failed to build WebSocket request: {}", e);
-                continue;
+                error!("Failed to build WebSocket request (invalid token?): {}", e);
+                // Token won't change between attempts — break to avoid infinite spin
+                *status.write().await = ConnectionStatus::Disconnected;
+                let _ = app.emit("ws:disconnected", ());
+                return;
             }
         };
         match connect_async(request).await {

--- a/client/src/components/pages/MarkdownPreview.tsx
+++ b/client/src/components/pages/MarkdownPreview.tsx
@@ -13,7 +13,7 @@ import { Marked } from "marked";
 import DOMPurify from "dompurify";
 // Mermaid is loaded dynamically to avoid bundling ~1.8MB in the main chunk.
 // It's only needed when the Pages feature is actually used.
-let mermaidModule: typeof import("mermaid") extends Promise<infer T> ? T : never;
+let mermaidModule: Awaited<typeof import("mermaid")> | undefined;
 let mermaidInitialized = false;
 
 async function loadMermaid() {

--- a/client/src/views/Login.tsx
+++ b/client/src/views/Login.tsx
@@ -30,6 +30,7 @@ const Login: Component = () => {
   document.title = "Login | Kaiku";
   onCleanup(() => { document.title = "Kaiku"; });
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const isTauri = typeof window !== "undefined" && "__TAURI__" in window;
   const defaultServerUrl = import.meta.env.VITE_SERVER_URL || window.location.origin;
   const [serverUrl, setServerUrl] = createSignal(defaultServerUrl);
@@ -91,8 +92,7 @@ const Login: Component = () => {
         authState.mfaRequired ? mfaCode() : undefined,
       );
       // Navigate to returnUrl if valid (relative path only), otherwise home
-      const [params] = useSearchParams();
-      const returnUrl = params.returnUrl;
+      const returnUrl = searchParams.returnUrl;
       const target = returnUrl && returnUrl.startsWith("/") && !returnUrl.startsWith("//")
         ? returnUrl
         : "/";

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -442,7 +442,8 @@ pub(crate) struct HealthResponse {
     path = "/health",
     tag = "health",
     responses(
-        (status = 200, description = "Service health status", body = HealthResponse),
+        (status = 200, description = "Service healthy", body = HealthResponse),
+        (status = 503, description = "Service degraded — database or Redis unreachable", body = HealthResponse),
     ),
 )]
 pub(crate) async fn health_check(


### PR DESCRIPTION
## Summary
Fixes 4 issues identified during code review of PRs #410-#413.

## Changes
1. **Login.tsx**: Move `useSearchParams()` to component scope (was called inside event handler, violating SolidJS hook conventions)
2. **api/mod.rs**: Add HTTP 503 response to health check OpenAPI spec (was only documenting 200)
3. **websocket.rs**: Fix infinite retry loop — `build_ws_request` failure (invalid token) now returns immediately instead of spinning without backoff
4. **MarkdownPreview.tsx**: Use `Awaited<>` utility type + `| undefined` for mermaid module declaration

## Test plan
- [x] `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings` — clean
- [x] 541/541 vitest client tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)