### PR TITLE
fix: 4 remaining Important beta fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scrolling up in a channel no longer causes false unread indicators
 - Deleted messages no longer counted in unread totals
 - DM unread aggregate query now uses correct `dm_read_state` table
+- Edited messages in E2EE channels now display decrypted content instead of ciphertext
+- Sending multiple messages rapidly no longer reorders them in the chat view
+- Slow WebSocket clients are now disconnected instead of blocking the message bus
+- Typing indicators no longer trigger database permission queries on every keystroke
 
 ### Added
 - Password visibility toggle on all password fields (login, register, reset password)

--- a/client/src-tauri/src/commands/chat.rs
+++ b/client/src-tauri/src/commands/chat.rs
@@ -64,6 +64,7 @@ pub struct Message {
     pub thread_last_reply_at: Option<String>,
     pub edited_at: Option<String>,
     pub created_at: String,
+    pub nonce: Option<String>,
 }
 
 /// Get all channels.
@@ -180,6 +181,7 @@ pub async fn send_message(
     state: State<'_, AppState>,
     channel_id: String,
     content: String,
+    nonce: Option<String>,
 ) -> Result<Message, String> {
     let (server_url, token) = {
         let auth = state.auth.read().await;
@@ -197,7 +199,8 @@ pub async fn send_message(
         .header("Authorization", format!("Bearer {token}"))
         .json(&serde_json::json!({
             "content": content,
-            "encrypted": false
+            "encrypted": false,
+            "nonce": nonce
         }))
         .send()
         .await

--- a/client/src/lib/types.ts
+++ b/client/src/lib/types.ts
@@ -291,6 +291,7 @@ export interface Message {
   thread_info?: ThreadInfo;
   pinned: boolean;
   message_type: string; // "user" | "system"
+  nonce?: string | null;
 }
 
 export interface ChannelPin {

--- a/client/src/stores/__tests__/messages.test.ts
+++ b/client/src/stores/__tests__/messages.test.ts
@@ -41,6 +41,7 @@ import {
   clearCurve25519KeyCache,
   editingMessageId,
   setEditingMessageId,
+  decryptMessageIfNeeded,
 } from "../messages";
 
 function createMessage(id: string, channelId = "ch-1"): Message {
@@ -300,6 +301,24 @@ describe("messages store", () => {
       expect(msgs).toHaveLength(2);
       expect(msgs[0].id).toBe("pending:nonce-AAA");
       expect(msgs[1].id).toBe("msg-other");
+    });
+  });
+
+  describe("decryptMessageIfNeeded", () => {
+    it("returns non-encrypted message unchanged", async () => {
+      const msg = createMessage("m1");
+      msg.encrypted = false;
+      msg.content = "hello";
+      const result = await decryptMessageIfNeeded(msg);
+      expect(result.content).toBe("hello");
+    });
+
+    it("returns placeholder for encrypted message without session", async () => {
+      const msg = createMessage("m1");
+      msg.encrypted = true;
+      msg.content = "ciphertext-blob";
+      const result = await decryptMessageIfNeeded(msg);
+      expect(result.content).toContain("[");
     });
   });
 

--- a/client/src/stores/__tests__/messages.test.ts
+++ b/client/src/stores/__tests__/messages.test.ts
@@ -67,6 +67,7 @@ function createMessage(id: string, channelId = "ch-1"): Message {
     pinned: false,
     message_type: "user",
     reactions: [],
+    nonce: null,
   };
 }
 
@@ -250,6 +251,55 @@ describe("messages store", () => {
       await addMessage(msg);
 
       expect(messagesState.byChannel["ch-1"]).toHaveLength(1);
+    });
+  });
+
+  describe("addMessage nonce matching", () => {
+    it("replaces the correct pending message when multiple are pending", async () => {
+      const pending1: Message = {
+        ...createMessage("pending:nonce-AAA", "ch-1"),
+        author: { id: "me", username: "me", display_name: "me", avatar_url: null, status: "online" },
+        nonce: "nonce-AAA",
+      };
+      const pending2: Message = {
+        ...createMessage("pending:nonce-BBB", "ch-1"),
+        author: { id: "me", username: "me", display_name: "me", avatar_url: null, status: "online" },
+        nonce: "nonce-BBB",
+      };
+      setMessagesState("byChannel", "ch-1", [pending1, pending2]);
+
+      const real2: Message = {
+        ...createMessage("msg-002", "ch-1"),
+        author: { id: "me", username: "me", display_name: "me", avatar_url: null, status: "online" },
+        nonce: "nonce-BBB",
+      };
+      await addMessage(real2);
+
+      const msgs = messagesState.byChannel["ch-1"]!;
+      expect(msgs).toHaveLength(2);
+      expect(msgs[0].id).toBe("pending:nonce-AAA");
+      expect(msgs[1].id).toBe("msg-002");
+    });
+
+    it("appends message from other user without touching pending messages", async () => {
+      const pending1: Message = {
+        ...createMessage("pending:nonce-AAA", "ch-1"),
+        author: { id: "me", username: "me", display_name: "me", avatar_url: null, status: "online" },
+        nonce: "nonce-AAA",
+      };
+      setMessagesState("byChannel", "ch-1", [pending1]);
+
+      const otherMsg: Message = {
+        ...createMessage("msg-other", "ch-1"),
+        author: { id: "other", username: "other", display_name: "Other", avatar_url: null, status: "online" },
+        nonce: null,
+      };
+      await addMessage(otherMsg);
+
+      const msgs = messagesState.byChannel["ch-1"]!;
+      expect(msgs).toHaveLength(2);
+      expect(msgs[0].id).toBe("pending:nonce-AAA");
+      expect(msgs[1].id).toBe("msg-other");
     });
   });
 

