### PR TITLE
fix(ws): VoiceStats → voice_stats message type case mismatch

### DIFF
--- a/client/src/stores/voice.ts
+++ b/client/src/stores/voice.ts
@@ -250,7 +250,7 @@ function startMetricsLoop(): void {
         const sessionId = voiceState.sessionId;
         if (sessionId && voiceState.channelId) {
           tauri.wsSend({
-            type: "VoiceStats",
+            type: "voice_stats",
             channel_id: voiceState.channelId,
             session_id: sessionId,
             latency: metrics.latency,


### PR DESCRIPTION
Pre-existing bug: client sent PascalCase, server expects snake_case. Flooded server logs every 3s.