### PR TITLE
fix(client): restore presetUno() in UnoCSS config

### DIFF
--- a/client/uno.config.ts
+++ b/client/uno.config.ts
@@ -1,7 +1,8 @@
-import { defineConfig, presetIcons } from "unocss";
+import { defineConfig, presetUno, presetIcons } from "unocss";
 
 export default defineConfig({
   presets: [
+    presetUno(),
     presetIcons({
       scale: 1.2,
       cdn: "https://esm.sh/",


### PR DESCRIPTION
## Summary
- Commit 3959e44 (dependency mega-update) accidentally removed `presetUno()` from `uno.config.ts`, leaving only `presetIcons`
- This broke **all** standard utility classes (`flex`, `w-full`, `rounded-lg`, `border`, etc.), rendering the entire frontend unstyled
- Re-adds `presetUno()` to the presets array

## Test plan
- [x] Verified locally: login page renders fully styled after fix
- [x] No UnoCSS "unmatched utility" warnings in Vite server output


🤖 Generated with [Claude Code](https://claude.com/claude-code)