### PR TITLE
fix(client): register local screen share track for self-viewing

### DIFF
--- a/client/src/lib/webrtc/browser.ts
+++ b/client/src/lib/webrtc/browser.ts
@@ -725,6 +725,14 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
   }
 
   /**
+   * Get the video track for a local screen share.
+   */
+  getScreenShareTrack(streamId: string): MediaStreamTrack | null {
+    const entry = this.screenShares.get(streamId);
+    return entry?.stream.getVideoTracks()[0] ?? null;
+  }
+
+  /**
    * Get info for all active screen shares.
    */
   getAllScreenShareInfo(): { streamId: string; hasAudio: boolean; sourceLabel: string }[] {

--- a/client/src/lib/webrtc/tauri.ts
+++ b/client/src/lib/webrtc/tauri.ts
@@ -318,6 +318,14 @@ export class TauriVoiceAdapter implements VoiceAdapter {
   }
 
   /**
+   * Get the video track for a local screen share.
+   * Tauri uses native capture — no MediaStreamTrack available.
+   */
+  getScreenShareTrack(_streamId: string): MediaStreamTrack | null {
+    return null;
+  }
+
+  /**
    * Enumerate native capture sources (monitors and windows).
    */
   async enumerateCaptureSources(): Promise<CaptureSource[] | null> {

--- a/client/src/lib/webrtc/types.ts
+++ b/client/src/lib/webrtc/types.ts
@@ -241,6 +241,8 @@ export interface VoiceAdapter {
   getScreenShareInfo(streamId?: string): { streamId: string; hasAudio: boolean; sourceLabel: string } | null;
   /** Get info for all active screen shares. */
   getAllScreenShareInfo(): { streamId: string; hasAudio: boolean; sourceLabel: string }[];
+  /** Get the video track for a local screen share. */
+  getScreenShareTrack(streamId: string): MediaStreamTrack | null;
   /** Enumerate native capture sources (Tauri only). Returns null if not supported. */
   enumerateCaptureSources?(): Promise<CaptureSource[] | null>;
 

--- a/client/src/stores/voice.ts
+++ b/client/src/stores/voice.ts
@@ -739,6 +739,16 @@ export async function startScreenShare(
   }
 
   setVoiceState({ screenSharing: true });
+
+  // Register local screen share track so the user can view their own share
+  const videoTrack = adapter.getScreenShareTrack(streamId);
+  if (videoTrack) {
+    const { currentUser } = await import("@/stores/auth");
+    const user = currentUser();
+    const { addAvailableTrack } = await import("@/stores/screenShareViewer");
+    addAvailableTrack(streamId, videoTrack, user?.id || "", user?.username || "You", sourceLabel);
+  }
+
   return { ok: true };
 }
 


### PR DESCRIPTION
Local screen share tracks now registered in viewer store for self-viewing.