### PR TITLE
fix(voice): memory leak, PLI lifecycle, stream_id validation

### DIFF
--- a/client/src/components/voice/VoiceTileGrid.tsx
+++ b/client/src/components/voice/VoiceTileGrid.tsx
@@ -276,45 +276,38 @@ const VoiceTileGrid: Component<VoiceTileGridProps> = (props) => {
           {/* Focused tile */}
           <div class="flex-1 min-h-0 min-w-0">
             <Show when={focusedTile()}>
-              {(tile) => (
-                <VoiceTile
-                  tile={tile()}
-                  onClick={() => handleTileClick(getTileId(tile()))}
-                  size="normal"
-                  poppedOut={
-                    tile().type === "screen_share"
-                      ? poppedOutStreams().has(
-                          (tile() as Extract<TileData, { type: "screen_share" }>).streamId,
-                        )
-                      : undefined
-                  }
-                  onPopOut={
-                    tile().type === "screen_share"
-                      ? () =>
-                          handlePopOut(
-                            (tile() as Extract<TileData, { type: "screen_share" }>).streamId,
-                          )
-                      : undefined
-                  }
-                  onBringBack={
-                    tile().type === "screen_share"
-                      ? () =>
-                          handleBringBack(
-                            (tile() as Extract<TileData, { type: "screen_share" }>).streamId,
-                          )
-                      : undefined
-                  }
-                  onStopShare={
-                    tile().type === "screen_share" &&
-                    (tile() as Extract<TileData, { type: "screen_share" }>).userId === authState.user?.id
-                      ? () =>
-                          stopScreenShare(
-                            (tile() as Extract<TileData, { type: "screen_share" }>).streamId,
-                          )
-                      : undefined
-                  }
-                />
-              )}
+              {(tile) => {
+                const screenTile = () =>
+                  tile() as Extract<TileData, { type: "screen_share" }>;
+                return (
+                  <VoiceTile
+                    tile={tile()}
+                    onClick={() => handleTileClick(getTileId(tile()))}
+                    size="normal"
+                    poppedOut={
+                      tile().type === "screen_share"
+                        ? poppedOutStreams().has(screenTile().streamId)
+                        : undefined
+                    }
+                    onPopOut={
+                      tile().type === "screen_share"
+                        ? () => handlePopOut(screenTile().streamId)
+                        : undefined
+                    }
+                    onBringBack={
+                      tile().type === "screen_share"
+                        ? () => handleBringBack(screenTile().streamId)
+                        : undefined
+                    }
+                    onStopShare={
+                      tile().type === "screen_share" &&
+                      screenTile().userId === authState.user?.id
+                        ? () => stopScreenShare(screenTile().streamId)
+                        : undefined
+                    }
+                  />
+                );
+              }}
             </Show>
           </div>
 

--- a/client/src/components/voice/screenSharePopOut.ts
+++ b/client/src/components/voice/screenSharePopOut.ts
@@ -63,8 +63,9 @@ export function popOut(
     });
   };
 
-  // Use requestAnimationFrame to ensure the window's document is ready
-  win.requestAnimationFrame(buildPage);
+  // Use setTimeout to ensure the window's document is ready.
+  // Unlike requestAnimationFrame, setTimeout fires even when the window is backgrounded.
+  setTimeout(buildPage, 0);
 }
 
 /** Bring a popped-out stream back to inline. */

