### PR TITLE
fix(client): fix message overlap when sending in full chat

### DIFF
--- a/client/src/components/messages/MessageList.tsx
+++ b/client/src/components/messages/MessageList.tsx
@@ -469,7 +469,7 @@ const MessageList: Component<MessageListProps> = (props) => {
                   data-index={virtualItem.index}
                   ref={(el) => {
                     el.setAttribute("data-index", String(virtualItem.index));
-                    virtualizer.measureElement(el);
+                    queueMicrotask(() => virtualizer.measureElement(el));
                   }}
                   class={isHighlighted() ? "message-highlight" : undefined}
                   style={{

--- a/client/src/views/Main.tsx
+++ b/client/src/views/Main.tsx
@@ -225,7 +225,7 @@ const Main: Component = () => {
             {/* Channel Chat */}
             <Match when={channel()}>
               <div class="flex flex-1 min-w-0 h-full overflow-hidden">
-                <div class="flex-1 flex flex-col min-w-0">
+                <div class="flex-1 flex flex-col min-w-0 min-h-0">
                   {/* Channel Header */}
                   <header class="h-12 px-4 flex items-center border-b border-white/5 bg-surface-layer1 shadow-sm">
                     <Show


### PR DESCRIPTION
## Summary
- Added `min-h-0` to flex-col container in Main.tsx channel chat — without it, the MessageList scroll container wasn't properly height-constrained, causing layout issues
- Deferred `measureElement` to `queueMicrotask()` per TanStack Virtual docs to avoid interfering with Solid's rendering cycle

## Test plan
- [ ] Send a message when chat is full of messages — should auto-scroll, no overlap
- [ ] Verify DMs still scroll correctly (already had `min-h-0`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)