### PR TITLE
feat(client): add category management UI in guild settings

### DIFF
--- a/client/src/components/guilds/CategoriesTab.tsx
+++ b/client/src/components/guilds/CategoriesTab.tsx
@@ -1,0 +1,283 @@
+/**
+ * CategoriesTab - Category management in guild settings
+ *
+ * Provides CRUD for channel categories:
+ * - Create categories and subcategories
+ * - Inline rename (click pencil, Enter to save, Escape to cancel)
+ * - Delete with confirmation
+ */
+
+import { Component, createSignal, For, Show, onMount } from "solid-js";
+import { Pencil, Trash2, Plus, Check, X, ChevronRight } from "lucide-solid";
+import {
+  categoriesState,
+  loadGuildCategories,
+  getTopLevelCategories,
+  getSubcategories,
+  createCategory,
+  updateCategory,
+  deleteCategory,
+} from "@/stores/categories";
+
+interface CategoriesTabProps {
+  guildId: string;
+}
+
+const CategoriesTab: Component<CategoriesTabProps> = (props) => {
+  const [newCategoryName, setNewCategoryName] = createSignal("");
+  const [editingId, setEditingId] = createSignal<string | null>(null);
+  const [editingName, setEditingName] = createSignal("");
+  const [deletingId, setDeletingId] = createSignal<string | null>(null);
+  const [addingSubcategoryFor, setAddingSubcategoryFor] = createSignal<string | null>(null);
+  const [subCategoryName, setSubCategoryName] = createSignal("");
+  const [isCreating, setIsCreating] = createSignal(false);
+
+  onMount(() => {
+    loadGuildCategories(props.guildId);
+  });
+
+  const topLevel = () => getTopLevelCategories(props.guildId);
+
+  const handleCreate = async () => {
+    const name = newCategoryName().trim();
+    if (!name) return;
+    setIsCreating(true);
+    await createCategory(props.guildId, name);
+    setNewCategoryName("");
+    setIsCreating(false);
+  };
+
+  const handleCreateSubcategory = async (parentId: string) => {
+    const name = subCategoryName().trim();
+    if (!name) return;
+    setIsCreating(true);
+    await createCategory(props.guildId, name, parentId);
+    setSubCategoryName("");
+    setAddingSubcategoryFor(null);
+    setIsCreating(false);
+  };
+
+  const startEditing = (id: string, currentName: string) => {
+    setEditingId(id);
+    setEditingName(currentName);
+  };
+
+  const handleRename = async () => {
+    const id = editingId();
+    const name = editingName().trim();
+    if (!id || !name) return;
+    await updateCategory(props.guildId, id, { name });
+    setEditingId(null);
+    setEditingName("");
+  };
+
+  const cancelEditing = () => {
+    setEditingId(null);
+    setEditingName("");
+  };
+
+  const handleDelete = async (id: string) => {
+    const success = await deleteCategory(props.guildId, id);
+    if (success) setDeletingId(null);
+  };
+
+  const renderCategoryRow = (categoryId: string, name: string, isSubcat: boolean) => {
+    const isEditing = () => editingId() === categoryId;
+    const isDeleting = () => deletingId() === categoryId;
+
+    return (
+      <div
+        class="flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-white/5 group"
+        classList={{ "ml-6": isSubcat }}
+      >
+        <Show when={!isSubcat}>
+          <ChevronRight class="w-3.5 h-3.5 text-text-muted shrink-0" />
+        </Show>
+
+        <Show
+          when={!isEditing()}
+          fallback={
+            <div class="flex-1 flex items-center gap-2">
+              <input
+                type="text"
+                value={editingName()}
+                onInput={(e) => setEditingName(e.currentTarget.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleRename();
+                  if (e.key === "Escape") cancelEditing();
+                }}
+                class="flex-1 px-2 py-1 bg-surface-layer2 rounded text-sm text-text-primary border border-white/10 outline-none focus:ring-1 focus:ring-accent-primary"
+                ref={(el) => setTimeout(() => el.focus(), 0)}
+              />
+              <button
+                onClick={handleRename}
+                class="p-1 text-accent-success hover:bg-white/10 rounded"
+                title="Save"
+              >
+                <Check class="w-4 h-4" />
+              </button>
+              <button
+                onClick={cancelEditing}
+                class="p-1 text-text-secondary hover:bg-white/10 rounded"
+                title="Cancel"
+              >
+                <X class="w-4 h-4" />
+              </button>
+            </div>
+          }
+        >
+          <span class="flex-1 text-sm text-text-primary truncate">{name}</span>
+          <Show when={!isDeleting()}>
+            <div class="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+              <Show when={!isSubcat}>
+                <button
+                  onClick={() => {
+                    setAddingSubcategoryFor(addingSubcategoryFor() === categoryId ? null : categoryId);
+                    setSubCategoryName("");
+                  }}
+                  class="p-1 text-text-secondary hover:text-accent-primary hover:bg-white/10 rounded transition-colors"
+                  title="Add Subcategory"
+                >
+                  <Plus class="w-3.5 h-3.5" />
+                </button>
+              </Show>
+              <button
+                onClick={() => startEditing(categoryId, name)}
+                class="p-1 text-text-secondary hover:text-text-primary hover:bg-white/10 rounded transition-colors"
+                title="Rename"
+              >
+                <Pencil class="w-3.5 h-3.5" />
+              </button>
+              <button
+                onClick={() => setDeletingId(categoryId)}
+                class="p-1 text-text-secondary hover:text-accent-danger hover:bg-white/10 rounded transition-colors"
+                title="Delete"
+              >
+                <Trash2 class="w-3.5 h-3.5" />
+              </button>
+            </div>
+          </Show>
+        </Show>
+
+        {/* Delete confirmation inline */}
+        <Show when={isDeleting()}>
+          <div class="flex items-center gap-2">
+            <span class="text-xs text-accent-danger">Delete?</span>
+            <button
+              onClick={() => handleDelete(categoryId)}
+              class="px-2 py-0.5 text-xs bg-accent-danger text-white rounded hover:opacity-80"
+            >
+              Yes
+            </button>
+            <button
+              onClick={() => setDeletingId(null)}
+              class="px-2 py-0.5 text-xs bg-white/10 text-text-primary rounded hover:bg-white/20"
+            >
+              No
+            </button>
+          </div>
+        </Show>
+      </div>
+    );
+  };
+
+  return (
+    <div class="p-6 space-y-6">
+      <div>
+        <h3 class="text-lg font-semibold text-text-primary mb-1">Categories</h3>
+        <p class="text-sm text-text-secondary">
+          Organize channels into categories. Drag channels in the sidebar to move them between categories.
+        </p>
+      </div>
+
+      {/* Create new category */}
+      <div class="flex gap-2">
+        <input
+          type="text"
+          placeholder="New category name"
+          value={newCategoryName()}
+          onInput={(e) => setNewCategoryName(e.currentTarget.value)}
+          onKeyDown={(e) => { if (e.key === "Enter") handleCreate(); }}
+          class="flex-1 px-3 py-2 bg-surface-layer2 rounded-lg text-sm text-text-primary border border-white/10 outline-none focus:ring-1 focus:ring-accent-primary placeholder-text-secondary"
+          disabled={isCreating()}
+        />
+        <button
+          onClick={handleCreate}
+          disabled={!newCategoryName().trim() || isCreating()}
+          class="px-4 py-2 bg-accent-primary text-on-accent rounded-lg text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Add
+        </button>
+      </div>
+
+      {/* Categories list */}
+      <Show
+        when={!categoriesState.isLoading}
+        fallback={<p class="text-sm text-text-secondary">Loading categories...</p>}
+      >
+        <Show
+          when={topLevel().length > 0}
+          fallback={
+            <p class="text-sm text-text-secondary py-4 text-center">
+              No categories yet. Create one above to organize your channels.
+            </p>
+          }
+        >
+          <div class="space-y-1 bg-surface-layer1 rounded-lg border border-white/5 py-2">
+            <For each={topLevel()}>
+              {(category) => {
+                const subs = () => getSubcategories(props.guildId, category.id);
+                return (
+                  <>
+                    {renderCategoryRow(category.id, category.name, false)}
+
+                    {/* Subcategories */}
+                    <For each={subs()}>
+                      {(sub) => renderCategoryRow(sub.id, sub.name, true)}
+                    </For>
+
+                    {/* Add subcategory inline form */}
+                    <Show when={addingSubcategoryFor() === category.id}>
+                      <div class="flex items-center gap-2 ml-6 px-3 py-1.5">
+                        <input
+                          type="text"
+                          placeholder="Subcategory name"
+                          value={subCategoryName()}
+                          onInput={(e) => setSubCategoryName(e.currentTarget.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") handleCreateSubcategory(category.id);
+                            if (e.key === "Escape") setAddingSubcategoryFor(null);
+                          }}
+                          class="flex-1 px-2 py-1 bg-surface-layer2 rounded text-sm text-text-primary border border-white/10 outline-none focus:ring-1 focus:ring-accent-primary placeholder-text-secondary"
+                          disabled={isCreating()}
+                          ref={(el) => setTimeout(() => el.focus(), 0)}
+                        />
+                        <button
+                          onClick={() => handleCreateSubcategory(category.id)}
+                          disabled={!subCategoryName().trim() || isCreating()}
+                          class="p-1 text-accent-success hover:bg-white/10 rounded disabled:opacity-50"
+                          title="Add"
+                        >
+                          <Check class="w-4 h-4" />
+                        </button>
+                        <button
+                          onClick={() => setAddingSubcategoryFor(null)}
+                          class="p-1 text-text-secondary hover:bg-white/10 rounded"
+                          title="Cancel"
+                        >
+                          <X class="w-4 h-4" />
+                        </button>
+                      </div>
+                    </Show>
+                  </>
+                );
+              }}
+            </For>
+          </div>
+        </Show>
+      </Show>
+    </div>
+  );
+};
+
+export default CategoriesTab;

