### PR TITLE
fix(infra,client): bump Dockerfile Rust to 1.93 and fix Login returnUrl type

### DIFF
--- a/client/src/views/Login.tsx
+++ b/client/src/views/Login.tsx
@@ -92,7 +92,8 @@ const Login: Component = () => {
         authState.mfaRequired ? mfaCode() : undefined,
       );
       // Navigate to returnUrl if valid (relative path only), otherwise home
-      const returnUrl = searchParams.returnUrl;
+      const raw = searchParams.returnUrl;
+      const returnUrl = Array.isArray(raw) ? raw[0] : raw;
       const target = returnUrl && returnUrl.startsWith("/") && !returnUrl.startsWith("//")
         ? returnUrl
         : "/";

--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -3,7 +3,7 @@
 # ============================================================================
 # Build Stage - Rust compilation
 # ============================================================================
-FROM rust:1.88-bookworm AS builder
+FROM rust:1.93-bookworm AS builder
 
 WORKDIR /build
 


### PR DESCRIPTION
## Summary
- **Dockerfile**: Bumped Rust from 1.88 to 1.93 — required by aws-sdk (1.91.1) and workspace crates (1.93)
- **Login.tsx**: Fixed TS error where `searchParams.returnUrl` could be `string | string[]`

## Test plan
- [x] Server image builds successfully with podman
- [x] Deployed to beta VPS — health check passes
- [x] Client builds and deploys without TS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)