--- a/client/src/stores/messages.ts
+++ b/client/src/stores/messages.ts
@@ -326,9 +326,11 @@ export async function sendMessage(
 
   // Build an optimistic (pending) message so the UI updates instantly
   const user = currentUser();
-  const pendingId = `pending:${crypto.randomUUID()}`;
+  const nonce = crypto.randomUUID();
+  const pendingId = `pending:${nonce}`;
   const optimisticMessage: Message = {
     id: pendingId,
+    nonce,
     channel_id: channelId,
     author: user
       ? { id: user.id, username: user.username, display_name: user.display_name, avatar_url: user.avatar_url, status: user.status }
@@ -354,7 +356,8 @@ export async function sendMessage(
   try {
     const { message, status } = await tauri.sendMessageWithStatus(
       channelId,
-      trimmedContent
+      trimmedContent,
+      { nonce },
     );
 
     // Slash command invocations return 202 Accepted and are not persisted as messages.
@@ -419,10 +422,12 @@ export async function addMessage(message: Message): Promise<void> {
   if (existing.some((m) => m.id === processedMessage.id)) {
     return;
   }
-  // If this is a confirmed echo of our own message, replace the oldest pending placeholder
+  // If this is a confirmed echo of our own message, replace the matching pending placeholder by nonce
   const me = currentUser();
-  if (me && processedMessage.author.id === me.id) {
-    const pendingIdx = existing.findIndex((m) => m.id.startsWith("pending:"));
+  if (me && processedMessage.author.id === me.id && processedMessage.nonce) {
+    const pendingIdx = existing.findIndex(
+      (m) => m.id.startsWith("pending:") && m.nonce === processedMessage.nonce,
+    );
     if (pendingIdx !== -1) {
       const base = [...existing];
       base.splice(pendingIdx, 1);

--- a/client/src/stores/messages.ts
+++ b/client/src/stores/messages.ts
@@ -55,7 +55,7 @@ export { editingMessageId, setEditingMessageId };
  * Also processes Megolm session key distribution messages automatically.
  * Returns the message with decrypted content, or a placeholder if decryption fails.
  */
-async function decryptMessageIfNeeded(message: Message): Promise<Message> {
+export async function decryptMessageIfNeeded(message: Message): Promise<Message> {
   // If not encrypted, return as-is
   if (!message.encrypted) {
     return message;

--- a/client/src/stores/websocket.ts
+++ b/client/src/stores/websocket.ts
@@ -205,8 +205,14 @@ async function applyMessageEdit(channelId: string, messageId: string, content: s
     newContent = decrypted.content;
   }
 
-  setMessagesState("byChannel", channelId, index, "content", newContent);
-  setMessagesState("byChannel", channelId, index, "edited_at", editedAt);
+  // Re-find index after await — concurrent loadMessages can prepend and shift indices
+  const current = messagesState.byChannel[channelId];
+  if (!current) return;
+  const freshIndex = current.findIndex((m) => m.id === messageId);
+  if (freshIndex === -1) return;
+
+  setMessagesState("byChannel", channelId, freshIndex, "content", newContent);
+  setMessagesState("byChannel", channelId, freshIndex, "edited_at", editedAt);
 }
 
 /**

--- a/client/src/stores/websocket.ts
+++ b/client/src/stores/websocket.ts
@@ -25,6 +25,7 @@ import {
   messagesState,
   setMessagesState,
   loadInitialMessages,
+  decryptMessageIfNeeded,
 } from "./messages";
 import { showToast, dismissToast } from "@/components/ui/Toast";
 import {
@@ -281,18 +282,27 @@ export async function initWebSocket(): Promise<void> {
         message_id: string;
         content: string;
         edited_at: string;
-      }>("ws:message_edit", (event) => {
+      }>("ws:message_edit", async (event) => {
         const { channel_id, message_id, content, edited_at } = event.payload;
         const messages = messagesState.byChannel[channel_id];
         if (messages) {
           const index = messages.findIndex((m) => m.id === message_id);
           if (index !== -1) {
+            const existingMsg = messages[index];
+            let newContent = content;
+
+            if (existingMsg.encrypted) {
+              const temp = { ...existingMsg, content };
+              const decrypted = await decryptMessageIfNeeded(temp);
+              newContent = decrypted.content;
+            }
+
             setMessagesState(
               "byChannel",
               channel_id,
               index,
               "content",
-              content,
+              newContent,
             );
             setMessagesState(
               "byChannel",
@@ -1015,12 +1025,21 @@ async function handleServerEvent(event: ServerEvent): Promise<void> {
           (m) => m.id === event.message_id,
         );
         if (editIndex !== -1) {
+          const existingMsg = editMessages[editIndex];
+          let newContent = event.content;
+
+          if (existingMsg.encrypted) {
+            const temp = { ...existingMsg, content: event.content };
+            const decrypted = await decryptMessageIfNeeded(temp);
+            newContent = decrypted.content;
+          }
+
           setMessagesState(
             "byChannel",
             event.channel_id,
             editIndex,
             "content",
-            event.content,
+            newContent,
           );
           setMessagesState(
             "byChannel",

--- a/client/src/stores/websocket.ts
+++ b/client/src/stores/websocket.ts
@@ -191,6 +191,24 @@ function handleMessageNotification(message: Message): void {
   );
 }
 
+/** Apply an edited message's content and timestamp, decrypting if needed for E2EE channels. */
+async function applyMessageEdit(channelId: string, messageId: string, content: string, editedAt: string): Promise<void> {
+  const messages = messagesState.byChannel[channelId];
+  if (!messages) return;
+  const index = messages.findIndex((m) => m.id === messageId);
+  if (index === -1) return;
+
+  const existingMsg = messages[index];
+  let newContent = content;
+  if (existingMsg.encrypted) {
+    const decrypted = await decryptMessageIfNeeded({ ...existingMsg, content });
+    newContent = decrypted.content;
+  }
+
+  setMessagesState("byChannel", channelId, index, "content", newContent);
+  setMessagesState("byChannel", channelId, index, "edited_at", editedAt);
+}
+
 /**
  * Initialize WebSocket event listeners.
  * Call this once when the app starts (after auth).
@@ -284,35 +302,7 @@ export async function initWebSocket(): Promise<void> {
         edited_at: string;
       }>("ws:message_edit", async (event) => {
         const { channel_id, message_id, content, edited_at } = event.payload;
-        const messages = messagesState.byChannel[channel_id];
-        if (messages) {
-          const index = messages.findIndex((m) => m.id === message_id);
-          if (index !== -1) {
-            const existingMsg = messages[index];
-            let newContent = content;
-
-            if (existingMsg.encrypted) {
-              const temp = { ...existingMsg, content };
-              const decrypted = await decryptMessageIfNeeded(temp);
-              newContent = decrypted.content;
-            }
-
-            setMessagesState(
-              "byChannel",
-              channel_id,
-              index,
-              "content",
-              newContent,
-            );
-            setMessagesState(
-              "byChannel",
-              channel_id,
-              index,
-              "edited_at",
-              edited_at,
-            );
-          }
-        }
+        await applyMessageEdit(channel_id, message_id, content, edited_at);
       }),
     );
 
@@ -1018,40 +1008,9 @@ async function handleServerEvent(event: ServerEvent): Promise<void> {
     case "unsubscribed":
       break;
 
-    case "message_edit": {
-      const editMessages = messagesState.byChannel[event.channel_id];
-      if (editMessages) {
-        const editIndex = editMessages.findIndex(
-          (m) => m.id === event.message_id,
-        );
-        if (editIndex !== -1) {
-          const existingMsg = editMessages[editIndex];
-          let newContent = event.content;
-
-          if (existingMsg.encrypted) {
-            const temp = { ...existingMsg, content: event.content };
-            const decrypted = await decryptMessageIfNeeded(temp);
-            newContent = decrypted.content;
-          }
-
-          setMessagesState(
-            "byChannel",
-            event.channel_id,
-            editIndex,
-            "content",
-            newContent,
-          );
-          setMessagesState(
-            "byChannel",
-            event.channel_id,
-            editIndex,
-            "edited_at",
-            event.edited_at,
-          );
-        }
-      }
+    case "message_edit":
+      await applyMessageEdit(event.channel_id, event.message_id, event.content, event.edited_at);
       break;
-    }
 
     case "message_delete":
       removeMessage(event.channel_id, event.message_id);

--- a/docs/developer-guide/plans/2026-03-19-beta-checklist.md
+++ b/docs/developer-guide/plans/2026-03-19-beta-checklist.md
@@ -45,7 +45,7 @@
 - [x] **Permission check swallows DB errors as "Unauthorized"** (#413)
   Fixed: now matches on variant, logs `DatabaseError`, only maps permission errors to `Unauthorized`.
 
-- [ ] **Permission resolution fires 3-5 queries per typing event**
+- [x] **Permission resolution fires 3-5 queries per typing event** (#497)
   Every `Typing`/`StopTyping` WS event triggers the full permission chain.
   - `server/src/permissions/helpers.rs:82-158`
   - `server/src/ws/mod.rs:1472-1493`
@@ -54,7 +54,7 @@
 - [x] **Regex compiled on every message (`detect_mention_type`)** (#413)
   Fixed: promoted to `static LazyLock<Regex>`.
 
-- [ ] **Slow WS clients block Redis pubsub task**
+- [x] **Slow WS clients block Redis pubsub task** (#497)
   `tx.send(event).await` on full buffer pauses the Redis subscriber for the connection.
   - `server/src/ws/mod.rs:1172,1811`
   - Fix: use `try_send()` and drop/disconnect on sustained backpressure
@@ -84,7 +84,7 @@
 - [x] **Voice panel shows raw UUIDs instead of usernames** (#413)
   Fixed: uses `display_name || username || user_id.slice(0, 8)`.
 
-- [ ] **Message edit doesn't decrypt in E2EE channels**
+- [x] **Message edit doesn't decrypt in E2EE channels** (#497)
   `message_edit` patches raw content without running `decryptMessageIfNeeded()`.
   - `client/src/stores/websocket.ts:985-1009` (browser), `262-290` (Tauri)
   - Fix: call `decryptMessageIfNeeded()` on edit content for E2EE channels
@@ -95,7 +95,7 @@
 - [x] **Guild load error invisible to user** (#413)
   Fixed: shows error indicator with retry button in `ServerRail`.
 
-- [ ] **Optimistic message send race condition**
+- [x] **Optimistic message send race condition** (#497)
   `findIndex(m => m.id.startsWith("pending:"))` matches the *oldest* pending, not the specific one. Rapid sends can corrupt ordering.
   - `client/src/stores/messages.ts:373-381`
   - Fix: match against a specific pending ID (e.g., store pending ID in nonce)
@@ -165,6 +165,6 @@
 | Category | Total | Done | Remaining |
 |----------|-------|------|-----------|
 | Critical | 7 | 7 | 0 |
-| Important | 19 | 15 | 4 |
+| Important | 19 | 19 | 0 |
 | Nice-to-have | 22 | 0 | 22 |
-| **Total** | **48** | **22** | **26** |
+| **Total** | **48** | **26** | **22** |

--- a/docs/developer-guide/plans/2026-03-19-beta-checklist.md
+++ b/docs/developer-guide/plans/2026-03-19-beta-checklist.md
@@ -1,0 +1,170 @@
+# Closed Beta Readiness Checklist
+
+> Generated: 2026-03-19
+> Goal: Track all improvements needed before and during the closed beta launch.
+
+---
+
+## Critical — Fix Before Beta Launch
+
+### Reconnection & Reliability
+
+- [x] **Channel subscriptions not restored after WebSocket reconnect** (#410)
+  Fixed: `handleReconnect()` snapshots and re-subscribes all channels on reconnect.
+
+- [x] **WebSocket reconnection invisible to users** (#410)
+  Fixed: persistent "Reconnecting..." toast shown during reconnect, dismissed after recovery.
+
+- [x] **No server-side WebSocket heartbeat / idle timeout** (#410)
+  Fixed: 30s ping/pong heartbeat with `OutboundMsg` enum and `tokio::select!` read loop.
+
+- [x] **Messages during disconnection are never backfilled** (#410)
+  Fixed: `loadInitialMessages()` called for all channels with loaded content on reconnect.
+
+### Security
+
+- [x] **JWT token exposed in WebSocket URL query parameter** (#411)
+  Fixed: Tauri client now uses `Sec-WebSocket-Protocol` header matching server and browser-mode client.
+
+### Deployment
+
+- [x] **JWT key mismatch — server won't start with compose config** (#412)
+  Fixed: setup-beta.sh now generates Ed25519 key pair, compose passes JWT_PRIVATE_KEY/JWT_PUBLIC_KEY.
+
+### Performance
+
+- [x] **Token refresh holds DB transaction during GeoIP HTTP call** (#411)
+  Fixed: GeoIP calls moved before `state.db.begin()` in register and refresh handlers.
+
+---
+
+## Important — Fix Early in Beta
+
+### Backend Reliability
+
+- [x] **Permission check swallows DB errors as "Unauthorized"** (#413)
+  Fixed: now matches on variant, logs `DatabaseError`, only maps permission errors to `Unauthorized`.
+
+- [ ] **Permission resolution fires 3-5 queries per typing event**
+  Every `Typing`/`StopTyping` WS event triggers the full permission chain.
+  - `server/src/permissions/helpers.rs:82-158`
+  - `server/src/ws/mod.rs:1472-1493`
+  - Fix: cache per `(user_id, channel_id)` with 30s TTL, or skip for already-subscribed channels
+
+- [x] **Regex compiled on every message (`detect_mention_type`)** (#413)
+  Fixed: promoted to `static LazyLock<Regex>`.
+
+- [ ] **Slow WS clients block Redis pubsub task**
+  `tx.send(event).await` on full buffer pauses the Redis subscriber for the connection.
+  - `server/src/ws/mod.rs:1172,1811`
+  - Fix: use `try_send()` and drop/disconnect on sustained backpressure
+
+- [x] **WS auth doesn't check user exists in DB on connect** (#413)
+  Fixed: `find_user_by_id` call added before `on_upgrade()`.
+
+- [x] **Health check always returns HTTP 200 even when degraded** (#413)
+  Fixed: returns HTTP 503 when `status != "ok"`.
+
+### Client — Tauri
+
+- [x] **Tauri `ServerEvent` enum missing multiple server events** (#413)
+  Fixed: added 10 missing variants (workspace, commands, moderation).
+
+- [x] **`screen_share_started` Tauri event missing `stream_id` field** (#413)
+  Fixed: added `stream_id` and `started_at` fields.
+
+### Client — Frontend
+
+- [x] **`console.log` stripping doesn't work in production builds** (#413)
+  Fixed: uses Vite `mode` parameter instead of `process.env.NODE_ENV`.
+
+- [x] **Mermaid statically imported — threatens <3s startup target** (#413)
+  Fixed: lazy-loaded via dynamic `import()`.
+
+- [x] **Voice panel shows raw UUIDs instead of usernames** (#413)
+  Fixed: uses `display_name || username || user_id.slice(0, 8)`.
+
+- [ ] **Message edit doesn't decrypt in E2EE channels**
+  `message_edit` patches raw content without running `decryptMessageIfNeeded()`.
+  - `client/src/stores/websocket.ts:985-1009` (browser), `262-290` (Tauri)
+  - Fix: call `decryptMessageIfNeeded()` on edit content for E2EE channels
+
+- [x] **Login doesn't honor `returnUrl` after auth redirect** (#413)
+  Fixed: reads `returnUrl` from query params, validates relative path, navigates to it.
+
+- [x] **Guild load error invisible to user** (#413)
+  Fixed: shows error indicator with retry button in `ServerRail`.
+
+- [ ] **Optimistic message send race condition**
+  `findIndex(m => m.id.startsWith("pending:"))` matches the *oldest* pending, not the specific one. Rapid sends can corrupt ordering.
+  - `client/src/stores/messages.ts:373-381`
+  - Fix: match against a specific pending ID (e.g., store pending ID in nonce)
+
+- [ ] **`any[]` types in voice/screen-share handlers**
+  Eight handlers bypass TypeScript type checking entirely.
+  - `client/src/stores/websocket.ts:459-460,1763-1765,1786,1815,1843,1871,1896`
+  - Fix: use existing `VoiceParticipant`, `ScreenShareServerInfo`, `WebcamServerInfo` types
+
+- [x] **`Patch` entity type `"channel"` not implemented client-side** (#413)
+  Fixed: added `"channel"` case to `handlePatchEvent` with `patchChannel()`.
+
+### Infrastructure
+
+- [x] **Presence scanner uses `ProcessRefreshKind::everything()` at startup** (#413)
+  Fixed: uses `ProcessRefreshKind::new()` (minimal).
+
+---
+
+## Nice-to-Have — Polish for Beta
+
+### Security & Data Hygiene
+
+- [ ] E2EE Megolm session cache never cleared on logout — `client/src/stores/messages.ts:618`
+- [ ] `returnUrl` injection risk when feature is implemented — validate relative URL — `client/src/components/auth/AuthGuard.tsx:28-30`
+- [ ] TURN credentials are static/long-lived — consider time-limited HMAC credentials — `server/src/voice/handlers.rs:47-66`
+- [ ] No virus scanning for file uploads (MIME + magic bytes is current defense) — `server/src/chat/uploads.rs`
+
+### UX Polish
+
+- [ ] Upload error auto-dismisses in 5s (toast convention is 8s) — `client/src/components/messages/MessageInput.tsx:147`
+- [ ] `createEffect` without reactive dep should be `onMount` — `client/src/views/Main.tsx:133-144`
+- [ ] Long channel names truncate in header without tooltip — `client/src/views/Main.tsx:239-241`
+- [ ] `/demo` theme route accessible in production — `client/src/App.tsx:290`
+- [ ] `Login.tsx` sets `document.title` but no other view does — `client/src/views/Login.tsx:30-31`
+
+### Accessibility
+
+- [ ] ServerRail buttons lack `aria-current` and `role="navigation"` — `client/src/components/layout/ServerRail.tsx:78-91`
+- [ ] ChannelItem uses `div[role=button]` instead of `<button>` — `client/src/components/channels/ChannelItem.tsx:153-183`
+
+### Backend Optimization
+
+- [ ] Per-request PEM key decode on every JWT validation — parse once at startup — `server/src/auth/jwt.rs:131-133`
+- [ ] `get_member_permission_context` fires 3 sequential queries where 1 CTE would suffice — `server/src/permissions/helpers.rs:88-135`
+- [ ] Session cleanup lacks optimal index for `expires_at < NOW()` range scan — `server/migrations/20260128000000_performance_indexes.sql:30`
+- [ ] Graceful shutdown doesn't drain active WS connections — `server/src/main.rs:379-413`
+- [ ] Connection pool (max 20) may be tight for hundreds of users — `server/src/db/mod.rs:49-60`
+- [ ] No rate limiting on WS typing events specifically — `server/src/ws/mod.rs:1470-1514`
+
+### Infrastructure
+
+- [ ] Deploy scripts use `docker` but dev uses `podman` — `infra/scripts/deploy.sh:16`, `infra/scripts/backup.sh:32`
+- [ ] `bitnami/postgresql:latest` in compose — pin to major version — `infra/compose/docker-compose.yml:65`
+- [ ] No code splitting for heavy deps (highlight.js, marked) beyond mermaid — `client/vite.config.ts:44-46`
+- [ ] `scap` git fork branch dependency — track upstream merge — `client/src-tauri/Cargo.toml:59`
+- [ ] No auto-updater for Tauri client (`tauri-plugin-updater` missing)
+- [ ] Upload S3 failure leaves orphaned empty message in DB — `server/src/chat/uploads.rs:675-693`
+- [ ] Duplicate presence update listeners in Tauri mode — `client/src/stores/presence.ts:49-97`
+- [ ] `SetupWizard` uses raw `fetch` instead of `tauri.fetchApi` — `client/src/components/SetupWizard.tsx:44-46`
+- [ ] `discovery/handlers.rs` uses `.unwrap()` on guarded Option — use `if let` — `server/src/discovery/handlers.rs:153,207`
+
+---
+
+## Progress Summary
+
+| Category | Total | Done | Remaining |
+|----------|-------|------|-----------|
+| Critical | 7 | 7 | 0 |
+| Important | 19 | 15 | 4 |
+| Nice-to-have | 22 | 0 | 22 |
+| **Total** | **48** | **22** | **26** |

--- a/docs/superpowers/plans/2026-04-01-beta-important-fixes.md
+++ b/docs/superpowers/plans/2026-04-01-beta-important-fixes.md
@@ -1,0 +1,665 @@
+# Beta Important Fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the 4 remaining Important items from the beta checklist: typing permission queries, WS backpressure, E2EE message edit decryption, and optimistic send race condition.
+
+**Architecture:** Two server-only fixes (typing throttle, WS backpressure) in `ws/mod.rs`, two client-only fixes (E2EE edit, nonce matching) across `messages.ts`, `websocket.ts`, and `types.ts`. All 4 are independent with no cross-dependencies.
+
+**Tech Stack:** Rust/tokio (server), Solid.js/TypeScript (client), Vitest (client tests)
+
+**Spec:** `docs/superpowers/specs/2026-04-01-beta-important-fixes-design.md`
+
+---
+
+## File Map
+
+### Server files to modify
+| File | Responsibility |
+|------|---------------|
+| `server/src/ws/mod.rs` | Typing handler (subscription check + throttle), pubsub backpressure (`try_send`) |
+
+### Client files to modify
+| File | Responsibility |
+|------|---------------|
+| `client/src/lib/types.ts` | Add `nonce` field to `Message` interface |
+| `client/src/stores/messages.ts` | Export `decryptMessageIfNeeded`, nonce generation in `sendMessage`, nonce matching in `addMessage` |
+| `client/src/stores/websocket.ts` | Decrypt edited messages in both browser and Tauri handlers |
+| `client/src/stores/__tests__/messages.test.ts` | Tests for nonce-based matching |
+
+---
+
+## Task 1: Server — Typing subscription check + throttle
+
+**Files:**
+- Modify: `server/src/ws/mod.rs:78-83` (struct), `server/src/ws/mod.rs:1549-1594` (handlers)
+
+- [ ] **Step 1: Add `last_typing` field to `ClientMessageState`**
+
+First, add the missing import at `server/src/ws/mod.rs:24` (alongside the existing `use std::collections::HashSet;`):
+
+```rust
+use std::collections::HashMap;
+```
+
+(`Duration` and `Instant` are already imported via `use std::time::{Duration, Instant};` at line 26.)
+
+Then at `server/src/ws/mod.rs:78-83`, add the new field to the struct:
+
+```rust
+#[derive(Default)]
+pub struct ClientMessageState {
+    /// Activity rate limiting and deduplication state.
+    pub activity: ActivityState,
+    /// Custom status rate limiting and deduplication state.
+    pub custom_status: CustomStatusState,
+    /// Per-channel typing throttle (channel_id → last typing broadcast time).
+    pub last_typing: HashMap<Uuid, Instant>,
+}
+```
+
+Note: `HashMap` implements `Default` (empty map), so `#[derive(Default)]` still works.
+
+- [ ] **Step 2: Replace `Typing` handler with subscription check + throttle**
+
+At `server/src/ws/mod.rs:1549-1572`, replace the entire `ClientEvent::Typing` arm:
+
+```rust
+ClientEvent::Typing { channel_id } => {
+    // Only allow typing in channels the user is subscribed to
+    // (subscription is already permission-gated)
+    if !subscribed_channels.read().await.contains(&channel_id) {
+        return Ok(());
+    }
+
+    // Server-side throttle: max 1 typing event per second per channel
+    let now = Instant::now();
+    if let Some(last) = msg_state.last_typing.get(&channel_id) {
+        if now.duration_since(*last) < Duration::from_secs(1) {
+            return Ok(());
+        }
+    }
+    msg_state.last_typing.insert(channel_id, now);
+
+    // Broadcast typing indicator
+    broadcast_to_channel(
+        &state.redis,
+        channel_id,
+        &ServerEvent::TypingStart {
+            channel_id,
+            user_id,
+        },
+    )
+    .await?;
+}
+```
+
+- [ ] **Step 3: Replace `StopTyping` handler with subscription check (no throttle)**
+
+At `server/src/ws/mod.rs:1574-1594`, replace the entire `ClientEvent::StopTyping` arm:
+
+```rust
+ClientEvent::StopTyping { channel_id } => {
+    // Only allow in channels the user is subscribed to
+    if !subscribed_channels.read().await.contains(&channel_id) {
+        return Ok(());
+    }
+
+    // No throttle on StopTyping — throttling it causes ghost typing indicators
+
+    // Broadcast stop typing
+    broadcast_to_channel(
+        &state.redis,
+        channel_id,
+        &ServerEvent::TypingStop {
+            channel_id,
+            user_id,
+        },
+    )
+    .await?;
+}
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/ws/mod.rs
+git commit -m "perf(ws): replace permission queries with subscription check for typing events
+
+Typing and StopTyping events now check the subscribed_channels set
+instead of running 4 DB queries per event. Adds a 1-second server-side
+throttle for Typing events. StopTyping bypasses the throttle to prevent
+ghost typing indicators."
+```
+
+---
+
+## Task 2: Server — WS pubsub backpressure with `try_send()`
+
+**Files:**
+- Modify: `server/src/ws/mod.rs:1792-1981` (`handle_pubsub` function)
+
+- [ ] **Step 1: Add backpressure counter at the top of the pubsub message loop**
+
+In `handle_pubsub()` (line 1792), find the `while let Ok(message) = pubsub_stream.recv().await` loop (line 1854). Declare the counter **immediately before** the `while let` line (outside the loop, so it persists across iterations):
+
+```rust
+let mut backpressure_drops: u32 = 0;
+while let Ok(message) = pubsub_stream.recv().await {
+```
+
+- [ ] **Step 2: Create a helper macro or closure for the try_send pattern**
+
+To avoid repeating the same 10-line block at 6 call sites, add a macro inside `handle_pubsub()` just before the loop:
+
+```rust
+macro_rules! try_forward {
+    ($tx:expr, $event:expr, $drops:ident, $user_id:expr) => {
+        match $tx.try_send(OutboundMsg::Event($event)) {
+            Ok(()) => { $drops = 0; }
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                $drops += 1;
+                if $drops > 10 {
+                    warn!(
+                        "Disconnecting slow WebSocket client (user {}): {} consecutive drops",
+                        $user_id, $drops
+                    );
+                    break;
+                }
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                break;
+            }
+        }
+    };
+}
+```
+
+- [ ] **Step 3: Replace send site 1 — channel events (line 1891-1895)**
+
+Replace:
+```rust
+if !should_filter
+    && params.tx.send(OutboundMsg::Event(event)).await.is_err()
+{
+    break;
+}
+```
+
+With:
+```rust
+if !should_filter {
+    try_forward!(params.tx, event, backpressure_drops, params.user_id);
+}
+```
+
+Note: `params` must have a `user_id` field. Check the `HandlePubsubParams` struct — if it doesn't have `user_id`, pass it as a separate field or use a placeholder identifier in the log message. The current code at line 1366 passes `user_id` into the params — verify this.
+
+- [ ] **Step 4: Replace send site 2 — user events (line 1920-1922)**
+
+Replace:
+```rust
+if params.tx.send(OutboundMsg::Event(event)).await.is_err() {
+    break;
+}
+```
+
+With:
+```rust
+try_forward!(params.tx, event, backpressure_drops, params.user_id);
+```
+
+- [ ] **Step 5: Replace send site 3 — admin events (line 1932-1934)**
+
+Same replacement as Step 4.
+
+- [ ] **Step 6: Replace send site 4 — presence events (line 1953-1955)**
+
+Replace:
+```rust
+if !should_filter && params.tx.send(OutboundMsg::Event(event)).await.is_err() {
+    break;
+}
+```
+
+With:
+```rust
+if !should_filter {
+    try_forward!(params.tx, event, backpressure_drops, params.user_id);
+}
+```
+
+- [ ] **Step 7: Replace send site 5 — user cross-device sync (line 1964-1966)**
+
+Same replacement as Step 4.
+
+- [ ] **Step 8: Replace send site 6 — guild events (line 1975-1977)**
+
+Same replacement as Step 4.
+
+- [ ] **Step 9: Verify `HandlePubsubParams` has `user_id`**
+
+Check the struct definition. If `user_id` is not a field, add it and pass it from the `handle_socket` call site at the `tokio::spawn` for `handle_pubsub`.
+
+- [ ] **Step 10: Build and verify**
+
+Run: `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings`
+Expected: PASS
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add server/src/ws/mod.rs
+git commit -m "fix(ws): replace blocking pubsub send with try_send and backpressure disconnect
+
+Slow WebSocket clients no longer block the per-connection Redis pubsub
+task. Messages are dropped when the channel is full, and clients are
+disconnected after 10 consecutive drops. The client's existing reconnect
+logic handles recovery."
+```
+
+---
+
+## Task 3: Client — Decrypt edited messages in E2EE channels
+
+**Files:**
+- Modify: `client/src/stores/messages.ts:58` (add `export`)
+- Modify: `client/src/stores/websocket.ts:1011-1035` (browser handler)
+- Modify: `client/src/stores/websocket.ts:278-306` (Tauri handler)
+
+- [ ] **Step 1: Export `decryptMessageIfNeeded`**
+
+At `client/src/stores/messages.ts:58`, change:
+```typescript
+async function decryptMessageIfNeeded(message: Message): Promise<Message> {
+```
+
+To:
+```typescript
+export async function decryptMessageIfNeeded(message: Message): Promise<Message> {
+```
+
+- [ ] **Step 2: Add import in `websocket.ts`**
+
+Find the existing import from `../messages` (or `@/stores/messages`) in `client/src/stores/websocket.ts` and add `decryptMessageIfNeeded` to it.
+
+- [ ] **Step 3: Update browser `message_edit` handler**
+
+At `client/src/stores/websocket.ts:1011-1035`, replace:
+
+```typescript
+case "message_edit": {
+  const editMessages = messagesState.byChannel[event.channel_id];
+  if (editMessages) {
+    const editIndex = editMessages.findIndex(
+      (m) => m.id === event.message_id,
+    );
+    if (editIndex !== -1) {
+      setMessagesState(
+        "byChannel",
+        event.channel_id,
+        editIndex,
+        "content",
+        event.content,
+      );
+      setMessagesState(
+        "byChannel",
+        event.channel_id,
+        editIndex,
+        "edited_at",
+        event.edited_at,
+      );
+    }
+  }
+  break;
+}
+```
+
+With:
+
+```typescript
+case "message_edit": {
+  const editMessages = messagesState.byChannel[event.channel_id];
+  if (editMessages) {
+    const editIndex = editMessages.findIndex(
+      (m) => m.id === event.message_id,
+    );
+    if (editIndex !== -1) {
+      const existingMsg = editMessages[editIndex];
+      let newContent = event.content;
+
+      if (existingMsg.encrypted) {
+        const temp = { ...existingMsg, content: event.content };
+        const decrypted = await decryptMessageIfNeeded(temp);
+        newContent = decrypted.content;
+      }
+
+      setMessagesState(
+        "byChannel",
+        event.channel_id,
+        editIndex,
+        "content",
+        newContent,
+      );
+      setMessagesState(
+        "byChannel",
+        event.channel_id,
+        editIndex,
+        "edited_at",
+        event.edited_at,
+      );
+    }
+  }
+  break;
+}
+```
+
+- [ ] **Step 4: Update Tauri `ws:message_edit` handler**
+
+At `client/src/stores/websocket.ts:278-306`, replace:
+
+```typescript
+listen<{
+  channel_id: string;
+  message_id: string;
+  content: string;
+  edited_at: string;
+}>("ws:message_edit", (event) => {
+  const { channel_id, message_id, content, edited_at } = event.payload;
+  const messages = messagesState.byChannel[channel_id];
+  if (messages) {
+    const index = messages.findIndex((m) => m.id === message_id);
+    if (index !== -1) {
+      setMessagesState(
+        "byChannel",
+        channel_id,
+        index,
+        "content",
+        content,
+      );
+      setMessagesState(
+        "byChannel",
+        channel_id,
+        index,
+        "edited_at",
+        edited_at,
+      );
+    }
+  }
+}),
+```
+
+With:
+
+```typescript
+listen<{
+  channel_id: string;
+  message_id: string;
+  content: string;
+  edited_at: string;
+}>("ws:message_edit", async (event) => {
+  const { channel_id, message_id, content, edited_at } = event.payload;
+  const messages = messagesState.byChannel[channel_id];
+  if (messages) {
+    const index = messages.findIndex((m) => m.id === message_id);
+    if (index !== -1) {
+      const existingMsg = messages[index];
+      let newContent = content;
+
+      if (existingMsg.encrypted) {
+        const temp = { ...existingMsg, content };
+        const decrypted = await decryptMessageIfNeeded(temp);
+        newContent = decrypted.content;
+      }
+
+      setMessagesState(
+        "byChannel",
+        channel_id,
+        index,
+        "content",
+        newContent,
+      );
+      setMessagesState(
+        "byChannel",
+        channel_id,
+        index,
+        "edited_at",
+        edited_at,
+      );
+    }
+  }
+}),
+```
+
+Note the two changes: `(event) =>` becomes `async (event) =>`, and the decryption logic is added.
+
+- [ ] **Step 5: Verify build**
+
+Run: `cd client && bunx tsc --noEmit`
+Expected: PASS (no type errors)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/stores/messages.ts client/src/stores/websocket.ts
+git commit -m "fix(chat): decrypt edited messages in E2EE channels
+
+The message_edit WebSocket handler now checks the existing message's
+encrypted flag and calls decryptMessageIfNeeded() before updating the
+store. Applies to both browser and Tauri handlers."
+```
+
+---
+
+## Task 4: Client — Nonce-based optimistic message matching
+
+**Files:**
+- Modify: `client/src/lib/types.ts:276-294` (Message interface)
+- Modify: `client/src/stores/messages.ts:329-357` (sendMessage), `client/src/stores/messages.ts:422-431` (addMessage)
+- Test: `client/src/stores/__tests__/messages.test.ts`
+
+- [ ] **Step 1: Write failing test for nonce-based matching**
+
+Add to `client/src/stores/__tests__/messages.test.ts`. First, update the `createMessage` helper to include `nonce`:
+
+```typescript
+function createMessage(id: string, channelId = "ch-1"): Message {
+  return {
+    id,
+    channel_id: channelId,
+    // ... existing fields ...
+    nonce: null,  // Add this line
+  };
+}
+```
+
+Then add the test:
+
+```typescript
+describe("addMessage nonce matching", () => {
+  it("replaces the correct pending message when multiple are pending", async () => {
+    // Set up two pending messages
+    const pending1: Message = {
+      ...createMessage("pending:nonce-AAA", "ch-1"),
+      author: { id: "me", username: "me", display_name: "me", avatar_url: null, status: "online" },
+      nonce: "nonce-AAA",
+    };
+    const pending2: Message = {
+      ...createMessage("pending:nonce-BBB", "ch-1"),
+      author: { id: "me", username: "me", display_name: "me", avatar_url: null, status: "online" },
+      nonce: "nonce-BBB",
+    };
+    setMessagesState("byChannel", "ch-1", [pending1, pending2]);
+
+    // Server confirms the SECOND message first
+    const real2: Message = {
+      ...createMessage("msg-002", "ch-1"),
+      author: { id: "me", username: "me", display_name: "me", avatar_url: null, status: "online" },
+      nonce: "nonce-BBB",
+    };
+    await addMessage(real2);
+
+    const msgs = messagesState.byChannel["ch-1"]!;
+    // pending1 should still be there, pending2 should be replaced by real2
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0].id).toBe("pending:nonce-AAA");
+    expect(msgs[1].id).toBe("msg-002");
+  });
+
+  it("appends message from other user without touching pending messages", async () => {
+    const pending1: Message = {
+      ...createMessage("pending:nonce-AAA", "ch-1"),
+      author: { id: "me", username: "me", display_name: "me", avatar_url: null, status: "online" },
+      nonce: "nonce-AAA",
+    };
+    setMessagesState("byChannel", "ch-1", [pending1]);
+
+    const otherMsg: Message = {
+      ...createMessage("msg-other", "ch-1"),
+      author: { id: "other", username: "other", display_name: "Other", avatar_url: null, status: "online" },
+      nonce: null,
+    };
+    await addMessage(otherMsg);
+
+    const msgs = messagesState.byChannel["ch-1"]!;
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0].id).toBe("pending:nonce-AAA");
+    expect(msgs[1].id).toBe("msg-other");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd client && bun run test:run -- --reporter=verbose messages.test`
+Expected: FAIL — `nonce` property doesn't exist on `Message` type
+
+- [ ] **Step 3: Add `nonce` to Message type**
+
+At `client/src/lib/types.ts:293` (before the closing `}` of the `Message` interface), add:
+
+```typescript
+  nonce?: string | null;
+```
+
+The interface becomes:
+```typescript
+export interface Message {
+  id: string;
+  channel_id: string;
+  author: UserProfile;
+  content: string;
+  encrypted: boolean;
+  attachments: Attachment[];
+  reply_to: string | null;
+  parent_id: string | null;
+  thread_reply_count: number;
+  thread_last_reply_at: string | null;
+  edited_at: string | null;
+  created_at: string;
+  mention_type: "direct" | "everyone" | "here" | null;
+  reactions?: Reaction[];
+  thread_info?: ThreadInfo;
+  pinned: boolean;
+  message_type: string; // "user" | "system"
+  nonce?: string | null;
+}
+```
+
+- [ ] **Step 4: Generate nonce in `sendMessage`**
+
+At `client/src/stores/messages.ts:329`, replace:
+```typescript
+const pendingId = `pending:${crypto.randomUUID()}`;
+const optimisticMessage: Message = {
+  id: pendingId,
+```
+
+With:
+```typescript
+const nonce = crypto.randomUUID();
+const pendingId = `pending:${nonce}`;
+const optimisticMessage: Message = {
+  id: pendingId,
+  nonce,
+```
+
+- [ ] **Step 5: Pass nonce to server**
+
+At `client/src/stores/messages.ts:355-358`, replace:
+```typescript
+const { message, status } = await tauri.sendMessageWithStatus(
+  channelId,
+  trimmedContent
+);
+```
+
+With:
+```typescript
+const { message, status } = await tauri.sendMessageWithStatus(
+  channelId,
+  trimmedContent,
+  { nonce },
+);
+```
+
+- [ ] **Step 6: Replace pending matching in `addMessage` with nonce-based lookup**
+
+At `client/src/stores/messages.ts:422-431`, replace:
+```typescript
+  // If this is a confirmed echo of our own message, replace the oldest pending placeholder
+  const me = currentUser();
+  if (me && processedMessage.author.id === me.id) {
+    const pendingIdx = existing.findIndex((m) => m.id.startsWith("pending:"));
+    if (pendingIdx !== -1) {
+      const base = [...existing];
+      base.splice(pendingIdx, 1);
+      setMessagesState("byChannel", channelId, [...base, processedMessage]);
+      return;
+    }
+  }
+```
+
+With:
+```typescript
+  // If this is a confirmed echo of our own message, replace the matching pending placeholder by nonce
+  const me = currentUser();
+  if (me && processedMessage.author.id === me.id && processedMessage.nonce) {
+    const pendingIdx = existing.findIndex(
+      (m) => m.id.startsWith("pending:") && m.nonce === processedMessage.nonce,
+    );
+    if (pendingIdx !== -1) {
+      const base = [...existing];
+      base.splice(pendingIdx, 1);
+      setMessagesState("byChannel", channelId, [...base, processedMessage]);
+      return;
+    }
+  }
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `cd client && bun run test:run -- --reporter=verbose messages.test`
+Expected: PASS
+
+- [ ] **Step 8: Run full client test suite**
+
+Run: `cd client && bun run test:run`
+Expected: PASS (no regressions)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add client/src/lib/types.ts client/src/stores/messages.ts client/src/stores/__tests__/messages.test.ts
+git commit -m "fix(chat): use nonce for optimistic message matching to prevent reordering
+
+Each sent message now includes a nonce (UUID) that links the optimistic
+pending message to the server-confirmed echo. addMessage() matches by
+nonce instead of finding the first pending message, fixing a race
+condition where rapid sends could reorder messages in the UI."
+```

--- a/docs/superpowers/plans/2026-04-02-pr497-review-fixes.md
+++ b/docs/superpowers/plans/2026-04-02-pr497-review-fixes.md
@@ -1,0 +1,320 @@
+# PR #497 Review Fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix 8 issues found during code review of PR #497, split into a code-fix commit and a docs/process commit.
+
+**Architecture:** All fixes are independent one-line to few-line changes across server Rust files, one client test file, and two documentation files. No new modules or dependencies.
+
+**Tech Stack:** Rust (server), TypeScript/Vitest (client tests), Markdown (docs)
+
+**Spec:** `docs/superpowers/specs/2026-04-02-pr497-review-fixes-design.md`
+
+---
+
+## File Map
+
+### Commit 1 — Code fixes
+| File | Responsibility |
+|------|---------------|
+| `server/src/chat/messages.rs` | Nonce validation + strip nonce from broadcast |
+| `server/src/chat/uploads.rs` | Strip nonce from upload broadcast |
+| `server/src/ws/mod.rs` | Backpressure reset logic + last_typing cleanup |
+| `server/src/db/models.rs` | Update stale comment |
+| `client/src/stores/__tests__/messages.test.ts` | E2EE decryption tests |
+
+### Commit 2 — Docs/process
+| File | Responsibility |
+|------|---------------|
+| `CHANGELOG.md` | Add 4 Fixed entries under [Unreleased] |
+| `docs/developer-guide/plans/2026-03-19-beta-checklist.md` | Mark 4 items done, update summary table |
+
+---
+
+## Task 1: Server — Nonce validation, broadcast stripping, and comment fix
+
+**Files:**
+- Modify: `server/src/chat/messages.rs:306` (add validate attribute)
+- Modify: `server/src/chat/messages.rs:1061` (strip nonce from broadcast)
+- Modify: `server/src/chat/uploads.rs:766` (strip nonce from broadcast)
+- Modify: `server/src/db/models.rs:130` (update comment)
+
+- [ ] **Step 1: Add nonce length validation**
+
+At `server/src/chat/messages.rs:306`, add the validate attribute:
+
+```rust
+// Before (line 306)
+    pub nonce: Option<String>,
+
+// After
+    #[validate(length(max = 64))]
+    pub nonce: Option<String>,
+```
+
+- [ ] **Step 2: Strip nonce from broadcast in messages.rs**
+
+At `server/src/chat/messages.rs:1061`, replace the serialization line. This single line feeds both the `MessageNew` and `ThreadReplyNew` broadcast branches (the `if/else` at lines 1063-1096), so one change covers both.
+
+```rust
+// Before (line 1061)
+    let message_json = serde_json::to_value(&response).unwrap_or_default();
+
+// After
+    let broadcast_response = MessageResponse { nonce: None, ..response.clone() };
+    let message_json = serde_json::to_value(&broadcast_response).unwrap_or_default();
+```
+
+- [ ] **Step 3: Strip nonce from broadcast in uploads.rs**
+
+At `server/src/chat/uploads.rs:766`, same pattern:
+
+```rust
+// Before (line 766)
+    let message_json = serde_json::to_value(&response).unwrap_or_default();
+
+// After
+    let broadcast_response = MessageResponse { nonce: None, ..response.clone() };
+    let message_json = serde_json::to_value(&broadcast_response).unwrap_or_default();
+```
+
+- [ ] **Step 4: Update DB model comment**
+
+At `server/src/db/models.rs:130`:
+
+```rust
+// Before
+    /// Encryption nonce (for E2EE).
+
+// After
+    /// Client-generated nonce for optimistic message matching (also used as E2EE encryption nonce).
+```
+
+- [ ] **Step 5: Build and verify**
+
+Run: `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings`
+Expected: PASS
+
+---
+
+## Task 2: Server — Backpressure reset and last_typing cleanup
+
+**Files:**
+- Modify: `server/src/ws/mod.rs:1860-1861` (remove reset from Ok arm)
+- Modify: `server/src/ws/mod.rs:1881` (add reset at loop top)
+- Modify: `server/src/ws/mod.rs:1565` (add retain after insert)
+
+- [ ] **Step 1: Remove counter reset from try_forward! Ok arm**
+
+At `server/src/ws/mod.rs:1860-1861`, replace the body of the `Ok(())` match arm:
+
+```rust
+// Before (lines 1860-1861)
+                Ok(()) => {
+                    $drops = 0;
+                }
+
+// After
+                Ok(()) => {}
+```
+
+- [ ] **Step 2: Add counter reset at top of while loop**
+
+At `server/src/ws/mod.rs:1881-1882`, add the reset after the `while let` line:
+
+```rust
+// Before (lines 1881-1882)
+    while let Ok(message) = pubsub_stream.recv().await {
+        let channel_name = message.channel.to_string();
+
+// After
+    while let Ok(message) = pubsub_stream.recv().await {
+        // Reset backpressure counter at the start of each pubsub message.
+        // Only consecutive back-to-back Full errors across sequential messages
+        // trigger disconnect.
+        backpressure_drops = 0;
+
+        let channel_name = message.channel.to_string();
+```
+
+- [ ] **Step 3: Add last_typing retain after insert**
+
+At `server/src/ws/mod.rs:1565`, add the retain call after the existing insert:
+
+```rust
+// Before (line 1565)
+            msg_state.last_typing.insert(channel_id, now);
+
+// After
+            msg_state.last_typing.insert(channel_id, now);
+            msg_state.last_typing.retain(|_, last| now.duration_since(*last) < Duration::from_secs(2));
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings`
+Expected: PASS
+
+---
+
+## Task 3: Client — E2EE decryption tests
+
+**Files:**
+- Modify: `client/src/stores/__tests__/messages.test.ts:28-44` (add import)
+- Modify: `client/src/stores/__tests__/messages.test.ts:304` (add test block)
+
+- [ ] **Step 1: Add decryptMessageIfNeeded to imports**
+
+At `client/src/stores/__tests__/messages.test.ts:28-44`, add `decryptMessageIfNeeded` to the import block:
+
+```typescript
+// Before (lines 28-44)
+import {
+  messagesState,
+  setMessagesState,
+  loadMessages,
+  loadInitialMessages,
+  sendMessage,
+  addMessage,
+  updateMessage,
+  removeMessage,
+  getChannelMessages,
+  isLoadingMessages,
+  hasMoreMessages,
+  clearChannelMessages,
+  clearCurve25519KeyCache,
+  editingMessageId,
+  setEditingMessageId,
+} from "../messages";
+
+// After
+import {
+  messagesState,
+  setMessagesState,
+  loadMessages,
+  loadInitialMessages,
+  sendMessage,
+  addMessage,
+  updateMessage,
+  removeMessage,
+  getChannelMessages,
+  isLoadingMessages,
+  hasMoreMessages,
+  clearChannelMessages,
+  clearCurve25519KeyCache,
+  editingMessageId,
+  setEditingMessageId,
+  decryptMessageIfNeeded,
+} from "../messages";
+```
+
+- [ ] **Step 2: Add decryptMessageIfNeeded test block**
+
+At `client/src/stores/__tests__/messages.test.ts:304`, before the `describe("updateMessage"` block, add:
+
+```typescript
+  describe("decryptMessageIfNeeded", () => {
+    it("returns non-encrypted message unchanged", async () => {
+      const msg = createMessage("m1");
+      msg.encrypted = false;
+      msg.content = "hello";
+      const result = await decryptMessageIfNeeded(msg);
+      expect(result.content).toBe("hello");
+    });
+
+    it("returns placeholder for encrypted message without session", async () => {
+      const msg = createMessage("m1");
+      msg.encrypted = true;
+      msg.content = "ciphertext-blob";
+      const result = await decryptMessageIfNeeded(msg);
+      expect(result.content).toContain("[");
+    });
+  });
+```
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Run: `cd client && bun run test:run -- --reporter=verbose src/stores/__tests__/messages.test.ts`
+Expected: PASS — both new tests should pass (non-encrypted passthrough; encrypted without session returns placeholder)
+
+---
+
+## Task 4: Commit code fixes
+
+- [ ] **Step 1: Commit all code changes**
+
+```bash
+git add server/src/chat/messages.rs server/src/chat/uploads.rs server/src/ws/mod.rs server/src/db/models.rs client/src/stores/__tests__/messages.test.ts
+git commit -m "fix: address code review issues from PR #497
+
+Add nonce length validation (#[validate(length(max = 64))]),
+strip nonce from WS broadcasts to other users, fix backpressure
+counter reset logic, prune stale last_typing entries, update DB
+model comment, and add E2EE decryption tests."
+```
+
+---
+
+## Task 5: Docs — CHANGELOG and beta checklist
+
+**Files:**
+- Modify: `CHANGELOG.md:28` (add entries after existing Fixed items)
+- Modify: `docs/developer-guide/plans/2026-03-19-beta-checklist.md:48,57,87,98,168,170` (mark done, update table)
+
+- [ ] **Step 1: Add CHANGELOG entries**
+
+At `CHANGELOG.md`, after the last existing entry under `### Fixed` in `[Unreleased]` (after line 39 — `- DM unread aggregate query now uses correct \`dm_read_state\` table`), add:
+
+```markdown
+- Edited messages in E2EE channels now display decrypted content instead of ciphertext
+- Sending multiple messages rapidly no longer reorders them in the chat view
+- Slow WebSocket clients are now disconnected instead of blocking the message bus
+- Typing indicators no longer trigger database permission queries on every keystroke
+```
+
+- [ ] **Step 2: Mark 4 beta checklist items as done**
+
+In `docs/developer-guide/plans/2026-03-19-beta-checklist.md`:
+
+Line 48: `- [ ] **Permission resolution fires 3-5 queries per typing event**`
+→ `- [x] **Permission resolution fires 3-5 queries per typing event** (#497)`
+
+Line 57: `- [ ] **Slow WS clients block Redis pubsub task**`
+→ `- [x] **Slow WS clients block Redis pubsub task** (#497)`
+
+Line 87: `- [ ] **Message edit doesn't decrypt in E2EE channels**`
+→ `- [x] **Message edit doesn't decrypt in E2EE channels** (#497)`
+
+Line 98: `- [ ] **Optimistic message send race condition**`
+→ `- [x] **Optimistic message send race condition** (#497)`
+
+- [ ] **Step 3: Update progress summary table**
+
+At `docs/developer-guide/plans/2026-03-19-beta-checklist.md:168,170`:
+
+```markdown
+// Before
+| Important | 19 | 15 | 4 |
+...
+| **Total** | **48** | **22** | **26** |
+
+// After
+| Important | 19 | 19 | 0 |
+...
+| **Total** | **48** | **26** | **22** |
+```
+
+- [ ] **Step 4: Commit docs changes**
+
+```bash
+git add CHANGELOG.md docs/developer-guide/plans/2026-03-19-beta-checklist.md
+git commit -m "docs: update CHANGELOG and beta checklist for PR #497 fixes
+
+Add 4 Fixed entries to CHANGELOG [Unreleased] and mark all 4
+Important beta checklist items as done with (#497) references."
+```
+
+- [ ] **Step 5: Push and verify**
+
+Run: `git push`
+Expected: Branch updated on remote, PR #497 shows new commits.

--- a/docs/superpowers/specs/2026-04-01-beta-important-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-01-beta-important-fixes-design.md
@@ -1,0 +1,287 @@
+# Beta Important Fixes — Design Spec
+
+**Date:** 2026-04-01
+**Status:** Approved
+**Scope:** 4 remaining Important items from the 2026-03-19 beta checklist
+
+## Fix 1: Permission queries per typing event
+
+### Problem
+
+Every `Typing` and `StopTyping` WebSocket event fires `require_channel_access()`, which runs 4 sequential DB queries (channel lookup, guild membership + owner, @everyone role + member roles, channel overrides). No server-side throttle exists — clients can spam typing events.
+
+**Impact:** 4 DB queries per typing event per user. A room of 50 users typing = potentially 200 queries/sec just for typing indicators.
+
+**Files:**
+- `server/src/ws/mod.rs:1549-1594` — typing/stop-typing handlers
+- `server/src/ws/mod.rs:74-83` — `ClientMessageState` struct
+
+### Design
+
+Replace the permission check with a subscription set lookup and add a server-side throttle.
+
+#### Skip permission check for subscribed channels
+
+The WS connection already maintains `subscribed_channels: RwLock<HashSet<Uuid>>`. Users pass a permission check when they subscribe to a channel. If a user is subscribed, they have permission to type — no DB query needed.
+
+In the `Typing` handler (line 1549), replace:
+```rust
+let permission_result = crate::permissions::require_channel_access(&state.db, user_id, channel_id).await;
+if permission_result.is_err() { return Ok(()); }
+```
+
+With:
+```rust
+if !subscribed_channels.read().await.contains(&channel_id) {
+    return Ok(());
+}
+```
+
+Same change for `StopTyping` (line 1574).
+
+#### Add server-side typing throttle
+
+Add `last_typing: HashMap<Uuid, Instant>` to `ClientMessageState`. Before broadcasting a typing event, check if the last typing event for this channel was less than 1 second ago. If so, silently ignore.
+
+```rust
+let now = Instant::now();
+if let Some(last) = msg_state.last_typing.get(&channel_id) {
+    if now.duration_since(*last) < Duration::from_secs(1) {
+        return Ok(());
+    }
+}
+msg_state.last_typing.insert(channel_id, now);
+```
+
+The throttle applies only to `Typing` events. `StopTyping` always passes through — throttling it would cause ghost typing indicators (user stops typing within 1s of starting, but the `StopTyping` is dropped and other clients show them as still typing). Both events still require the subscription check.
+
+#### Trade-off
+
+If a user's permissions are revoked mid-session (role removed), they can still type until they reconnect. This is acceptable — Discord behaves the same way, and the actual messages they send still go through full permission checks.
+
+---
+
+## Fix 2: Slow WS clients block Redis pubsub task
+
+### Problem
+
+Each WS connection has a per-connection pubsub task that calls `params.tx.send(OutboundMsg::Event(event)).await` into a bounded mpsc channel (capacity 100). If the WebSocket sender is slow (network congestion), the channel fills and `tx.send().await` blocks the pubsub task. The entire Redis pubsub connection for that user becomes stuck — no more events are received.
+
+**Impact:** One slow client loses all real-time events. Messages delivered via Redis pubsub during the block are permanently lost.
+
+**Files:**
+- `server/src/ws/mod.rs:1792-1981` — `handle_pubsub()` function
+- Send call sites at lines ~1892, 1920, 1932, 1953, 1964, 1975
+
+### Design
+
+Replace blocking sends with `try_send()` and disconnect on sustained backpressure.
+
+#### Replace `tx.send().await` with `tx.try_send()`
+
+At all 6 send sites in `handle_pubsub()`, replace:
+```rust
+if params.tx.send(OutboundMsg::Event(event)).await.is_err() {
+    break;
+}
+```
+
+With:
+```rust
+match params.tx.try_send(OutboundMsg::Event(event)) {
+    Ok(()) => { backpressure_drops = 0; }
+    Err(mpsc::error::TrySendError::Full(_)) => {
+        backpressure_drops += 1;
+        if backpressure_drops > 10 {
+            warn!("Disconnecting slow WebSocket client (user {}): {} consecutive drops", user_id, backpressure_drops);
+            break;
+        }
+    }
+    Err(mpsc::error::TrySendError::Closed(_)) => {
+        break;
+    }
+}
+```
+
+#### Backpressure counter
+
+Declare `let mut backpressure_drops: u32 = 0;` at the top of the pubsub loop. Reset to 0 on every successful send. If 10 consecutive events are dropped (channel is persistently full), break out of the loop.
+
+Breaking triggers the existing cleanup: `pubsub_handle.abort()` and `sender_handle.abort()` (lines 1470-1471), which closes the WebSocket. The client's reconnect logic handles recovery.
+
+#### No changes to
+
+- Channel capacity (stays at 100)
+- Sender task (stays as-is, draining mpsc → WebSocket)
+- Connection setup or upgrade logic
+
+---
+
+## Fix 3: Message edit doesn't decrypt in E2EE channels
+
+### Problem
+
+Both browser and Tauri `message_edit` WebSocket handlers set `event.content` directly on the store without calling `decryptMessageIfNeeded()`. Edited messages in E2EE channels display encrypted ciphertext.
+
+**Impact:** Edited messages in encrypted DM channels show gibberish instead of decrypted content.
+
+**Files:**
+- `client/src/stores/websocket.ts:1011-1035` — browser `message_edit` handler
+- `client/src/stores/websocket.ts:278-307` — Tauri `message_edit` handler (callback is synchronous, must be made `async`)
+- `client/src/stores/messages.ts:58-133` — `decryptMessageIfNeeded()` function (currently not exported, must add `export`)
+
+### Design
+
+Check the existing message's `encrypted` flag and decrypt the edited content before updating the store.
+
+#### Browser handler (lines 1011-1035)
+
+Replace the current direct content assignment with:
+
+```typescript
+case "message_edit": {
+  const editMessages = messagesState.byChannel[event.channel_id];
+  if (editMessages) {
+    const editIndex = editMessages.findIndex(
+      (m) => m.id === event.message_id,
+    );
+    if (editIndex !== -1) {
+      const existing = editMessages[editIndex];
+      let newContent = event.content;
+
+      if (existing.encrypted) {
+        const temp = { ...existing, content: event.content };
+        const decrypted = await decryptMessageIfNeeded(temp);
+        newContent = decrypted.content;
+      }
+
+      setMessagesState(
+        "byChannel",
+        event.channel_id,
+        editIndex,
+        "content",
+        newContent,
+      );
+      setMessagesState(
+        "byChannel",
+        event.channel_id,
+        editIndex,
+        "edited_at",
+        event.edited_at,
+      );
+    }
+  }
+  break;
+}
+```
+
+The `case "message_edit"` block is inside an `async` handler (the `handleServerEvent` function), so `await` is valid.
+
+#### Export `decryptMessageIfNeeded`
+
+Add `export` to the function declaration at `messages.ts:58`:
+```typescript
+export async function decryptMessageIfNeeded(message: Message): Promise<Message> {
+```
+
+#### Tauri handler (lines 278-307)
+
+Same pattern. The callback at line 284 is currently synchronous — change to `async (event) => { ... }` to support `await decryptMessageIfNeeded()`.
+
+#### No server changes
+
+The server already sends the raw (encrypted) content in the `message_edit` event. Decryption is the client's responsibility, same as for `message_new`.
+
+---
+
+## Fix 4: Optimistic message send race condition
+
+### Problem
+
+`addMessage()` uses `findIndex(m => m.id.startsWith("pending:"))` to find a pending message to replace with the real server-confirmed message. This finds the *oldest* pending message, not the one that corresponds to the arriving confirmation. Rapid sends cause message reordering:
+
+1. User sends "Hello" → `[pending:UUID-A]`
+2. User sends "World" → `[pending:UUID-A, pending:UUID-B]`
+3. Server confirms "World" first → `addMessage()` finds `pending:UUID-A` (wrong!) → replaces it
+4. Messages appear in wrong order
+
+**Impact:** Rapid message sends cause visible message reordering in the UI.
+
+**Files:**
+- `client/src/stores/messages.ts:329-377` — `sendMessage()` (optimistic creation + HTTP replace)
+- `client/src/stores/messages.ts:405-434` — `addMessage()` (WebSocket echo handling)
+- `client/src/lib/types.ts:276-294` — `Message` type
+- `client/src/lib/tauri.ts:1225-1280` — `sendMessageWithStatus()`
+
+### Design
+
+Use the existing `nonce` field for exact pending-to-real matching.
+
+#### Add `nonce` to TypeScript Message type
+
+In `client/src/lib/types.ts`, add to the `Message` interface:
+```typescript
+nonce?: string | null;
+```
+
+The server already stores `nonce: Option<String>` in the DB and returns it in the `Message` struct (both HTTP response and WebSocket broadcast).
+
+#### Generate nonce on every message send
+
+In `sendMessage()` (messages.ts ~line 329), generate a nonce and use it for both the optimistic message and the server request:
+
+```typescript
+const nonce = crypto.randomUUID();
+const pendingId = `pending:${nonce}`;
+
+const optimisticMessage: Message = {
+  id: pendingId,
+  nonce,
+  // ... rest unchanged
+};
+```
+
+Pass the nonce to the server via the existing `options.nonce` parameter:
+```typescript
+const { message, status } = await tauri.sendMessageWithStatus(
+  channelId,
+  trimmedContent,
+  { nonce },
+);
+```
+
+#### Match by nonce in `addMessage()`
+
+Replace line 425:
+```typescript
+const pendingIdx = existing.findIndex((m) => m.id.startsWith("pending:"));
+```
+
+With:
+```typescript
+const pendingIdx = processedMessage.nonce
+  ? existing.findIndex(
+      (m) => m.id.startsWith("pending:") && m.nonce === processedMessage.nonce,
+    )
+  : -1;
+```
+
+If no nonce match (message from another user, or no nonce), fall through to the append path. This means own-authored messages arriving without a nonce (e.g., from an older client) skip pending replacement in `addMessage()` and append normally. The HTTP response handler in `sendMessage()` (line 370) still cleans up the pending entry by exact `pendingId`, so a transient duplicate may appear for one round-trip but is resolved immediately.
+
+#### Server changes: none
+
+The server already:
+- Accepts `nonce: Option<String>` in the create message request
+- Stores it in the `messages` table
+- Returns it in the `Message` response and WebSocket broadcast
+
+---
+
+## Changes Summary
+
+| Fix | Server | Client | Complexity |
+|-----|--------|--------|------------|
+| 1. Typing permission bypass | `ws/mod.rs` — replace permission check with subscription check, add throttle map | None | Low |
+| 2. WS backpressure | `ws/mod.rs` — `try_send()` + backpressure counter at 6 call sites | None | Low |
+| 3. E2EE message edit | None | `websocket.ts` — decrypt edited content in both browser and Tauri handlers | Low |
+| 4. Optimistic send race | None | `messages.ts` — generate nonce, match by nonce; `types.ts` — add nonce field | Low |

--- a/docs/superpowers/specs/2026-04-02-pr497-review-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-02-pr497-review-fixes-design.md
@@ -1,0 +1,199 @@
+# PR #497 Review Fixes — Design Spec
+
+**Date:** 2026-04-02
+**Status:** Draft
+**Scope:** 8 issues found during code review of PR #497 (fix/beta-important-items)
+
+## Overview
+
+PR #497 implements 4 Important beta fixes. Code review found 8 issues scoring >= 50/100 confidence. This spec addresses all 8, split into two commits: code fixes and docs/process updates.
+
+## Commit 1: Code Fixes
+
+### Fix 1a: Nonce length validation
+
+**Problem:** `CreateMessageRequest.nonce` (`server/src/chat/messages.rs:306`) has no `#[validate]` attribute. The DB column is `VARCHAR(64)`. A nonce > 64 chars causes a PostgreSQL error surfaced as HTTP 500 instead of 400.
+
+**Fix:** Add `#[validate(length(max = 64))]` to the `nonce` field. The struct already derives `Validate` and `body.validate()` runs in the handler.
+
+**File:** `server/src/chat/messages.rs:306`
+
+```rust
+// Before
+pub nonce: Option<String>,
+
+// After
+#[validate(length(max = 64))]
+pub nonce: Option<String>,
+```
+
+### Fix 1b: Backpressure counter reset logic
+
+**Problem:** `backpressure_drops` in `server/src/ws/mod.rs:1880` is shared across all 6 pubsub event branches. A successful send of any event type (e.g., presence) resets the counter to 0, forgiving prior dropped channel messages. In mixed-traffic scenarios, a slow client can drop many messages without hitting the 10-drop disconnect threshold.
+
+**Fix:** Move the counter reset from the `Ok(())` arm of `try_forward!` to the top of the `while let` loop. Each pubsub message starts fresh — only consecutive back-to-back failures across sequential messages trigger disconnect.
+
+**File:** `server/src/ws/mod.rs:1857-1881`
+
+```rust
+// try_forward! macro — remove the reset from Ok
+macro_rules! try_forward {
+    ($tx:expr, $event:expr, $drops:ident, $user_id:expr) => {
+        match $tx.try_send(OutboundMsg::Event($event)) {
+            Ok(()) => {
+                // Don't reset here — reset at top of loop instead
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                $drops += 1;
+                if $drops > 10 {
+                    warn!(
+                        "Disconnecting slow WebSocket client (user {}): {} consecutive drops",
+                        $user_id, $drops
+                    );
+                    break;
+                }
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                break;
+            }
+        }
+    };
+}
+
+let mut backpressure_drops: u32 = 0;
+while let Ok(message) = pubsub_stream.recv().await {
+    // Reset backpressure counter at the start of each pubsub message.
+    // Only consecutive back-to-back Full errors across sequential messages
+    // trigger disconnect — a successful send on the previous message resets.
+    backpressure_drops = 0;
+
+    let channel_name = message.channel.to_string();
+    // ... rest of handler
+}
+```
+
+### Fix 1c: Prune stale `last_typing` entries
+
+**Problem:** `ClientMessageState.last_typing` (`server/src/ws/mod.rs:84`) is a `HashMap<Uuid, Instant>` that grows unboundedly — entries are inserted on typing events but never removed.
+
+**Fix:** After each insert, `retain` entries younger than 2 seconds. The throttle window is 1 second, so anything older is guaranteed stale. Piggybacks on the existing typing handler — no background task needed.
+
+**File:** `server/src/ws/mod.rs:1565`
+
+```rust
+msg_state.last_typing.insert(channel_id, now);
+msg_state.last_typing.retain(|_, last| now.duration_since(*last) < Duration::from_secs(2));
+```
+
+### Fix 1d: Update DB model comment
+
+**Problem:** `server/src/db/models.rs:130` says `/// Encryption nonce (for E2EE).` but nonce is now used for all messages as an optimistic-matching token.
+
+**Fix:** Update the comment to match the `MessageResponse` doc.
+
+**File:** `server/src/db/models.rs:130`
+
+```rust
+// Before
+/// Encryption nonce (for E2EE).
+
+// After
+/// Client-generated nonce for optimistic message matching (also used as E2EE encryption nonce).
+```
+
+### Fix 1e: Strip nonce from broadcast
+
+**Problem:** The sender's nonce (a UUID) is included in `MessageNew` WebSocket broadcasts to all channel members. Other users don't need it — the client only uses nonces for its own pending messages.
+
+**Fix:** After building the `MessageResponse`, serialize a copy with `nonce: None` for the broadcast. The sender still receives the nonce in their HTTP response. Apply to both `messages.rs` (regular + thread reply) and `uploads.rs` (file upload).
+
+**File:** `server/src/chat/messages.rs:1060-1061`
+
+```rust
+// Before
+let message_json = serde_json::to_value(&response).unwrap_or_default();
+
+// After
+let broadcast_response = MessageResponse { nonce: None, ..response.clone() };
+let message_json = serde_json::to_value(&broadcast_response).unwrap_or_default();
+```
+
+Same pattern in `server/src/chat/uploads.rs:766`.
+
+Note: This single replacement at line 1061 covers both `MessageNew` and `ThreadReplyNew` broadcasts, since `message_json` is computed before the `if/else` branch. `MessageResponse` already derives `Clone`.
+
+### Fix 1f: E2EE edit decryption test
+
+**Problem:** The new `decryptMessageIfNeeded` export is called from `websocket.ts` in two E2EE edit handlers, but no tests cover this path.
+
+**Fix:** Add a test in `client/src/stores/__tests__/messages.test.ts` that verifies `decryptMessageIfNeeded` correctly handles an encrypted-flagged message. Since the actual Megolm decryption requires crypto setup, test the two observable behaviors:
+1. Non-encrypted message passes through unchanged
+2. Encrypted message with no session returns the `[Unable to decrypt message]` placeholder
+
+**File:** `client/src/stores/__tests__/messages.test.ts`
+
+Add `decryptMessageIfNeeded` to the existing import from `"../messages"` (lines 28-44). The existing `e2eeStore` mock provides `status: vi.fn(() => ({ initialized: false }))`, which causes the early-exit branch for encrypted messages without a session — no additional mock setup needed.
+
+```typescript
+describe("decryptMessageIfNeeded", () => {
+  it("returns non-encrypted message unchanged", async () => {
+    const msg = createMessage("m1");
+    msg.encrypted = false;
+    msg.content = "hello";
+    const result = await decryptMessageIfNeeded(msg);
+    expect(result.content).toBe("hello");
+  });
+
+  it("returns placeholder for encrypted message without session", async () => {
+    const msg = createMessage("m1");
+    msg.encrypted = true;
+    msg.content = "ciphertext-blob";
+    const result = await decryptMessageIfNeeded(msg);
+    expect(result.content).toContain("[");
+  });
+});
+```
+
+## Commit 2: Docs/Process
+
+### Fix 2a: CHANGELOG.md entries
+
+Add under `### Fixed` in `[Unreleased]`:
+
+```markdown
+- Edited messages in E2EE channels now display decrypted content instead of ciphertext
+- Sending multiple messages rapidly no longer reorders them in the chat view
+- Slow WebSocket clients are now disconnected instead of blocking the message bus
+- Typing indicators no longer trigger database permission queries on every keystroke
+```
+
+### Fix 2b: Beta checklist updates
+
+In `docs/developer-guide/plans/2026-03-19-beta-checklist.md`:
+
+1. Mark the 4 Important items as `[x]` with `(#497)`:
+   - `[x] Permission resolution fires 3-5 queries per typing event (#497)`
+   - `[x] Slow WS clients block Redis pubsub task (#497)`
+   - `[x] Message edit doesn't decrypt in E2EE channels (#497)`
+   - `[x] Optimistic message send race condition (#497)`
+
+2. Update progress summary table: Important `19 | 19 | 0`, Total `48 | 26 | 22`
+
+## File Map
+
+### Commit 1 files
+| File | Change |
+|------|--------|
+| `server/src/chat/messages.rs:306` | Add `#[validate(length(max = 64))]` to nonce |
+| `server/src/chat/messages.rs:1060-1061` | Strip nonce from broadcast JSON |
+| `server/src/chat/uploads.rs:766` | Strip nonce from broadcast JSON |
+| `server/src/ws/mod.rs:1857-1881` | Fix backpressure reset logic |
+| `server/src/ws/mod.rs:1565` | Add `last_typing` retain after insert |
+| `server/src/db/models.rs:130` | Update comment |
+| `client/src/stores/__tests__/messages.test.ts` | Add decryptMessageIfNeeded tests |
+
+### Commit 2 files
+| File | Change |
+|------|--------|
+| `CHANGELOG.md` | Add 4 entries under `### Fixed` |
+| `docs/developer-guide/plans/2026-03-19-beta-checklist.md` | Mark 4 items done, update table |

--- a/server/src/chat/messages.rs
+++ b/server/src/chat/messages.rs
@@ -1037,7 +1037,7 @@ pub async fn create(
         detect_mention_type(&message.content, Some(&author.username))
     };
 
-    let response = MessageResponse {
+    let mut response = MessageResponse {
         id: message.id,
         channel_id: message.channel_id,
         author: author.clone(),
@@ -1055,12 +1055,14 @@ pub async fn create(
         thread_info: None,
         pinned: false,
         message_type: message.message_type,
-        nonce: message.nonce,
+        nonce: None,
     };
 
-    // Broadcast via Redis pub-sub
-    let broadcast_response = MessageResponse { nonce: None, ..response.clone() };
-    let message_json = serde_json::to_value(&broadcast_response).unwrap_or_default();
+    // Broadcast via Redis pub-sub (nonce excluded — it's only for the sender)
+    let message_json = serde_json::to_value(&response).unwrap_or_default();
+
+    // Set nonce for the HTTP response to the sender
+    response.nonce = message.nonce;
 
     if let Some(parent_id) = body.parent_id {
         // Thread reply: broadcast ThreadReplyNew with updated thread info

--- a/server/src/chat/messages.rs
+++ b/server/src/chat/messages.rs
@@ -216,6 +216,9 @@ pub struct MessageResponse {
     pub pinned: bool,
     /// Message type: "user" for normal messages, "system" for system events.
     pub message_type: String,
+    /// Client-generated nonce for optimistic message matching.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nonce: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
@@ -686,6 +689,7 @@ pub async fn create(
                         thread_info: None,
                         pinned: false,
                         message_type: "user".to_string(),
+                        nonce: None,
                     };
 
                     let message_json = serde_json::to_value(&response).unwrap_or_default();
@@ -938,6 +942,7 @@ pub async fn create(
                             thread_info: None,
                             pinned: false,
                             message_type: "user".to_string(),
+                            nonce: body.nonce.clone(),
                         };
 
                         return Ok((StatusCode::ACCEPTED, Json(accepted)));
@@ -1049,6 +1054,7 @@ pub async fn create(
         thread_info: None,
         pinned: false,
         message_type: message.message_type,
+        nonce: message.nonce,
     };
 
     // Broadcast via Redis pub-sub
@@ -1265,6 +1271,7 @@ pub async fn update(
         .await
         .unwrap_or(false),
         message_type: message.message_type.clone(),
+        nonce: None,
     };
 
     // Broadcast edit via Redis pub-sub
@@ -1535,6 +1542,7 @@ pub async fn build_message_responses(
                 thread_info,
                 pinned: pinned_ids.contains(&msg.id),
                 message_type: msg.message_type.clone(),
+                nonce: None,
             }
         })
         .collect();

--- a/server/src/chat/messages.rs
+++ b/server/src/chat/messages.rs
@@ -303,6 +303,7 @@ pub struct CreateMessageRequest {
     pub content: String,
     #[serde(default)]
     pub encrypted: bool,
+    #[validate(length(max = 64))]
     pub nonce: Option<String>,
     pub reply_to: Option<Uuid>,
     pub parent_id: Option<Uuid>,
@@ -1058,7 +1059,8 @@ pub async fn create(
     };
 
     // Broadcast via Redis pub-sub
-    let message_json = serde_json::to_value(&response).unwrap_or_default();
+    let broadcast_response = MessageResponse { nonce: None, ..response.clone() };
+    let message_json = serde_json::to_value(&broadcast_response).unwrap_or_default();
 
     if let Some(parent_id) = body.parent_id {
         // Thread reply: broadcast ThreadReplyNew with updated thread info

--- a/server/src/chat/uploads.rs
+++ b/server/src/chat/uploads.rs
@@ -759,6 +759,7 @@ pub async fn upload_message_with_file(
         reactions: None,
         pinned: false,
         message_type: message.message_type,
+        nonce: message.nonce,
     };
 
     // Broadcast new message via Redis pub-sub

--- a/server/src/chat/uploads.rs
+++ b/server/src/chat/uploads.rs
@@ -741,7 +741,7 @@ pub async fn upload_message_with_file(
 
     let mention_type = detect_mention_type(&message.content, Some(&author.username));
 
-    let response = MessageResponse {
+    let mut response = MessageResponse {
         id: message.id,
         channel_id: message.channel_id,
         author: author.clone(),
@@ -759,12 +759,14 @@ pub async fn upload_message_with_file(
         reactions: None,
         pinned: false,
         message_type: message.message_type,
-        nonce: message.nonce,
+        nonce: None,
     };
 
-    // Broadcast new message via Redis pub-sub
-    let broadcast_response = MessageResponse { nonce: None, ..response.clone() };
-    let message_json = serde_json::to_value(&broadcast_response).unwrap_or_default();
+    // Broadcast new message via Redis pub-sub (nonce excluded — it's only for the sender)
+    let message_json = serde_json::to_value(&response).unwrap_or_default();
+
+    // Set nonce for the HTTP response to the sender
+    response.nonce = message.nonce;
     if let Err(e) = broadcast_to_channel(
         &state.redis,
         channel_id,

--- a/server/src/chat/uploads.rs
+++ b/server/src/chat/uploads.rs
@@ -763,7 +763,8 @@ pub async fn upload_message_with_file(
     };
 
     // Broadcast new message via Redis pub-sub
-    let message_json = serde_json::to_value(&response).unwrap_or_default();
+    let broadcast_response = MessageResponse { nonce: None, ..response.clone() };
+    let message_json = serde_json::to_value(&broadcast_response).unwrap_or_default();
     if let Err(e) = broadcast_to_channel(
         &state.redis,
         channel_id,

--- a/server/src/db/models.rs
+++ b/server/src/db/models.rs
@@ -127,7 +127,7 @@ pub struct Message {
     pub content: String,
     /// Whether the message is E2EE encrypted.
     pub encrypted: bool,
-    /// Encryption nonce (for E2EE).
+    /// Client-generated nonce for optimistic message matching (also used as E2EE encryption nonce).
     pub nonce: Option<String>,
     /// Message ID this is replying to.
     pub reply_to: Option<Uuid>,

--- a/server/src/ws/mod.rs
+++ b/server/src/ws/mod.rs
@@ -1854,6 +1854,30 @@ async fn handle_pubsub(redis: Client, params: HandlePubsubParams) {
         }
     }
 
+    macro_rules! try_forward {
+        ($tx:expr, $event:expr, $drops:ident, $user_id:expr) => {
+            match $tx.try_send(OutboundMsg::Event($event)) {
+                Ok(()) => {
+                    $drops = 0;
+                }
+                Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                    $drops += 1;
+                    if $drops > 10 {
+                        warn!(
+                            "Disconnecting slow WebSocket client (user {}): {} consecutive drops",
+                            $user_id, $drops
+                        );
+                        break;
+                    }
+                }
+                Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                    break;
+                }
+            }
+        };
+    }
+
+    let mut backpressure_drops: u32 = 0;
     while let Ok(message) = pubsub_stream.recv().await {
         let channel_name = message.channel.to_string();
 
@@ -1891,10 +1915,8 @@ async fn handle_pubsub(redis: Client, params: HandlePubsubParams) {
                             };
                             drop(blocked);
 
-                            if !should_filter
-                                && params.tx.send(OutboundMsg::Event(event)).await.is_err()
-                            {
-                                break;
+                            if !should_filter {
+                                try_forward!(params.tx, event, backpressure_drops, params.user_id);
                             }
                         }
                     }
@@ -1920,9 +1942,7 @@ async fn handle_pubsub(redis: Client, params: HandlePubsubParams) {
                         _ => {}
                     }
 
-                    if params.tx.send(OutboundMsg::Event(event)).await.is_err() {
-                        break;
-                    }
+                    try_forward!(params.tx, event, backpressure_drops, params.user_id);
                 }
             }
         }
@@ -1932,9 +1952,7 @@ async fn handle_pubsub(redis: Client, params: HandlePubsubParams) {
             if *params.admin_subscribed.read().await {
                 if let Some(payload) = message.value.as_str() {
                     if let Ok(event) = serde_json::from_str::<ServerEvent>(&payload) {
-                        if params.tx.send(OutboundMsg::Event(event)).await.is_err() {
-                            break;
-                        }
+                        try_forward!(params.tx, event, backpressure_drops, params.user_id);
                     }
                 }
             }
@@ -1953,8 +1971,8 @@ async fn handle_pubsub(redis: Client, params: HandlePubsubParams) {
                         _ => false,
                     };
 
-                    if !should_filter && params.tx.send(OutboundMsg::Event(event)).await.is_err() {
-                        break;
+                    if !should_filter {
+                        try_forward!(params.tx, event, backpressure_drops, params.user_id);
                     }
                 }
             }
@@ -1964,9 +1982,7 @@ async fn handle_pubsub(redis: Client, params: HandlePubsubParams) {
             // Forward all user-targeted events (read sync, etc.)
             if let Some(payload) = message.value.as_str() {
                 if let Ok(event) = serde_json::from_str::<ServerEvent>(&payload) {
-                    if params.tx.send(OutboundMsg::Event(event)).await.is_err() {
-                        break;
-                    }
+                    try_forward!(params.tx, event, backpressure_drops, params.user_id);
                 }
             }
         }
@@ -1975,9 +1991,7 @@ async fn handle_pubsub(redis: Client, params: HandlePubsubParams) {
             // Forward guild/member patch events to all guild members
             if let Some(payload) = message.value.as_str() {
                 if let Ok(event) = serde_json::from_str::<ServerEvent>(&payload) {
-                    if params.tx.send(OutboundMsg::Event(event)).await.is_err() {
-                        break;
-                    }
+                    try_forward!(params.tx, event, backpressure_drops, params.user_id);
                 }
             }
         }

--- a/server/src/ws/mod.rs
+++ b/server/src/ws/mod.rs
@@ -1858,7 +1858,9 @@ async fn handle_pubsub(redis: Client, params: HandlePubsubParams) {
     macro_rules! try_forward {
         ($tx:expr, $event:expr, $drops:ident, $user_id:expr) => {
             match $tx.try_send(OutboundMsg::Event($event)) {
-                Ok(()) => {}
+                Ok(()) => {
+                    $drops = 0;
+                }
                 Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
                     $drops += 1;
                     if $drops > 10 {
@@ -1876,14 +1878,8 @@ async fn handle_pubsub(redis: Client, params: HandlePubsubParams) {
         };
     }
 
-    #[allow(unused_assignments)]
     let mut backpressure_drops: u32 = 0;
     while let Ok(message) = pubsub_stream.recv().await {
-        // Reset backpressure counter at the start of each pubsub message.
-        // Only consecutive back-to-back Full errors across sequential messages
-        // trigger disconnect.
-        backpressure_drops = 0;
-
         let channel_name = message.channel.to_string();
 
         // Handle channel events (channel:{uuid})

--- a/server/src/ws/mod.rs
+++ b/server/src/ws/mod.rs
@@ -21,7 +21,7 @@
 pub mod bot_events;
 pub mod bot_gateway;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -80,6 +80,8 @@ pub struct ClientMessageState {
     pub activity: ActivityState,
     /// Custom status rate limiting and deduplication state.
     pub custom_status: CustomStatusState,
+    /// Per-channel typing throttle (`channel_id` → last typing broadcast time).
+    pub last_typing: HashMap<Uuid, Instant>,
 }
 
 /// WebSocket protocol header name for authentication.
@@ -1547,17 +1549,20 @@ pub async fn handle_client_message(
         }
 
         ClientEvent::Typing { channel_id } => {
-            // Check if user has VIEW_CHANNEL permission
-            let permission_result: Result<_, crate::permissions::PermissionError> =
-                crate::permissions::require_channel_access(&state.db, user_id, channel_id).await;
-
-            if permission_result.is_err() {
-                warn!(
-                    "User {} attempted to send typing indicator for channel {} without permission",
-                    user_id, channel_id
-                );
-                return Ok(()); // Silently ignore unauthorized typing indicator
+            // Only allow typing in channels the user is subscribed to
+            // (subscription is already permission-gated)
+            if !subscribed_channels.read().await.contains(&channel_id) {
+                return Ok(());
             }
+
+            // Server-side throttle: max 1 typing event per second per channel
+            let now = Instant::now();
+            if let Some(last) = msg_state.last_typing.get(&channel_id) {
+                if now.duration_since(*last) < Duration::from_secs(1) {
+                    return Ok(());
+                }
+            }
+            msg_state.last_typing.insert(channel_id, now);
 
             // Broadcast typing indicator
             broadcast_to_channel(
@@ -1572,14 +1577,12 @@ pub async fn handle_client_message(
         }
 
         ClientEvent::StopTyping { channel_id } => {
-            // Check if user has VIEW_CHANNEL permission
-            let permission_result: Result<_, crate::permissions::PermissionError> =
-                crate::permissions::require_channel_access(&state.db, user_id, channel_id).await;
-
-            if permission_result.is_err() {
-                warn!("User {} attempted to send stop typing indicator for channel {} without permission", user_id, channel_id);
-                return Ok(()); // Silently ignore unauthorized stop typing indicator
+            // Only allow in channels the user is subscribed to
+            if !subscribed_channels.read().await.contains(&channel_id) {
+                return Ok(());
             }
+
+            // No throttle on StopTyping — throttling it causes ghost typing indicators
 
             // Broadcast stop typing
             broadcast_to_channel(

--- a/server/src/ws/mod.rs
+++ b/server/src/ws/mod.rs
@@ -1563,6 +1563,7 @@ pub async fn handle_client_message(
                 }
             }
             msg_state.last_typing.insert(channel_id, now);
+            msg_state.last_typing.retain(|_, last| now.duration_since(*last) < Duration::from_secs(2));
 
             // Broadcast typing indicator
             broadcast_to_channel(
@@ -1857,9 +1858,7 @@ async fn handle_pubsub(redis: Client, params: HandlePubsubParams) {
     macro_rules! try_forward {
         ($tx:expr, $event:expr, $drops:ident, $user_id:expr) => {
             match $tx.try_send(OutboundMsg::Event($event)) {
-                Ok(()) => {
-                    $drops = 0;
-                }
+                Ok(()) => {}
                 Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
                     $drops += 1;
                     if $drops > 10 {
@@ -1877,8 +1876,14 @@ async fn handle_pubsub(redis: Client, params: HandlePubsubParams) {
         };
     }
 
+    #[allow(unused_assignments)]
     let mut backpressure_drops: u32 = 0;
     while let Ok(message) = pubsub_stream.recv().await {
+        // Reset backpressure counter at the start of each pubsub message.
+        // Only consecutive back-to-back Full errors across sequential messages
+        // trigger disconnect.
+        backpressure_drops = 0;
+
         let channel_name = message.channel.to_string();
 
         // Handle channel events (channel:{uuid})


### PR DESCRIPTION
## Summary

Fixes the 4 remaining **Important** items from the beta checklist:

- **Typing event permission queries** — replaced 4 DB queries per typing event with a subscription-set check + 1s server-side throttle per channel
- **WS pubsub backpressure** — replaced blocking `send()` with `try_send()` and a `try_forward!` macro that disconnects slow clients after 10 consecutive drops
- **E2EE message edit decryption** — edited messages in encrypted channels are now decrypted before display (both browser WebSocket and Tauri event handlers)
- **Nonce-based optimistic message matching** — `sendMessage` generates a nonce echoed back by the server, so confirmed messages replace the correct pending placeholder instead of always replacing the oldest one

## Changes

### Server (`server/`)
- `ws/mod.rs`: Typing/StopTyping use `subscribed_channels` set instead of `require_channel_access` DB queries; 1s per-channel throttle via `last_typing` HashMap; `try_forward!` macro for backpressure on all 6 pubsub send sites
- `chat/messages.rs`: Added `nonce` field to `MessageResponse`, echoed from request body on create
- `chat/uploads.rs`: Pass through `nonce` on file upload messages

### Client (`client/`)
- `stores/messages.ts`: Exported `decryptMessageIfNeeded`; nonce generation in `sendMessage`; nonce-based pending message matching in `addMessage`
- `stores/websocket.ts`: Decrypt edited messages in E2EE channels (both browser and Tauri handlers)
- `lib/types.ts`: Added `nonce` field to `Message` interface
- `src-tauri/src/commands/chat.rs`: Pass `nonce` through `send_message` Tauri command
- `stores/__tests__/messages.test.ts`: Tests for nonce-based matching (correct replacement, no interference with other users' messages)

### Docs
- Design spec and implementation plan for all 4 fixes
- Restored beta checklist lost during docs reorganization

## Test plan
- [x] `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings` passes
- [x] `bun run test:run` passes (including new nonce-matching tests)
- [ ] Manual: send messages in E2EE channel, edit one, verify decrypted content displays
- [ ] Manual: send rapid messages, verify ordering is preserved (no reordering)
- [ ] Manual: verify typing indicators still appear in channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)