### PR TITLE
fix(api): cast channel_type enum to TEXT in favorites query

### DIFF
--- a/server/src/api/favorites.rs
+++ b/server/src/api/favorites.rs
@@ -197,7 +197,7 @@ pub async fn list_favorites(
         SELECT
             fc.channel_id,
             c.name as channel_name,
-            c.channel_type,
+            c.channel_type::TEXT as channel_type,
             fc.guild_id,
             g.name as guild_name,
             g.icon_url as guild_icon,


### PR DESCRIPTION
## Summary
- The `list_favorites` query selected `c.channel_type` directly, but `channel_type` is a PostgreSQL custom enum type
- sqlx couldn't decode the enum into a Rust `String`, causing `database_error` on every favorites load
- Fix: cast to `c.channel_type::TEXT`

## Test plan
- [x] Server compiles with `SQLX_OFFLINE=true cargo clippy`
- [ ] Verify favorites load successfully after deploy


🤖 Generated with [Claude Code](https://claude.com/claude-code)