### PR TITLE
refactor(ws,voice,client): simplify beta fix code

### DIFF
--- a/client/src/components/voice/VoicePanel.tsx
+++ b/client/src/components/voice/VoicePanel.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/stores/voice";
 import { getChannel } from "@/stores/channels";
 import { startViewing } from "@/stores/screenShareViewer";
-import { formatElapsedTime } from "@/lib/utils";
+import { formatElapsedTime, getParticipantDisplayName } from "@/lib/utils";
 import { QualityIndicator } from "./QualityIndicator";
 import { QualityTooltip } from "./QualityTooltip";
 import type { ConnectionMetrics } from "@/lib/webrtc/types";
@@ -138,10 +138,10 @@ const VoicePanel: Component = () => {
                     title={participant.muted ? "Muted" : undefined}
                   >
                     <div class="w-4 h-4 rounded-full bg-accent-primary/20 flex items-center justify-center text-accent-primary">
-                      {(participant.display_name || participant.username || participant.user_id).charAt(0).toUpperCase()}
+                      {getParticipantDisplayName(participant).charAt(0).toUpperCase()}
                     </div>
                     <span class="truncate max-w-20">
-                      {participant.display_name || participant.username || participant.user_id.slice(0, 8)}
+                      {getParticipantDisplayName(participant)}
                     </span>
                     {participant.screen_sharing && (
                       <button

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -3,6 +3,17 @@
  */
 
 /**
+ * Get the display name for a voice participant with fallback chain.
+ */
+export function getParticipantDisplayName(participant: {
+  user_id: string;
+  display_name?: string | null;
+  username?: string | null;
+}): string {
+  return participant.display_name || participant.username || participant.user_id.slice(0, 8);
+}
+
+/**
  * Format a timestamp for display.
  * Shows time only for today, date and time for older messages.
  */

--- a/client/src/stores/websocket.ts
+++ b/client/src/stores/websocket.ts
@@ -225,6 +225,7 @@ export async function initWebSocket(): Promise<void> {
     pending.push(
       listen("ws:disconnected", () => {
         setWsState({ status: "disconnected" });
+        dismissToast("ws-reconnect");
       }),
     );
 

--- a/server/src/voice/ws_handler.rs
+++ b/server/src/voice/ws_handler.rs
@@ -24,6 +24,17 @@ use super::webcam::WebcamInfo;
 use super::Quality;
 use crate::ws::{ClientEvent, OutboundMsg, ServerEvent, VoiceParticipant};
 
+/// Map a permission error to a voice error, logging database errors instead of masking them.
+fn map_permission_error(e: crate::permissions::PermissionError, context: &str) -> VoiceError {
+    match e {
+        crate::permissions::PermissionError::DatabaseError(msg) => {
+            error!(error = %msg, "Database error during {context}");
+            VoiceError::Signaling(format!("Permission check failed: {msg}"))
+        }
+        _ => VoiceError::Unauthorized,
+    }
+}
+
 /// Handle a voice-related client event.
 pub async fn handle_voice_event(
     sfu: &Arc<SfuServer>,
@@ -142,13 +153,7 @@ async fn handle_join(
     // Check if user has VIEW_CHANNEL and VOICE_CONNECT permissions
     let ctx = crate::permissions::require_channel_access(pool, user_id, channel_id)
         .await
-        .map_err(|e| match &e {
-            crate::permissions::PermissionError::DatabaseError(msg) => {
-                error!(error = %msg, "Database error during voice permission check");
-                VoiceError::Signaling(format!("Permission check failed: {msg}"))
-            }
-            _ => VoiceError::Unauthorized,
-        })?;
+        .map_err(|e| map_permission_error(e, "voice join"))?;
 
     if !ctx.has_permission(crate::permissions::GuildPermissions::VOICE_CONNECT) {
         return Err(VoiceError::Unauthorized);
@@ -304,13 +309,7 @@ async fn handle_leave(
     // Check if user has VIEW_CHANNEL permission
     crate::permissions::require_channel_access(pool, user_id, channel_id)
         .await
-        .map_err(|e| match &e {
-            crate::permissions::PermissionError::DatabaseError(msg) => {
-                error!(error = %msg, "Database error during voice leave permission check");
-                VoiceError::Signaling(format!("Permission check failed: {msg}"))
-            }
-            _ => VoiceError::Unauthorized,
-        })?;
+        .map_err(|e| map_permission_error(e, "voice leave"))?;
 
     let room = sfu
         .get_room(channel_id)
@@ -621,13 +620,7 @@ async fn handle_screen_share_start(
     // Check if user has VIEW_CHANNEL and SCREEN_SHARE permissions
     let ctx = crate::permissions::require_channel_access(pool, params.user_id, params.channel_id)
         .await
-        .map_err(|e| match &e {
-            crate::permissions::PermissionError::DatabaseError(msg) => {
-                error!(error = %msg, "Database error during screen share permission check");
-                VoiceError::Signaling(format!("Permission check failed: {msg}"))
-            }
-            _ => VoiceError::Unauthorized,
-        })?;
+        .map_err(|e| map_permission_error(e, "screen share"))?;
 
     if !ctx.has_permission(crate::permissions::GuildPermissions::SCREEN_SHARE) {
         return Err(VoiceError::Unauthorized);

--- a/server/src/ws/mod.rs
+++ b/server/src/ws/mod.rs
@@ -1155,10 +1155,14 @@ pub async fn handler(
         }
     };
 
-    // Verify user still exists and is not banned/deleted
-    match db::find_user_by_id(&state.db, user_id).await {
-        Ok(Some(_)) => {}
-        Ok(None) => {
+    // Verify user still exists (lightweight existence check, not full row fetch)
+    match sqlx::query_scalar::<_, bool>("SELECT EXISTS(SELECT 1 FROM users WHERE id = $1)")
+        .bind(user_id)
+        .fetch_one(&state.db)
+        .await
+    {
+        Ok(true) => {}
+        Ok(false) => {
             return error_response(401, "User not found");
         }
         Err(e) => {


### PR DESCRIPTION
## Summary
Code simplification from /simplify review of PRs #410-#415.

## Changes
1. **Extract `map_permission_error()` helper** — 3 identical inline closures in voice `ws_handler.rs` replaced with shared function
2. **Dismiss reconnecting toast on disconnect** — persistent toast no longer stays forever if reconnection fails permanently
3. **Lightweight WS auth check** — `SELECT EXISTS(...)` instead of full `SELECT * FROM users` row fetch on every WS handshake
4. **Extract `getParticipantDisplayName()`** — shared utility in `lib/utils.ts` for the `display_name || username || user_id` fallback chain used in voice components

## Test plan
- [x] `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings` — clean
- [x] 541/541 vitest client tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)