### PR TITLE
fix(client): set data-index before measureElement in all virtualizer consumers

### DIFF
--- a/client/src/components/guilds/MembersTab.tsx
+++ b/client/src/components/guilds/MembersTab.tsx
@@ -177,7 +177,10 @@ const MembersTab: Component<MembersTabProps> = (props) => {
                 return (
                   <div
                     data-index={virtualItem.index}
-                    ref={(el) => virtualizer.measureElement(el)}
+                    ref={(el) => {
+                      el.setAttribute("data-index", String(virtualItem.index));
+                      queueMicrotask(() => virtualizer.measureElement(el));
+                    }}
                     style={{
                       position: "absolute",
                       top: `${virtualItem.start}px`,

--- a/client/src/components/search/SearchPanel.tsx
+++ b/client/src/components/search/SearchPanel.tsx
@@ -462,7 +462,10 @@ const SearchPanel: Component<SearchPanelProps> = (props) => {
                 return (
                   <div
                     data-index={virtualItem.index}
-                    ref={(el) => virtualizer.measureElement(el)}
+                    ref={(el) => {
+                      el.setAttribute("data-index", String(virtualItem.index));
+                      queueMicrotask(() => virtualizer.measureElement(el));
+                    }}
                     style={{
                       position: "absolute",
                       top: `${virtualItem.start}px`,


### PR DESCRIPTION
Fixes 'Missing attribute name data-index' warning in MembersTab and SearchPanel.