--- a/client/src/components/guilds/GuildSettingsModal.tsx
+++ b/client/src/components/guilds/GuildSettingsModal.tsx
@@ -16,6 +16,7 @@ import {
   Bot,
   Settings,
   BarChart3,
+  LayoutList,
 } from "lucide-solid";
 import { guildsState, isGuildOwner } from "@/stores/guilds";
 import { authState } from "@/stores/auth";
@@ -27,6 +28,7 @@ import EmojisTab from "./EmojisTab";
 import BotsTab from "./BotsTab";
 import SafetyTab from "./SafetyTab";
 import UsageTab from "./UsageTab";
+import CategoriesTab from "./CategoriesTab";
 import RoleEditor from "./RoleEditor";
 import { memberHasPermission } from "@/stores/permissions";
 import { PermissionBits } from "@/lib/permissionConstants";
@@ -41,6 +43,7 @@ type TabId =
   | "general"
   | "invites"
   | "members"
+  | "categories"
   | "roles"
   | "emojis"
   | "bots"
@@ -97,6 +100,15 @@ const GuildSettingsModal: Component<GuildSettingsModalProps> = (props) => {
     );
 
   const canManageBots = () => canManageGuild();
+
+  const canManageChannels = () =>
+    isOwner() ||
+    memberHasPermission(
+      props.guildId,
+      authState.user?.id || "",
+      isOwner(),
+      PermissionBits.MANAGE_CHANNELS,
+    );
 
   const handleBackdropClick = (e: MouseEvent) => {
     if (e.target === e.currentTarget) {
@@ -191,6 +203,21 @@ const GuildSettingsModal: Component<GuildSettingsModalProps> = (props) => {
               <Users class="w-4 h-4" />
               Members
             </button>
+            <Show when={canManageChannels()}>
+              <button
+                onClick={() => setActiveTab("categories")}
+                class="flex items-center gap-2 px-6 py-3 font-medium transition-colors"
+                classList={{
+                  "text-accent-primary border-b-2 border-accent-primary":
+                    activeTab() === "categories",
+                  "text-text-secondary hover:text-text-primary":
+                    activeTab() !== "categories",
+                }}
+              >
+                <LayoutList class="w-4 h-4" />
+                Categories
+              </button>
+            </Show>
             <button
               onClick={() => setActiveTab("usage")}
               class="flex items-center gap-2 px-6 py-3 font-medium transition-colors"
@@ -277,6 +304,9 @@ const GuildSettingsModal: Component<GuildSettingsModalProps> = (props) => {
             </Show>
             <Show when={activeTab() === "members"}>
               <MembersTab guildId={props.guildId} isOwner={isOwner()} />
+            </Show>
+            <Show when={activeTab() === "categories" && canManageChannels()}>
+              <CategoriesTab guildId={props.guildId} />
             </Show>
             <Show when={activeTab() === "usage"}>
               <UsageTab guildId={props.guildId} />

--- a/client/src/stores/categories.ts
+++ b/client/src/stores/categories.ts
@@ -339,6 +339,79 @@ export async function reorderCategories(
 }
 
 /**
+ * Create a new category in a guild.
+ */
+export async function createCategory(
+  guildId: string,
+  name: string,
+  parentId?: string,
+): Promise<ChannelCategory | null> {
+  try {
+    const category = await tauri.createGuildCategory(guildId, name, parentId);
+    // Add to local store
+    const existing = categoriesState.categories[guildId] ?? [];
+    setCategoriesState("categories", guildId, [...existing, category]);
+    return category;
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    console.error("Failed to create category:", error);
+    showToast({ type: "error", title: "Failed to create category", message: error, duration: 8000 });
+    return null;
+  }
+}
+
+/**
+ * Update a category (rename, move, etc.).
+ */
+export async function updateCategory(
+  guildId: string,
+  categoryId: string,
+  updates: { name?: string; position?: number; parentId?: string | null },
+): Promise<boolean> {
+  try {
+    const updated = await tauri.updateGuildCategory(guildId, categoryId, updates);
+    // Update in local store
+    const existing = categoriesState.categories[guildId] ?? [];
+    setCategoriesState(
+      "categories",
+      guildId,
+      existing.map((c) => (c.id === categoryId ? updated : c)),
+    );
+    return true;
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    console.error("Failed to update category:", error);
+    showToast({ type: "error", title: "Failed to update category", message: error, duration: 8000 });
+    return false;
+  }
+}
+
+/**
+ * Delete a category. Channels in it move to uncategorized.
+ */
+export async function deleteCategory(
+  guildId: string,
+  categoryId: string,
+): Promise<boolean> {
+  try {
+    await tauri.deleteGuildCategory(guildId, categoryId);
+    // Remove from local store (including subcategories)
+    const existing = categoriesState.categories[guildId] ?? [];
+    setCategoriesState(
+      "categories",
+      guildId,
+      existing.filter((c) => c.id !== categoryId && c.parent_id !== categoryId),
+    );
+    return true;
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    console.error("Failed to delete category:", error);
+    showToast({ type: "error", title: "Failed to delete category", message: error, duration: 8000 });
+    return false;
+  }
+}
+
+/**
  * Check if a category is a subcategory (has a parent).
  */
 export function isSubcategory(categoryId: string): boolean {


### PR DESCRIPTION
## Summary
- New "Categories" tab in guild settings (requires MANAGE_CHANNELS permission)
- Create categories and subcategories with inline forms
- Inline rename (pencil icon, Enter/Escape)
- Delete with inline confirmation
- Store actions added: createCategory(), updateCategory(), deleteCategory()

## Test plan
- [ ] Categories tab visible in guild settings for users with MANAGE_CHANNELS
- [ ] Create a category — appears in sidebar
- [ ] Rename a category — reflected in sidebar
- [ ] Add subcategory — appears nested under parent
- [ ] Delete a category — channels move to uncategorized


🤖 Generated with [Claude Code](https://claude.com/claude-code)