### PR TITLE
feat(client,api): add category type restriction (text/voice/mixed)

### DIFF
--- a/client/src/components/channels/CategoryHeader.tsx
+++ b/client/src/components/channels/CategoryHeader.tsx
@@ -9,7 +9,8 @@
  */
 
 import { Component, createSignal, Show } from "solid-js";
-import { ChevronDown, ChevronRight, Plus, Settings } from "lucide-solid";
+import { ChevronDown, ChevronRight, Plus, Settings, Hash, Volume2 } from "lucide-solid";
+import type { CategoryType } from "@/lib/types";
 
 interface CategoryHeaderProps {
   /** Category ID */
@@ -22,6 +23,8 @@ interface CategoryHeaderProps {
   hasUnread: boolean;
   /** Whether this is a subcategory (nested under another category) */
   isSubcategory: boolean;
+  /** Category type restriction */
+  categoryType?: CategoryType;
   /** Callback when expand/collapse is toggled */
   onToggle: () => void;
   /** Callback when "create channel" button is clicked (only shown if provided) */
@@ -61,6 +64,14 @@ const CategoryHeader: Component<CategoryHeaderProps> = (props) => {
       >
         {props.name}
       </span>
+
+      {/* Category type icon */}
+      <Show when={props.categoryType === "text"}>
+        <span title="Text only"><Hash class="w-3 h-3 text-text-muted shrink-0" /></span>
+      </Show>
+      <Show when={props.categoryType === "voice"}>
+        <span title="Voice only"><Volume2 class="w-3 h-3 text-text-muted shrink-0" /></span>
+      </Show>
 
       {/* Unread indicator - shown when collapsed and has unread */}
       <Show when={props.hasUnread && props.collapsed}>

--- a/client/src/components/channels/ChannelList.tsx
+++ b/client/src/components/channels/ChannelList.tsx
@@ -37,6 +37,7 @@ import {
   loadGuildCategories,
   getTopLevelCategories,
   getSubcategories,
+  getCategory,
   isCategoryCollapsed,
   toggleCategoryCollapse,
   reorderCategories,
@@ -303,18 +304,43 @@ const ChannelList: Component = () => {
       return;
     }
 
+    // Helper: check if a channel type is allowed in a category
+    const isCategoryTypeAllowed = (channelId: string, targetCategoryId: string): boolean => {
+      const channel = channelsState.channels.find((c) => c.id === channelId);
+      const category = getCategory(targetCategoryId);
+      if (!channel || !category || category.category_type === "mixed") return true;
+      const allowed = category.category_type === channel.channel_type;
+      if (!allowed) {
+        showToast({
+          type: "warning",
+          title: "Cannot move channel",
+          message: `${channel.channel_type === "voice" ? "Voice" : "Text"} channels can't be moved to a ${category.category_type}-only category.`,
+          duration: 5000,
+        });
+      }
+      return allowed;
+    };
+
     // Handle the drop based on source and target types
     if (result.sourceType === "channel") {
       if (result.targetType === "channel") {
         // Channel dropped on channel - reorder (possibly across categories)
+        const targetChannel = channelsState.channels.find((c) => c.id === result.targetId);
+        if (targetChannel?.category_id && !isCategoryTypeAllowed(result.sourceId, targetChannel.category_id)) {
+          endDrag();
+          return;
+        }
         await moveChannel(
           result.sourceId,
           result.targetId,
           result.position as "before" | "after",
         );
       } else if (result.targetType === "category") {
-        // Channel dropped on category header - move into that category
-        // "before" = insert at top, "after"/"inside" = insert at bottom
+        // Channel dropped on category header - validate type
+        if (!isCategoryTypeAllowed(result.sourceId, result.targetId)) {
+          endDrag();
+          return;
+        }
         await moveChannelToCategory(
           result.sourceId,
           result.targetId,
@@ -493,6 +519,7 @@ const ChannelList: Component = () => {
                 collapsed={isCollapsed()}
                 hasUnread={categoryHasUnread(subcategory.id)}
                 isSubcategory={true}
+                categoryType={subcategory.category_type}
                 onToggle={() => toggleCategoryCollapse(subcategory.id)}
                 onCreateChannel={
                   canManageChannels()
@@ -552,6 +579,7 @@ const ChannelList: Component = () => {
                 collapsed={isCollapsed()}
                 hasUnread={categoryHasUnread(category.id)}
                 isSubcategory={false}
+                categoryType={category.category_type}
                 onToggle={() => toggleCategoryCollapse(category.id)}
                 onCreateChannel={
                   canManageChannels()

--- a/client/src/components/channels/CreateChannelModal.tsx
+++ b/client/src/components/channels/CreateChannelModal.tsx
@@ -7,6 +7,7 @@
 import { Component, createSignal, Show, onMount, onCleanup } from "solid-js";
 import { X, Hash, Mic } from "lucide-solid";
 import { createChannel } from "@/stores/channels";
+import { getCategory } from "@/stores/categories";
 import { Portal } from "solid-js/web";
 import { showToast } from "@/components/ui/Toast";
 
@@ -28,12 +29,22 @@ const CreateChannelModal: Component<CreateChannelModalProps> = (props) => {
     onCleanup(() => document.removeEventListener("keydown", handleKeyDown));
   });
 
+  // If the category restricts channel type, lock the selector
+  const categoryTypeRestriction = () => {
+    if (!props.categoryId) return null;
+    const cat = getCategory(props.categoryId);
+    if (!cat || cat.category_type === "mixed") return null;
+    return cat.category_type as "text" | "voice";
+  };
+
   const [name, setName] = createSignal("");
   const [channelType, setChannelType] = createSignal<"text" | "voice">(
-    props.initialType || "text",
+    categoryTypeRestriction() ?? props.initialType ?? "text",
   );
   const [isCreating, setIsCreating] = createSignal(false);
   const [error, setError] = createSignal<string | null>(null);
+
+  const isTypeLocked = () => categoryTypeRestriction() !== null;
 
   const handleSubmit = async (e: Event) => {
     e.preventDefault();
@@ -105,13 +116,16 @@ const CreateChannelModal: Component<CreateChannelModalProps> = (props) => {
                 <div class="flex gap-3">
                   <button
                     type="button"
-                    onClick={() => setChannelType("text")}
+                    onClick={() => !isTypeLocked() && setChannelType("text")}
+                    disabled={isTypeLocked() && channelType() !== "text"}
                     class="flex-1 flex items-center gap-3 p-4 rounded-xl border-2 transition-all"
                     classList={{
                       "border-accent-primary bg-accent-primary/10":
                         channelType() === "text",
                       "border-white/10 hover:border-white/20":
-                        channelType() !== "text",
+                        channelType() !== "text" && !isTypeLocked(),
+                      "border-white/5 opacity-40 cursor-not-allowed":
+                        isTypeLocked() && channelType() !== "text",
                     }}
                   >
                     <div
@@ -129,13 +143,16 @@ const CreateChannelModal: Component<CreateChannelModalProps> = (props) => {
                   </button>
                   <button
                     type="button"
-                    onClick={() => setChannelType("voice")}
+                    onClick={() => !isTypeLocked() && setChannelType("voice")}
+                    disabled={isTypeLocked() && channelType() !== "voice"}
                     class="flex-1 flex items-center gap-3 p-4 rounded-xl border-2 transition-all"
                     classList={{
                       "border-accent-primary bg-accent-primary/10":
                         channelType() === "voice",
                       "border-white/10 hover:border-white/20":
-                        channelType() !== "voice",
+                        channelType() !== "voice" && !isTypeLocked(),
+                      "border-white/5 opacity-40 cursor-not-allowed":
+                        isTypeLocked() && channelType() !== "voice",
                     }}
                   >
                     <div

--- a/client/src/components/guilds/CategoriesTab.tsx
+++ b/client/src/components/guilds/CategoriesTab.tsx
@@ -8,7 +8,7 @@
  */
 
 import { Component, createSignal, For, Show, onMount } from "solid-js";
-import { Pencil, Trash2, Plus, Check, X, ChevronRight } from "lucide-solid";
+import { Pencil, Trash2, Plus, Check, X, ChevronRight, Hash, Volume2, Layers } from "lucide-solid";
 import {
   categoriesState,
   loadGuildCategories,
@@ -31,6 +31,7 @@ const CategoriesTab: Component<CategoriesTabProps> = (props) => {
   const [addingSubcategoryFor, setAddingSubcategoryFor] = createSignal<string | null>(null);
   const [subCategoryName, setSubCategoryName] = createSignal("");
   const [isCreating, setIsCreating] = createSignal(false);
+  const [newCategoryType, setNewCategoryType] = createSignal<"mixed" | "text" | "voice">("mixed");
 
   onMount(() => {
     loadGuildCategories(props.guildId);
@@ -38,12 +39,29 @@ const CategoriesTab: Component<CategoriesTabProps> = (props) => {
 
   const topLevel = () => getTopLevelCategories(props.guildId);
 
+  const typeIcon = (type: string) => {
+    switch (type) {
+      case "text": return <Hash class="w-3.5 h-3.5" />;
+      case "voice": return <Volume2 class="w-3.5 h-3.5" />;
+      default: return <Layers class="w-3.5 h-3.5" />;
+    }
+  };
+
+  const typeLabel = (type: string) => {
+    switch (type) {
+      case "text": return "Text only";
+      case "voice": return "Voice only";
+      default: return "Mixed";
+    }
+  };
+
   const handleCreate = async () => {
     const name = newCategoryName().trim();
     if (!name) return;
     setIsCreating(true);
-    await createCategory(props.guildId, name);
+    await createCategory(props.guildId, name, undefined, newCategoryType());
     setNewCategoryName("");
+    setNewCategoryType("mixed");
     setIsCreating(false);
   };
 
@@ -81,7 +99,7 @@ const CategoriesTab: Component<CategoriesTabProps> = (props) => {
     if (success) setDeletingId(null);
   };
 
-  const renderCategoryRow = (categoryId: string, name: string, isSubcat: boolean) => {
+  const renderCategoryRow = (categoryId: string, name: string, isSubcat: boolean, catType: string = "mixed") => {
     const isEditing = () => editingId() === categoryId;
     const isDeleting = () => deletingId() === categoryId;
 
@@ -127,6 +145,11 @@ const CategoriesTab: Component<CategoriesTabProps> = (props) => {
           }
         >
           <span class="flex-1 text-sm text-text-primary truncate">{name}</span>
+          <Show when={catType !== "mixed"}>
+            <span class="flex items-center gap-1 text-[11px] text-text-muted px-1.5 py-0.5 rounded bg-white/5 shrink-0">
+              {typeIcon(catType)} {typeLabel(catType)}
+            </span>
+          </Show>
           <Show when={!isDeleting()}>
             <div class="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
               <Show when={!isSubcat}>
@@ -191,7 +214,7 @@ const CategoriesTab: Component<CategoriesTabProps> = (props) => {
       </div>
 
       {/* Create new category */}
-      <div class="flex gap-2">
+      <div class="flex gap-2 items-center">
         <input
           type="text"
           placeholder="New category name"
@@ -201,10 +224,25 @@ const CategoriesTab: Component<CategoriesTabProps> = (props) => {
           class="flex-1 px-3 py-2 bg-surface-layer2 rounded-lg text-sm text-text-primary border border-white/10 outline-none focus:ring-1 focus:ring-accent-primary placeholder-text-secondary"
           disabled={isCreating()}
         />
+        <div class="flex rounded-lg border border-white/10 overflow-hidden shrink-0">
+          {(["mixed", "text", "voice"] as const).map((t) => (
+            <button
+              onClick={() => setNewCategoryType(t)}
+              class="px-2 py-2 text-xs transition-colors"
+              classList={{
+                "bg-accent-primary text-on-accent": newCategoryType() === t,
+                "bg-surface-layer2 text-text-secondary hover:text-text-primary": newCategoryType() !== t,
+              }}
+              title={typeLabel(t)}
+            >
+              {typeIcon(t)}
+            </button>
+          ))}
+        </div>
         <button
           onClick={handleCreate}
           disabled={!newCategoryName().trim() || isCreating()}
-          class="px-4 py-2 bg-accent-primary text-on-accent rounded-lg text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+          class="px-4 py-2 bg-accent-primary text-on-accent rounded-lg text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
         >
           Add
         </button>
@@ -229,11 +267,11 @@ const CategoriesTab: Component<CategoriesTabProps> = (props) => {
                 const subs = () => getSubcategories(props.guildId, category.id);
                 return (
                   <>
-                    {renderCategoryRow(category.id, category.name, false)}
+                    {renderCategoryRow(category.id, category.name, false, category.category_type)}
 
                     {/* Subcategories */}
                     <For each={subs()}>
-                      {(sub) => renderCategoryRow(sub.id, sub.name, true)}
+                      {(sub) => renderCategoryRow(sub.id, sub.name, true, sub.category_type)}
                     </For>
 
                     {/* Add subcategory inline form */}

--- a/client/src/lib/tauri.ts
+++ b/client/src/lib/tauri.ts
@@ -1849,10 +1849,11 @@ export async function createGuildCategory(
   guildId: string,
   name: string,
   parentId?: string,
+  categoryType?: string,
 ): Promise<ChannelCategory> {
   if (isTauri) {
     const { invoke } = await import("@tauri-apps/api/core");
-    return invoke("create_guild_category", { guildId, name, parentId });
+    return invoke("create_guild_category", { guildId, name, parentId, categoryType });
   }
 
   return httpRequest<ChannelCategory>(
@@ -1861,6 +1862,7 @@ export async function createGuildCategory(
     {
       name,
       parent_id: parentId,
+      category_type: categoryType ?? "mixed",
     },
   );
 }

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -219,12 +219,15 @@ export interface ChannelWithUnread extends Channel {
   unread_count: number;
 }
 
+export type CategoryType = "mixed" | "text" | "voice";
+
 export interface ChannelCategory {
   id: string;
   guild_id: string;
   name: string;
   position: number;
   parent_id: string | null;
+  category_type: CategoryType;
   collapsed: boolean;
   created_at: string;
 }

--- a/client/src/stores/__tests__/categories.test.ts
+++ b/client/src/stores/__tests__/categories.test.ts
@@ -45,6 +45,7 @@ function createCategory(
     name,
     position,
     parent_id: parentId,
+    category_type: "mixed" as const,
     collapsed,
     created_at: new Date().toISOString(),
   };

--- a/client/src/stores/categories.ts
+++ b/client/src/stores/categories.ts
@@ -345,9 +345,10 @@ export async function createCategory(
   guildId: string,
   name: string,
   parentId?: string,
+  categoryType?: string,
 ): Promise<ChannelCategory | null> {
   try {
-    const category = await tauri.createGuildCategory(guildId, name, parentId);
+    const category = await tauri.createGuildCategory(guildId, name, parentId, categoryType);
     // Add to local store
     const existing = categoriesState.categories[guildId] ?? [];
     setCategoriesState("categories", guildId, [...existing, category]);

--- a/server/migrations/20260321000000_category_type.sql
+++ b/server/migrations/20260321000000_category_type.sql
@@ -1,0 +1,7 @@
+-- Add category_type to channel_categories
+-- Allows restricting a category to text-only or voice-only channels
+
+CREATE TYPE category_type AS ENUM ('mixed', 'text', 'voice');
+
+ALTER TABLE channel_categories
+    ADD COLUMN category_type category_type NOT NULL DEFAULT 'mixed';

--- a/server/src/chat/channels.rs
+++ b/server/src/chat/channels.rs
@@ -216,6 +216,31 @@ pub async fn create(
             )));
         }
 
+        // Validate channel type against category type restriction
+        if let Some(cat_id) = body.category_id {
+            let cat_type: Option<(String,)> = sqlx::query_as(
+                "SELECT category_type::TEXT FROM channel_categories WHERE id = $1",
+            )
+            .bind(cat_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+
+            if let Some((cat_type,)) = cat_type {
+                let channel_type_str = match &channel_type {
+                    db::ChannelType::Text => "text",
+                    db::ChannelType::Voice => "voice",
+                    db::ChannelType::Dm => "dm",
+                };
+                if (cat_type == "text" && channel_type_str != "text")
+                    || (cat_type == "voice" && channel_type_str != "voice")
+                {
+                    return Err(ChannelError::Validation(format!(
+                        "This category only allows {cat_type} channels"
+                    )));
+                }
+            }
+        }
+
         let position: i32 = sqlx::query_scalar(
             "SELECT COALESCE(MAX(position), 0) + 1 FROM channels WHERE category_id IS NOT DISTINCT FROM $1",
         )

--- a/server/src/guild/categories.rs
+++ b/server/src/guild/categories.rs
@@ -19,6 +19,16 @@ use crate::permissions::{require_guild_permission, GuildPermissions, PermissionE
 // Types
 // ============================================================================
 
+/// Category type restriction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type, utoipa::ToSchema)]
+#[sqlx(type_name = "category_type", rename_all = "lowercase")]
+#[serde(rename_all = "lowercase")]
+pub enum CategoryType {
+    Mixed,
+    Text,
+    Voice,
+}
+
 /// Category response model.
 #[derive(Debug, Serialize, FromRow, utoipa::ToSchema)]
 pub struct Category {
@@ -27,6 +37,7 @@ pub struct Category {
     pub name: String,
     pub position: i32,
     pub parent_id: Option<Uuid>,
+    pub category_type: CategoryType,
     pub created_at: chrono::DateTime<chrono::Utc>,
 }
 
@@ -36,6 +47,12 @@ pub struct CreateCategoryRequest {
     pub name: String,
     #[serde(default)]
     pub parent_id: Option<Uuid>,
+    #[serde(default = "default_category_type")]
+    pub category_type: CategoryType,
+}
+
+const fn default_category_type() -> CategoryType {
+    CategoryType::Mixed
 }
 
 /// Request to update a category.
@@ -45,6 +62,7 @@ pub struct UpdateCategoryRequest {
     pub position: Option<i32>,
     /// None = don't change, Some(None) = clear parent, Some(Some(id)) = set parent
     pub parent_id: Option<Option<Uuid>>,
+    pub category_type: Option<CategoryType>,
 }
 
 /// Request to reorder multiple categories.
@@ -156,7 +174,7 @@ pub async fn list_categories(
 
     let categories = sqlx::query_as::<_, Category>(
         r"
-        SELECT id, guild_id, name, position, parent_id, created_at
+        SELECT id, guild_id, name, position, parent_id, category_type, created_at
         FROM channel_categories
         WHERE guild_id = $1
         ORDER BY position
@@ -237,19 +255,20 @@ pub async fn create_category(
     let category_id = Uuid::now_v7();
     let category = sqlx::query_as::<_, Category>(
         r"
-        INSERT INTO channel_categories (id, guild_id, name, parent_id, position)
-        VALUES ($1, $2, $3, $4, (
+        INSERT INTO channel_categories (id, guild_id, name, parent_id, category_type, position)
+        VALUES ($1, $2, $3, $4, $5, (
             SELECT COALESCE(MAX(position) + 1, 0)
             FROM channel_categories
             WHERE guild_id = $2 AND parent_id IS NOT DISTINCT FROM $4
         ))
-        RETURNING id, guild_id, name, position, parent_id, created_at
+        RETURNING id, guild_id, name, position, parent_id, category_type, created_at
         ",
     )
     .bind(category_id)
     .bind(guild_id)
     .bind(&body.name)
     .bind(body.parent_id)
+    .bind(body.category_type)
     .fetch_one(&state.db)
     .await?;
 
@@ -341,6 +360,30 @@ pub async fn update_category(
         }
     }
 
+    // If changing category_type, validate no conflicting channels exist
+    if let Some(new_type) = &body.category_type {
+        if *new_type != CategoryType::Mixed {
+            let conflicting_type = match new_type {
+                CategoryType::Text => "voice",
+                CategoryType::Voice => "text",
+                CategoryType::Mixed => unreachable!(),
+            };
+            let has_conflicts = sqlx::query_scalar::<_, bool>(
+                "SELECT EXISTS(SELECT 1 FROM channels WHERE category_id = $1 AND channel_type::TEXT = $2)",
+            )
+            .bind(category_id)
+            .bind(conflicting_type)
+            .fetch_one(&state.db)
+            .await?;
+
+            if has_conflicts {
+                return Err(CategoryError::Validation(format!(
+                    "Cannot change to {new_type:?} — category contains {conflicting_type} channels"
+                )));
+            }
+        }
+    }
+
     // Build and execute update query
     let category = sqlx::query_as::<_, Category>(
         r"
@@ -348,17 +391,19 @@ pub async fn update_category(
         SET
             name = COALESCE($3, name),
             position = COALESCE($4, position),
-            parent_id = CASE WHEN $5 THEN $6 ELSE parent_id END
+            parent_id = CASE WHEN $5 THEN $6 ELSE parent_id END,
+            category_type = COALESCE($7, category_type)
         WHERE id = $1 AND guild_id = $2
-        RETURNING id, guild_id, name, position, parent_id, created_at
+        RETURNING id, guild_id, name, position, parent_id, category_type, created_at
         ",
     )
     .bind(category_id)
     .bind(guild_id)
     .bind(&body.name)
     .bind(body.position)
-    .bind(body.parent_id.is_some()) // whether to update parent_id
-    .bind(body.parent_id.flatten()) // the new parent_id value
+    .bind(body.parent_id.is_some())
+    .bind(body.parent_id.flatten())
+    .bind(body.category_type)
     .fetch_optional(&state.db)
     .await?
     .ok_or(CategoryError::NotFound)?;

--- a/server/src/guild/handlers.rs
+++ b/server/src/guild/handlers.rs
@@ -807,6 +807,35 @@ pub async fn reorder_channels(
     let mut tx = state.db.begin().await?;
 
     for ch in &body.channels {
+        // Validate category type restriction when moving to a new category
+        if let Some(cat_id) = ch.category_id {
+            let cat_type: Option<(String,)> = sqlx::query_as(
+                "SELECT category_type::TEXT FROM channel_categories WHERE id = $1",
+            )
+            .bind(cat_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+
+            if let Some((cat_type,)) = cat_type {
+                if cat_type != "mixed" {
+                    let ch_type: Option<(String,)> = sqlx::query_as(
+                        "SELECT channel_type::TEXT FROM channels WHERE id = $1",
+                    )
+                    .bind(ch.id)
+                    .fetch_optional(&mut *tx)
+                    .await?;
+
+                    if let Some((ch_type,)) = ch_type {
+                        if cat_type != ch_type {
+                            return Err(GuildError::Validation(format!(
+                                "Cannot move {ch_type} channel to {cat_type}-only category"
+                            )));
+                        }
+                    }
+                }
+            }
+        }
+
         sqlx::query(
             r"
             UPDATE channels


### PR DESCRIPTION
## Summary
- New `category_type` column on `channel_categories` (enum: mixed/text/voice)
- Server validates channel type on create and reorder
- Client: type selector in CategoriesTab, type icons in sidebar, locked type in CreateChannelModal
- Warning toast when dragging wrong channel type into restricted category

## Test plan
- [ ] Create a text-only category — only text channels can be created/moved into it
- [ ] Create a voice-only category — only voice channels allowed
- [ ] Drag wrong channel type → yellow warning toast
- [ ] Existing categories default to mixed (backward compatible)


🤖 Generated with [Claude Code](https://claude.com/claude-code)