### PR TITLE
fix(ratelimit): increase read rate limit to 1000/min

### DIFF
--- a/server/src/ratelimit/config.rs
+++ b/server/src/ratelimit/config.rs
@@ -121,7 +121,7 @@ impl Default for RateLimits {
                 window_secs: 60,
             },
             read: LimitConfig {
-                requests: 200,
+                requests: 1000,
                 window_secs: 60,
             },
             ws_connect: LimitConfig {
@@ -315,7 +315,7 @@ mod tests {
         let limits = RateLimits::default();
         assert_eq!(limits.auth_login.requests, 3);
         assert_eq!(limits.auth_login.window_secs, 60);
-        assert_eq!(limits.read.requests, 200);
+        assert_eq!(limits.read.requests, 1000);
         assert_eq!(limits.failed_auth.max_failures, 10);
         assert_eq!(limits.failed_auth.block_duration_secs, 900);
     }


### PR DESCRIPTION
## Summary
- Increased read rate limit from 200 to 1000 requests per 60s window
- Login burst (messages, members, pins, favorites, settings) regularly exceeded 200/min, causing 429 errors

## Test plan
- [x] Compiles, test updated
- [ ] Verify no rate limiting on login after deploy


🤖 Generated with [Claude Code](https://claude.com/claude-code)