--- a/server/src/voice/sfu.rs
+++ b/server/src/voice/sfu.rs
@@ -605,19 +605,21 @@ impl SfuServer {
                     // by default, and PeerConnection::write_rtcp() doesn't reliably
                     // deliver PLI to the remote browser.
                     if source_type.is_video() && layer == Layer::High {
-                        let publisher_pc = peer.publisher_pc.clone();
+                        let publisher_pc_weak = Arc::downgrade(&peer.publisher_pc);
                         let track_ssrc = track.ssrc();
                         tokio::spawn(async move {
                             use webrtc::rtcp::payload_feedbacks::picture_loss_indication::PictureLossIndication;
                             let mut interval = tokio::time::interval(std::time::Duration::from_secs(3));
                             loop {
                                 interval.tick().await;
+                                let Some(publisher_pc) = publisher_pc_weak.upgrade() else {
+                                    break; // PC dropped — stop PLI
+                                };
                                 let pli = PictureLossIndication {
                                     sender_ssrc: 0,
                                     media_ssrc: track_ssrc,
                                 };
                                 if publisher_pc.write_rtcp(&[Box::new(pli)]).await.is_err() {
-                                    // PC closed — stop the interval
                                     break;
                                 }
                             }

--- a/server/src/voice/track.rs
+++ b/server/src/voice/track.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, Instant};
 
 use dashmap::DashMap;
 use tokio::sync::mpsc;
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 use uuid::Uuid;
 use webrtc::rtp::packet::Packet as RtpPacket;
 use webrtc::rtp_transceiver::rtp_codec::RTCRtpCodecCapability;
@@ -196,11 +196,13 @@ impl TrackRouter {
                 .simulcast_tracks
                 .contains_key(&(source_user_id, source_type, Layer::Medium));
 
-        // DashMap::get returns a guard that provides lock-free concurrent read access
-        if let Some(subscribers) = self.subscriptions.get(&key) {
-            crate::observability::metrics::record_rtp_packet_forwarded();
+        // DashMap::get returns a guard that provides lock-free concurrent read access.
+        // Record the metric outside the guard scope to avoid holding it during I/O.
+        let forwarded = if let Some(subscribers) = self.subscriptions.get(&key) {
+            let mut count = 0u32;
             for sub in subscribers.value() {
                 if sub.active_layer == layer || !is_simulcast {
+                    count += 1;
                     // Write RTP packet to local track (forwards to subscriber)
                     if let Err(e) = sub.local_track.write_rtp(rtp_packet).await {
                         warn!(
@@ -211,6 +213,12 @@ impl TrackRouter {
                     }
                 }
             }
+            count
+        } else {
+            0
+        };
+        if forwarded > 0 {
+            crate::observability::metrics::record_rtp_packet_forwarded();
         }
     }
 
@@ -254,12 +262,23 @@ impl TrackRouter {
         self.subscriptions
             .retain(|(uid, _), _| *uid != source_user_id);
 
+        // Clean up simulcast tracks for this source
+        self.simulcast_tracks
+            .retain(|(uid, _, _), _| *uid != source_user_id);
+        // Clean up pending secondary layers for this source
+        self.pending_secondary
+            .retain(|(uid, _), _| *uid != source_user_id);
+
         debug!(source = %source_user_id, "Removed source and all subscriptions");
     }
 
     /// Remove all subscriptions for a specific source track (e.g. when a user stops webcam).
     pub async fn remove_source_track(&self, source_user_id: Uuid, source_type: TrackSource) {
         self.subscriptions.remove(&(source_user_id, source_type));
+
+        // Clean up simulcast layers for this specific track
+        self.simulcast_tracks
+            .retain(|(uid, st, _), _| !(*uid == source_user_id && *st == source_type));
 
         debug!(
             source = %source_user_id,
@@ -443,7 +462,7 @@ pub fn spawn_rtp_forwarder(
                     packet_count += 1;
                     if packet_count == 1 || packet_count.is_multiple_of(500) {
                         let sub_count = router.subscription_count(source_user_id, source_type);
-                        info!(
+                        debug!(
                             source = %source_user_id,
                             source_type = ?source_type,
                             layer = ?layer,
@@ -470,13 +489,11 @@ pub fn spawn_rtp_forwarder(
             }
         }
 
-        // Clean up this specific track when it ends
-        // We can't use remove_source because that removes ALL tracks for the user
-        // We need a way to remove just this track from subscriptions?
-        // Actually, remove_source is fine if the user disconnects, but if they just stop screen
-        // sharing? We should probably just let the subscriptions stick around or clean them
-        // up specifically. For now, let's just log. The Peer cleanup handles the main
-        // removal.
+        // The forwarder stops naturally when track.read() returns an error
+        // (publisher removed the track or PC closed). Between the stop signal
+        // and the read failure, some packets may be forwarded to removed
+        // subscriber tracks — this causes harmless write errors that are
+        // silently ignored by webrtc-rs.
         debug!(
              source = %source_user_id,
              source_type = ?source_type,

--- a/server/src/voice/ws_handler.rs
+++ b/server/src/voice/ws_handler.rs
@@ -779,6 +779,13 @@ async fn handle_screen_share_start(
     // Use the stream_id provided by the client.
     let stream_id = params.stream_id;
 
+    // Reject duplicate stream_id
+    if room.screen_shares.read().await.contains_key(&stream_id) {
+        return Err(VoiceError::Signaling(format!(
+            "Screen share stream already exists: {stream_id}"
+        )));
+    }
+
     // Queue pending track sources so setup_track_handler can identify them
     peer.push_pending_source(TrackSource::ScreenVideo(stream_id))
         .await;


### PR DESCRIPTION
## Summary

Fixes 8 findings from screen sharing implementation review:

- **Critical:** Clean up `simulcast_tracks` and `pending_secondary` DashMaps on peer disconnect (memory leak)
- PLI interval task uses `Weak<PC>` instead of strong `Arc` to avoid preventing PeerConnection cleanup
- Reject duplicate `stream_id` in `handle_screen_share_start` to prevent metadata hijacking
- Move `record_rtp_packet_forwarded()` outside DashMap guard scope (performance)
- Downgrade RTP forwarder periodic log from `info!` to `debug!` (reduce log noise)
- Pop-out window uses `setTimeout` instead of `requestAnimationFrame` (reliability)
- Fix stale TODO comment in RTP forwarder
- Extract repeated type cast in VoiceTileGrid focus mode

## Test plan

- [x] Server clippy clean
- [x] 548/548 client tests pass
- [ ] Manual: screen share still works after fixes
- [ ] Manual: join/leave voice channel repeatedly — verify no memory growth in server

Generated with [Claude Code](https://claude.com/claude-code)