### PR TITLE
fix(client): guard virtualizer against undefined virtual items

### DIFF
--- a/client/src/components/messages/MessageList.tsx
+++ b/client/src/components/messages/MessageList.tsx
@@ -476,6 +476,7 @@ const MessageList: Component<MessageListProps> = (props) => {
         >
           <For each={virtualizer.getVirtualItems()}>
             {(virtualItem) => {
+              if (!virtualItem || virtualItem.index == null) return null;
               const item = () => messagesWithCompact()[virtualItem.index];
               const isHighlighted = () =>
                 item()?.message.id != null &&
@@ -491,7 +492,7 @@ const MessageList: Component<MessageListProps> = (props) => {
                   class={isHighlighted() ? "message-highlight" : undefined}
                   style={{
                     position: "absolute",
-                    top: `${virtualItem.start}px`,
+                    top: `${virtualItem.start ?? 0}px`,
                     width: "100%",
                   }}
                 >

--- a/client/src/lib/virtualizer.ts
+++ b/client/src/lib/virtualizer.ts
@@ -28,7 +28,7 @@ export function createVirtualizer(options: VirtualizerOptions) {
   });
 
   return {
-    getVirtualItems: (): VirtualItem[] => virtualizer.getVirtualItems(),
+    getVirtualItems: (): VirtualItem[] => virtualizer.getVirtualItems()?.filter(Boolean) ?? [],
     getTotalSize: (): number => virtualizer.getTotalSize(),
     getScrollElement: options.getScrollElement,
     scrollToIndex: (


### PR DESCRIPTION
## Summary
- Filter undefined items from getVirtualItems() in virtualizer wrapper
- Guard For callback: skip rendering if virtualItem is undefined
- Prevents "Cannot read properties of undefined (reading 'index')" crash

## Test plan
- [ ] Messages load successfully
- [ ] Sending messages works
- [ ] No console errors about 'index'


🤖 Generated with [Claude Code](https://claude.com/claude-code)