### PR TITLE
fix(voice): replace stale voice peers instead of rejecting

### DIFF
--- a/client/src/stores/voice.ts
+++ b/client/src/stores/voice.ts
@@ -411,14 +411,6 @@ export async function joinVoice(channelId: string): Promise<void> {
       await leaveVoice();
     }
 
-    // Always send voice_leave first to clean up any stale server session
-    // (e.g., from a previous browser tab that didn't disconnect properly)
-    try {
-      await tauri.wsSend({ type: "voice_leave", channel_id: channelId });
-    } catch {
-      // Ignore — the user might not have been in a channel
-    }
-
     setVoiceState({ state: "connecting", channelId, error: null });
 
     const adapter = await createVoiceAdapter();

--- a/server/src/voice/sfu.rs
+++ b/server/src/voice/sfu.rs
@@ -98,8 +98,14 @@ impl Room {
             });
         }
 
-        if peers.contains_key(&peer.user_id) {
-            return Err(VoiceError::AlreadyJoined);
+        // If the user already has a peer (stale session from a previous connection),
+        // remove it and replace with the new one instead of rejecting
+        if let Some(old_peer) = peers.remove(&peer.user_id) {
+            tracing::info!(user_id = %peer.user_id, "Replacing stale voice peer");
+            // Close old peer connection
+            if let Err(e) = old_peer.peer_connection.close().await {
+                tracing::warn!(user_id = %peer.user_id, error = %e, "Failed to close stale peer connection");
+            }
         }
 
         peers.insert(peer.user_id, peer);


### PR DESCRIPTION
Server replaces stale peers on re-join instead of rejecting with AlreadyJoined.