### PR TITLE
fix(voice): add screen share track immediately

### DIFF
--- a/client/src/lib/webrtc/browser.ts
+++ b/client/src/lib/webrtc/browser.ts
@@ -359,33 +359,7 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
         sdp,
       });
 
-      // Add pending screen share tracks AFTER setRemoteDescription (so the
-      // server's recv transceiver exists) and BEFORE createAnswer (so the
-      // answer includes the track). addTrack() auto-matches to the right
-      // transceiver because the browser just created it from the offer.
-      if (this.pendingScreenShares.size > 0) {
-        for (const [streamId, pending] of this.pendingScreenShares) {
-          const videoTrack = pending.stream.getVideoTracks()[0];
-          if (!videoTrack) continue;
-
-          const videoSender = this.peerConnection.addTrack(videoTrack, pending.stream);
-          const audioTrack = pending.stream.getAudioTracks()[0];
-          let audioSender: RTCRtpSender | null = null;
-          if (audioTrack) {
-            audioSender = this.peerConnection.addTrack(audioTrack, pending.stream);
-          }
-
-          this.screenShares.set(streamId, {
-            stream: pending.stream,
-            videoSender,
-            audioSender,
-          });
-          console.warn("[BrowserVoiceAdapter] Pending screen share added to peer connection:", streamId);
-        }
-        this.pendingScreenShares.clear();
-      }
-
-      // Create answer — includes the newly added tracks
+      // Create answer — tracks already added via addTrack are included
       const answer = await this.peerConnection.createAnswer();
       await this.peerConnection.setLocalDescription(answer);
 
@@ -811,12 +785,19 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
         this.handleScreenShareEnded(streamId);
       };
 
-      // Store as pending — track will be added in handleOffer() AFTER
-      // setRemoteDescription but BEFORE createAnswer. This is critical:
-      // addTrack() must happen after the server's offer creates the recv
-      // transceiver, so the browser can match them correctly.
-      this.pendingScreenShares.set(streamId, { stream, quality: options?.quality ?? "medium" });
-      console.warn("[BrowserVoiceAdapter] Screen share captured (pending)", streamId);
+      // Add track immediately. The server will then add a recv transceiver
+      // and renegotiate. The browser matches the existing local track to the
+      // server's transceiver during the offer/answer exchange.
+      const videoSender = this.peerConnection.addTrack(videoTrack, stream);
+
+      const audioTrack = stream.getAudioTracks()[0];
+      let audioSender: RTCRtpSender | null = null;
+      if (audioTrack) {
+        audioSender = this.peerConnection.addTrack(audioTrack, stream);
+      }
+
+      this.screenShares.set(streamId, { stream, videoSender, audioSender });
+      console.warn("[BrowserVoiceAdapter] Screen share track added", streamId);
 
       return { ok: true, value: undefined };
     } catch (err) {


### PR DESCRIPTION
Deferred addTrack sent only 1 RTP packet. Immediate addTrack sends continuously.