### PR TITLE
fix(client): hardcode kaiku.pmind.de as server URL for beta

### DIFF
--- a/client/.env.production
+++ b/client/.env.production
@@ -1,3 +1,2 @@
-# Production server URL
-# This will be set by docker-compose or deployment environment
-VITE_SERVER_URL=
+# Production server URL — hardcoded for beta
+VITE_SERVER_URL=https://kaiku.pmind.de

--- a/client/src/views/ForgotPassword.tsx
+++ b/client/src/views/ForgotPassword.tsx
@@ -7,11 +7,7 @@ const ForgotPassword: Component = () => {
   onCleanup(() => { document.title = "Kaiku"; });
   const isTauri = typeof window !== "undefined" && "__TAURI__" in window;
   const defaultServerUrl = import.meta.env.VITE_SERVER_URL || window.location.origin;
-  const storedUrl =
-    typeof localStorage !== "undefined"
-      ? localStorage.getItem("serverUrl") || ""
-      : "";
-  const [serverUrl, setServerUrl] = createSignal(isTauri ? (storedUrl || defaultServerUrl) : defaultServerUrl);
+  const [serverUrl] = createSignal(defaultServerUrl);
   const [email, setEmail] = createSignal("");
   const [error, setError] = createSignal("");
   const [success, setSuccess] = createSignal(false);
@@ -22,10 +18,6 @@ const ForgotPassword: Component = () => {
     setError("");
     setSuccess(false);
 
-    if (!serverUrl().trim()) {
-      setError("Server URL is required");
-      return;
-    }
     if (!email().trim() || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email())) {
       setError("Please enter a valid email address");
       return;
@@ -75,28 +67,7 @@ const ForgotPassword: Component = () => {
 
         <Show when={!success()}>
           <form onSubmit={handleSubmit} method="post" noValidate class="space-y-4">
-            <Show when={isTauri}>
-              <div>
-                <label
-                  for="fp-server-url"
-                  class="block text-sm font-medium text-text-secondary mb-1"
-                >
-                  Server URL
-                </label>
-                <input
-                  id="fp-server-url"
-                  type="url"
-                  class="input-field"
-                  name="url"
-                  autocomplete="url"
-                  placeholder="https://chat.example.com"
-                  value={serverUrl()}
-                  onInput={(e) => setServerUrl(e.currentTarget.value)}
-                  disabled={isLoading()}
-                  required
-                />
-              </div>
-            </Show>
+            {/* Server URL input hidden during beta — hardcoded to kaiku.pmind.de */}
 
             <div>
               <label

--- a/client/src/views/Login.tsx
+++ b/client/src/views/Login.tsx
@@ -31,18 +31,16 @@ const Login: Component = () => {
   onCleanup(() => { document.title = "Kaiku"; });
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const isTauri = typeof window !== "undefined" && "__TAURI__" in window;
   const defaultServerUrl = import.meta.env.VITE_SERVER_URL || window.location.origin;
-  const [serverUrl, setServerUrl] = createSignal(defaultServerUrl);
+  const [serverUrl] = createSignal(defaultServerUrl);
   const [username, setUsername] = createSignal("");
   const [password, setPassword] = createSignal("");
   const [mfaCode, setMfaCode] = createSignal("");
   const [localError, setLocalError] = createSignal("");
   const [oidcLoading, setOidcLoading] = createSignal<string | null>(null);
 
-  // Fetch server settings when server URL is entered (debounced)
-  const [settingsUrl, setSettingsUrl] = createSignal(defaultServerUrl);
-  const [settings] = createResource(settingsUrl, async (url) => {
+  // Fetch server settings from hardcoded beta URL
+  const [settings] = createResource(() => defaultServerUrl, async (url) => {
     if (!url.trim()) return null;
     try {
       return await fetchServerSettings(url);
@@ -52,23 +50,11 @@ const Login: Component = () => {
     }
   });
 
-  // Debounce server URL changes for settings fetch
-  let urlTimer: ReturnType<typeof setTimeout> | undefined;
-  const handleServerUrlChange = (value: string) => {
-    setServerUrl(value);
-    clearTimeout(urlTimer);
-    urlTimer = setTimeout(() => setSettingsUrl(value), 500);
-  };
-
   const handleLogin = async (e: Event) => {
     e.preventDefault();
     setLocalError("");
     clearError();
 
-    if (isTauri && !serverUrl().trim()) {
-      setLocalError("Server URL is required");
-      return;
-    }
     if (!username().trim()) {
       setLocalError("Username is required");
       return;
@@ -216,27 +202,7 @@ const Login: Component = () => {
           Login to continue to Kaiku
         </p>
 
-        <Show when={isTauri}>
-          <div class="mb-4">
-            <label for="login-server-url" class="block text-sm font-medium text-text-secondary mb-1">
-              Server URL
-            </label>
-            <input
-              id="login-server-url"
-              type="url"
-              class="input-field"
-              name="url"
-              autocomplete="url"
-              placeholder="https://chat.example.com"
-              value={serverUrl()}
-              onInput={(e) => handleServerUrlChange(e.currentTarget.value)}
-              disabled={
-                authState.isLoading || !!oidcLoading() || authState.mfaRequired
-              }
-              required
-            />
-          </div>
-        </Show>
+        {/* Server URL input hidden during beta — hardcoded to kaiku.pmind.de */}
 
         {/* MFA Code Step */}
         <Show when={authState.mfaRequired}>

--- a/client/src/views/Register.tsx
+++ b/client/src/views/Register.tsx
@@ -24,9 +24,8 @@ const Register: Component = () => {
   document.title = "Create Account | Kaiku";
   onCleanup(() => { document.title = "Kaiku"; });
   const navigate = useNavigate();
-  const isTauri = typeof window !== "undefined" && "__TAURI__" in window;
   const defaultServerUrl = import.meta.env.VITE_SERVER_URL || window.location.origin;
-  const [serverUrl, setServerUrl] = createSignal(defaultServerUrl);
+  const [serverUrl] = createSignal(defaultServerUrl);
   const [username, setUsername] = createSignal("");
   const [email, setEmail] = createSignal("");
   const [displayName, setDisplayName] = createSignal("");
@@ -35,9 +34,8 @@ const Register: Component = () => {
   const [localError, setLocalError] = createSignal("");
   const [oidcLoading, setOidcLoading] = createSignal<string | null>(null);
 
-  // Fetch server settings when server URL is entered (debounced)
-  const [settingsUrl, setSettingsUrl] = createSignal(defaultServerUrl);
-  const [settings] = createResource(settingsUrl, async (url) => {
+  // Fetch server settings from hardcoded beta URL
+  const [settings] = createResource(() => defaultServerUrl, async (url) => {
     if (!url.trim()) return null;
     try {
       return await fetchServerSettings(url);
@@ -47,22 +45,11 @@ const Register: Component = () => {
     }
   });
 
-  let urlTimer: ReturnType<typeof setTimeout> | undefined;
-  const handleServerUrlChange = (value: string) => {
-    setServerUrl(value);
-    clearTimeout(urlTimer);
-    urlTimer = setTimeout(() => setSettingsUrl(value), 500);
-  };
-
   const handleRegister = async (e: Event) => {
     e.preventDefault();
     setLocalError("");
     clearError();
 
-    if (isTauri && !serverUrl().trim()) {
-      setLocalError("Server URL is required");
-      return;
-    }
     if (!username().trim()) {
       setLocalError("Username is required");
       return;
@@ -215,26 +202,7 @@ const Register: Component = () => {
           Join Kaiku to start chatting
         </p>
 
-        <Show when={isTauri}>
-          <div class="mb-4">
-            <label for="register-server-url" class="block text-sm font-medium text-text-secondary mb-1">
-              Server URL
-            </label>
-            <input
-              id="register-server-url"
-              type="url"
-              class="input-field"
-              name="url"
-              autocomplete="url"
-              data-testid="register-server-url"
-              placeholder="https://chat.example.com"
-              value={serverUrl()}
-              onInput={(e) => handleServerUrlChange(e.currentTarget.value)}
-              disabled={authState.isLoading || !!oidcLoading()}
-              required
-            />
-          </div>
-        </Show>
+        {/* Server URL input hidden during beta — hardcoded to kaiku.pmind.de */}
 
         {/* Registration closed message */}
         <Show when={isClosed()}>

--- a/client/src/views/ResetPassword.tsx
+++ b/client/src/views/ResetPassword.tsx
@@ -1,5 +1,5 @@
 import { Component, createSignal, Show, onCleanup } from "solid-js";
-import { A, useSearchParams } from "@solidjs/router";
+import { A } from "@solidjs/router";
 import PasswordInput from "@/components/ui/PasswordInput";
 import { getThemeImage } from "@/lib/themeImage";
 
@@ -7,16 +7,8 @@ const ResetPassword: Component = () => {
   document.title = "Reset Password | Kaiku";
   onCleanup(() => { document.title = "Kaiku"; });
   const isTauri = typeof window !== "undefined" && "__TAURI__" in window;
-  const [searchParams] = useSearchParams();
   const defaultServerUrl = import.meta.env.VITE_SERVER_URL || window.location.origin;
-  const storedUrl =
-    typeof localStorage !== "undefined"
-      ? localStorage.getItem("serverUrl") || ""
-      : "";
-  const rawServerUrl = searchParams.serverUrl;
-  const paramServerUrl = Array.isArray(rawServerUrl) ? rawServerUrl[0] : rawServerUrl;
-  const initialUrl = paramServerUrl || (isTauri ? storedUrl : "") || defaultServerUrl;
-  const [serverUrl, setServerUrl] = createSignal(initialUrl);
+  const [serverUrl] = createSignal(defaultServerUrl);
   const [token, setToken] = createSignal("");
   const [newPassword, setNewPassword] = createSignal("");
   const [confirmPassword, setConfirmPassword] = createSignal("");
@@ -29,10 +21,6 @@ const ResetPassword: Component = () => {
     setError("");
     setSuccess(false);
 
-    if (!serverUrl().trim()) {
-      setError("Server URL is required");
-      return;
-    }
     if (!token().trim()) {
       setError("Reset code is required");
       return;
@@ -90,28 +78,7 @@ const ResetPassword: Component = () => {
 
         <Show when={!success()}>
           <form onSubmit={handleSubmit} method="post" noValidate class="space-y-4">
-            <Show when={isTauri}>
-              <div>
-                <label
-                  for="rp-server-url"
-                  class="block text-sm font-medium text-text-secondary mb-1"
-                >
-                  Server URL
-                </label>
-                <input
-                  id="rp-server-url"
-                  type="url"
-                  class="input-field"
-                  name="url"
-                  autocomplete="url"
-                  placeholder="https://chat.example.com"
-                  value={serverUrl()}
-                  onInput={(e) => setServerUrl(e.currentTarget.value)}
-                  disabled={isLoading()}
-                  required
-                />
-              </div>
-            </Show>
+            {/* Server URL input hidden during beta — hardcoded to kaiku.pmind.de */}
 
             <div>
               <label


### PR DESCRIPTION
## Summary
- Set `VITE_SERVER_URL=https://kaiku.pmind.de` in `.env.production` so both web and Tauri builds point to the beta server
- Remove the server URL input fields from Login, Register, ForgotPassword, and ResetPassword views
- Clean up unused debounce handlers, localStorage lookups, and validation for the now-hardcoded URL

## Test plan
- [x] TypeScript type check passes (no new errors)
- [x] All 573 client tests pass
- [ ] Verify web client login connects to kaiku.pmind.de
- [ ] Verify Tauri desktop client login connects to kaiku.pmind.de
- [ ] Verify password reset flow works without server URL field

🤖 Generated with [Claude Code](https://claude.com/claude-code)