### PR TITLE
fix(voice): clean up stale sessions before joining

### DIFF
--- a/client/src/stores/voice.ts
+++ b/client/src/stores/voice.ts
@@ -406,9 +406,17 @@ export async function joinVoice(channelId: string): Promise<void> {
   isJoining = true;
 
   try {
-    // Leave current channel if connected
+    // Leave current channel if connected (client-side)
     if (voiceState.state !== "disconnected") {
       await leaveVoice();
+    }
+
+    // Always send voice_leave first to clean up any stale server session
+    // (e.g., from a previous browser tab that didn't disconnect properly)
+    try {
+      await tauri.wsSend({ type: "voice_leave", channel_id: channelId });
+    } catch {
+      // Ignore — the user might not have been in a channel
     }
 
     setVoiceState({ state: "connecting", channelId, error: null });

--- a/client/src/stores/websocket.ts
+++ b/client/src/stores/websocket.ts
@@ -1702,7 +1702,11 @@ async function handleVoiceOffer(channelId: string, sdp: string): Promise<void> {
       });
       console.log("[WebSocket] Voice answer sent successfully");
     } else {
-      console.error("Failed to handle voice offer:", result.error);
+      console.error("Failed to handle voice offer:", JSON.stringify(result.error));
+      // If connection failed and retriable, the adapter will handle reconnection
+      if ((result.error as any)?.retriable) {
+        console.log("[WebSocket] Voice offer failed but retriable — will retry on next offer");
+      }
     }
   } catch (err) {
     console.error("Error handling voice offer:", err);


### PR DESCRIPTION
Send voice_leave before voice_join to clear stale server sessions. Fixes 'Already in voice channel' error.