### PR TITLE
fix(client): guild settings icon and contrast rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,14 @@ cargo deny check licenses
 - Client CPU (Idle): <1%
 - Startup: <3s
 
+### UI Contrast Rules (KRITISCH)
+- **Text on backgrounds**: Use `text-text-primary` (not accent colors) for any text that must be readable. Accent colors are for decorative indicators only.
+- **Selected/active states**: Use `text-text-primary` + `bg-accent-primary/20` (or higher opacity). Never use `text-accent-primary` on `bg-accent-primary/*` — same hue, poor contrast.
+- **Interactive text opacity**: Never use `opacity-*` below 50% on text the user needs to read. `text-text-secondary` is the minimum readable tier.
+- **White-on-dark overlays**: `text-white/40` and below are invisible on dark themes. Use `text-text-muted` instead.
+- **WCAG targets**: text-primary ≥7:1 on surface-base (AAA), text-secondary ≥4.5:1 on surface-layer1 (AA), text-muted ≥3:1 (AA for UI components).
+- **Verify**: When adding colored text on colored backgrounds, check with https://webaim.org/resources/contrastchecker/
+
 ### Security-Basics
 - TLS 1.3 für alle Verbindungen
 - Passwörter: Argon2id

--- a/client/src/components/guilds/GuildSettingsModal.tsx
+++ b/client/src/components/guilds/GuildSettingsModal.tsx
@@ -116,7 +116,7 @@ const GuildSettingsModal: Component<GuildSettingsModalProps> = (props) => {
       data-testid={testId}
       class="flex items-center gap-2.5 w-full px-3 py-2 rounded-lg text-sm font-medium transition-colors"
       classList={{
-        "bg-accent-primary/15 text-accent-primary": activeTab() === tab,
+        "bg-accent-primary/20 text-text-primary font-semibold": activeTab() === tab,
         "text-text-secondary hover:text-text-primary hover:bg-white/5": activeTab() !== tab,
       }}
     >
@@ -152,11 +152,22 @@ const GuildSettingsModal: Component<GuildSettingsModalProps> = (props) => {
           {/* Header */}
           <div class="flex items-center justify-between px-6 py-4 border-b border-white/10">
             <div class="flex items-center gap-3">
-              <div class="w-10 h-10 rounded-xl bg-accent-primary/20 flex items-center justify-center">
-                <span class="text-lg font-bold text-accent-primary">
-                  {guild()?.name.charAt(0).toUpperCase()}
-                </span>
-              </div>
+              <Show
+                when={guild()?.icon_url}
+                fallback={
+                  <div class="w-10 h-10 rounded-xl bg-accent-primary/20 flex items-center justify-center">
+                    <span class="text-lg font-bold text-accent-primary">
+                      {guild()?.name.charAt(0).toUpperCase()}
+                    </span>
+                  </div>
+                }
+              >
+                <img
+                  src={guild()!.icon_url!}
+                  alt={guild()?.name}
+                  class="w-10 h-10 rounded-xl object-cover"
+                />
+              </Show>
               <div>
                 <h2 class="text-lg font-bold text-text-primary">
                   {guild()?.name}


### PR DESCRIPTION
## Summary
- Guild settings header now shows guild icon (was always letter avatar)
- Active sidebar tab uses text-text-primary for proper contrast
- Added UI Contrast Rules to CLAUDE.md for all future development

## Test plan
- [ ] Guild icon visible in settings header
- [ ] Active sidebar tab text is readable
- [ ] CLAUDE.md contrast rules present


🤖 Generated with [Claude Code](https://claude.com/claude-code)