### PR TITLE
fix(client): stop drag event propagation from channels to categories

### DIFF
--- a/client/src/components/channels/ChannelList.tsx
+++ b/client/src/components/channels/ChannelList.tsx
@@ -234,6 +234,7 @@ const ChannelList: Component = () => {
     _categoryId: string | null,
   ) => {
     e.preventDefault();
+    e.stopPropagation(); // Prevent bubbling to category handler which would overwrite the drop target
     if (!canManageChannels()) return;
     if (!dragState.isDragging) return;
 


### PR DESCRIPTION
## Summary
- The dragover event on channels bubbled to parent category handler, overwriting the channel drop target — this is why the channel insertion line was never visible
- One-line fix: `e.stopPropagation()` in `handleChannelDragOver`

## Test plan
- [ ] Drag channel over other channels — insertion line appears between them
- [ ] Drag channel over category header — category highlight still works
- [ ] Drop channel between channels — reorders correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)