### PR TITLE
refactor(client): use TanStack Virtual directly, fix message overlap

### DIFF
--- a/client/src/components/messages/MessageList.tsx
+++ b/client/src/components/messages/MessageList.tsx
@@ -1,6 +1,6 @@
 import {
   Component,
-  For,
+  Index,
   Show,
   createEffect,
   on,
@@ -95,42 +95,38 @@ const MessageList: Component<MessageListProps> = (props) => {
     },
     getScrollElement: () => containerRef ?? null,
     estimateSize: (index: number) => {
-      try {
-        const item = messagesWithCompact()[index];
-        if (!item?.message) return 96;
-        const msg = item.message;
-        const content = msg.content || "";
-        const attachments = msg.attachments || [];
+      const item = messagesWithCompact()[index];
+      if (!item?.message) return 96;
+      const msg = item.message;
+      const content = msg.content || "";
+      const attachments = msg.attachments || [];
 
-        // Base: header (avatar + name + timestamp) or compact (no header)
-        let estimate = item.isCompact ? 8 : 52;
+      // Base: header (avatar + name + timestamp) or compact (no header)
+      let estimate = item.isCompact ? 8 : 52;
 
-        // Content lines (~22px each), with code blocks handled separately
-        let contentHeight = 0;
-        const codeBlockRegex = /```[\s\S]*?```/g;
-        const codeBlocks = content.match(codeBlockRegex) || [];
-        const textOnly = content.replace(codeBlockRegex, "");
+      // Content lines (~22px each), with code blocks handled separately
+      let contentHeight = 0;
+      const codeBlockRegex = /```[\s\S]*?```/g;
+      const codeBlocks = content.match(codeBlockRegex) || [];
+      const textOnly = content.replace(codeBlockRegex, "");
 
-        for (const block of codeBlocks) {
-          contentHeight += block.split("\n").length * 20 + 32;
-        }
-        contentHeight += textOnly.split("\n").length * 22;
-
-        estimate += Math.max(contentHeight, 22);
-
-        // Attachments
-        for (const a of attachments) {
-          estimate += a.mime_type?.startsWith("image/") ? 320 : 48;
-        }
-
-        // Reactions (~36px) and thread indicator (~28px)
-        if (msg.reactions?.length) estimate += 36;
-        if (msg.thread_reply_count) estimate += 28;
-
-        return estimate + 16; // padding
-      } catch {
-        return 96;
+      for (const block of codeBlocks) {
+        contentHeight += block.split("\n").length * 20 + 32;
       }
+      contentHeight += textOnly.split("\n").length * 22;
+
+      estimate += Math.max(contentHeight, 22);
+
+      // Attachments
+      for (const a of attachments) {
+        estimate += a.mime_type?.startsWith("image/") ? 320 : 48;
+      }
+
+      // Reactions (~36px) and thread indicator (~28px)
+      if (msg.reactions?.length) estimate += 36;
+      if (msg.thread_reply_count) estimate += 28;
+
+      return estimate + 16; // padding
     },
     overscan: 5,
   });
@@ -474,26 +470,26 @@ const MessageList: Component<MessageListProps> = (props) => {
             position: "relative",
           }}
         >
-          <For each={virtualizer.getVirtualItems()}>
+          <Index each={virtualizer.getVirtualItems()}>
             {(virtualItem) => {
-              if (!virtualItem || virtualItem.index == null) return null;
-              const item = () => messagesWithCompact()[virtualItem.index];
+              const item = () => messagesWithCompact()[virtualItem().index];
               const isHighlighted = () =>
                 item()?.message.id != null &&
                 highlightedId() === item()?.message.id;
               return (
                 <div
                   role="listitem"
-                  data-index={virtualItem.index}
+                  data-index={virtualItem().index}
                   ref={(el) => {
-                    el.setAttribute("data-index", String(virtualItem.index));
-                    virtualizer.measureElement(el);
+                    queueMicrotask(() => virtualizer.measureElement(el));
                   }}
                   class={isHighlighted() ? "message-highlight" : undefined}
                   style={{
                     position: "absolute",
-                    top: `${virtualItem.start ?? 0}px`,
+                    top: 0,
+                    left: 0,
                     width: "100%",
+                    transform: `translateY(${virtualItem().start}px)`,
                   }}
                 >
                   {(() => {
@@ -510,7 +506,7 @@ const MessageList: Component<MessageListProps> = (props) => {
                 </div>
               );
             }}
-          </For>
+          </Index>
         </div>
       </Show>
 

--- a/client/src/lib/virtualizer.ts
+++ b/client/src/lib/virtualizer.ts
@@ -12,13 +12,15 @@ interface VirtualizerOptions {
   overscan?: number;
 }
 
-interface ScrollToIndexOptions {
-  align?: "start" | "center" | "end" | "auto";
-  behavior?: "auto" | "smooth";
-}
-
+/**
+ * Thin wrapper around TanStack Virtual's createVirtualizer for Solid.js.
+ *
+ * Returns the TanStack virtualizer directly to preserve Solid's reactive
+ * tracking. Previous versions wrapped methods in arrow functions which
+ * could break reactivity in edge cases.
+ */
 export function createVirtualizer(options: VirtualizerOptions) {
-  const virtualizer = createTanStackVirtualizer({
+  return createTanStackVirtualizer({
     get count() {
       return options.count;
     },
@@ -26,21 +28,4 @@ export function createVirtualizer(options: VirtualizerOptions) {
     estimateSize: options.estimateSize,
     overscan: options.overscan ?? 0,
   });
-
-  return {
-    getVirtualItems: (): VirtualItem[] => virtualizer.getVirtualItems()?.filter(Boolean) ?? [],
-    getTotalSize: (): number => virtualizer.getTotalSize(),
-    getScrollElement: options.getScrollElement,
-    scrollToIndex: (
-      index: number,
-      scrollOptions: ScrollToIndexOptions = {},
-    ) => {
-      virtualizer.scrollToIndex(index, scrollOptions);
-    },
-    measureElement: (node: Element | null | undefined) => {
-      if (node) {
-        virtualizer.measureElement(node as HTMLElement);
-      }
-    },
-  };
 }


### PR DESCRIPTION
## Summary
- **Root cause fix**: The virtualizer wrapper broke Solid.js reactive tracking by wrapping TanStack's reactive methods in arrow functions, causing stale/undefined virtual items
- **Wrapper rewritten**: Now returns TanStack virtualizer directly — no indirection, full reactivity preserved
- **`<For>` → `<Index>`**: `<Index>` keys by position with reactive signal accessors (`virtualItem()`), properly updating when the virtualizer recalculates. `<For>` keyed by reference, causing full DOM recreation
- **`top` → `transform: translateY()`**: GPU-composited positioning per TanStack docs
- **`queueMicrotask` for measurement**: Per TanStack docs, defers measurement to after render
- **Band-aids removed**: filter(Boolean), try-catch, null guards no longer needed

## Test plan
- [ ] Messages load without errors
- [ ] No message overlap with code blocks or multi-line messages
- [ ] Sending messages auto-scrolls correctly
- [ ] Scrolling up loads older messages
- [ ] Search, Members tab, Home sidebar still work (also use virtualizer)


🤖 Generated with [Claude Code](https://claude.com/claude-code)