### PR TITLE
fix(voice): enable cloned VAD monitor track to prevent audio deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Desktop client can now see screen share and webcam indicators from other users
 - Desktop client now restores your session on restart — no more re-login every time you open the app
 - Voice activity detection now actually gates the microphone — audio is only transmitted when speech is detected, using the configurable sensitivity threshold with 300ms hold-open
+- Fixed VAD gating silencing all audio: cloned monitor track inherited disabled state from the gated mic track, so speech was never detected and the mic stayed permanently muted (#496)
 - Mic test level meter gradient now spans the full bar width instead of compressing the full green-yellow-red range into the current level
 - Screen sharing video now flows between users — was blocked by single-PeerConnection offer model
 - Screen share video renders correctly instead of showing black (switched to VP8-only codec to fix RTP payload type mismatch between publisher/subscriber sessions)

--- a/client/src/lib/webrtc/browser.ts
+++ b/client/src/lib/webrtc/browser.ts
@@ -1408,12 +1408,14 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
     console.log("[BrowserVoiceAdapter] Starting VAD monitoring");
 
     try {
-      // Clone the mic track for VAD analysis. The clone is unaffected by
-      // track.enabled on the original, so we always see the real mic level
-      // even when VAD gating has disabled the original track.
+      // Clone the mic track for VAD analysis. The clone must be explicitly
+      // enabled because cloned tracks inherit the original's enabled state
+      // (W3C MediaStreamTrack spec). When VAD gating has disabled the
+      // original track, the clone would otherwise produce silence too.
       const srcTrack = this.localStream.getAudioTracks()[0];
       if (!srcTrack) return;
       this.vadMonitorTrack = srcTrack.clone();
+      this.vadMonitorTrack.enabled = true;
       const vadStream = new MediaStream([this.vadMonitorTrack]);
 
       this.vadAudioContext = new AudioContext();


### PR DESCRIPTION
## Summary

- Fix VAD gating deadlock that silences all audio transmission when Voice Activity Detection is enabled (the default)
- `syncVadConfig()` disables the mic track before `startVAD()` runs; the cloned monitor track inherits `enabled=false` (W3C MediaStreamTrack spec), producing silence — so VAD never detects speech and the track stays disabled forever
- Explicitly set `vadMonitorTrack.enabled = true` after cloning so the monitor always receives real mic input

## Test plan

- [ ] Join a voice channel with VAD enabled (default setting) — verify audio transmits and speaking indicator activates
- [ ] Join with VAD disabled — verify audio still works as before
- [ ] Change mic device mid-call — verify VAD restarts correctly with new device
- [ ] Toggle VAD on/off in settings during a call — verify audio gates properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)