### PR TITLE
fix: clear E2EE sessions on logout and encode returnUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Slow WebSocket clients are now disconnected instead of blocking the message bus
 - Typing indicators no longer trigger database permission queries on every keystroke
 
+### Security
+- E2EE Megolm session cache is now cleared on logout — prevents stale session keys from persisting
+- `returnUrl` parameter is now URL-encoded to prevent query string injection
+
 ### Added
 - Password visibility toggle on all password fields (login, register, reset password)
 - Skip-to-content keyboard navigation link

--- a/client/src-tauri/src/commands/auth.rs
+++ b/client/src-tauri/src/commands/auth.rs
@@ -300,6 +300,9 @@ pub async fn logout(state: State<'_, AppState>) -> Result<(), String> {
         // Keep server_url for potential re-login
     }
 
+    // Clear crypto state — drops Megolm sessions, Olm account, closes SQLite
+    *state.crypto.lock().await = None;
+
     // Clear stored credentials
     if let Some(url) = server_url {
         let _ = clear_refresh_token(&url);

--- a/client/src/components/auth/AuthGuard.tsx
+++ b/client/src/components/auth/AuthGuard.tsx
@@ -26,7 +26,7 @@ const AuthGuard: Component<AuthGuardProps> = (props) => {
     if (authState.isInitialized && !isAuthenticated()) {
       // Store the intended destination for redirect after login
       const returnUrl = location.pathname;
-      navigate(`/login${returnUrl !== "/" ? `?returnUrl=${returnUrl}` : ""}`, {
+      navigate(`/login${returnUrl !== "/" ? `?returnUrl=${encodeURIComponent(returnUrl)}` : ""}`, {
         replace: true,
       });
     }

--- a/client/src/stores/auth.ts
+++ b/client/src/stores/auth.ts
@@ -21,6 +21,7 @@ import {
 } from "./presence";
 import { initPreferences } from "./preferences";
 import { clearAllDrafts, cleanupDrafts } from "./drafts";
+import { resetE2EEState } from "./e2ee";
 import { showToast } from "@/components/ui/Toast";
 
 // Auth state interface
@@ -407,6 +408,7 @@ export async function logout(): Promise<void> {
 
   try {
     await tauri.logout();
+    resetE2EEState();
     setAuthState({
       user: null,
       isLoading: false,

--- a/client/src/stores/auth.ts
+++ b/client/src/stores/auth.ts
@@ -416,6 +416,7 @@ export async function logout(): Promise<void> {
     });
   } catch (err) {
     console.error("[Auth] Logout failed:", err);
+    resetE2EEState();
     const error = err instanceof Error ? err.message : String(err);
     setAuthState({
       user: null,

--- a/client/src/stores/e2ee.ts
+++ b/client/src/stores/e2ee.ts
@@ -240,6 +240,13 @@ async function addInboundSession(
   }
 }
 
+/** Reset all E2EE state signals to defaults. Called on logout. */
+export function resetE2EEState(): void {
+  setStatus({ initialized: false, device_id: null, has_identity_keys: false });
+  setIsInitializing(false);
+  setError(null);
+}
+
 // Export the store
 export const e2eeStore = {
   // Reactive getters

--- a/client/src/views/Login.tsx
+++ b/client/src/views/Login.tsx
@@ -80,8 +80,9 @@ const Login: Component = () => {
       // Navigate to returnUrl if valid (relative path only), otherwise home
       const raw = searchParams.returnUrl;
       const returnUrl = Array.isArray(raw) ? raw[0] : raw;
-      const target = returnUrl && returnUrl.startsWith("/") && !returnUrl.startsWith("//")
-        ? returnUrl
+      const decoded = returnUrl ? decodeURIComponent(returnUrl) : null;
+      const target = decoded && decoded.startsWith("/") && !decoded.startsWith("//")
+        ? decoded
         : "/";
       navigate(target, { replace: true });
     } catch (err) {

--- a/docs/developer-guide/plans/2026-03-19-beta-checklist.md
+++ b/docs/developer-guide/plans/2026-03-19-beta-checklist.md
@@ -119,8 +119,8 @@
 
 ### Security & Data Hygiene
 
-- [ ] E2EE Megolm session cache never cleared on logout — `client/src/stores/messages.ts:618`
-- [ ] `returnUrl` injection risk when feature is implemented — validate relative URL — `client/src/components/auth/AuthGuard.tsx:28-30`
+- [x] E2EE Megolm session cache never cleared on logout — `client/src/stores/messages.ts:618`
+- [x] `returnUrl` injection risk when feature is implemented — validate relative URL — `client/src/components/auth/AuthGuard.tsx:28-30`
 - [ ] TURN credentials are static/long-lived — consider time-limited HMAC credentials — `server/src/voice/handlers.rs:47-66`
 - [ ] No virus scanning for file uploads (MIME + magic bytes is current defense) — `server/src/chat/uploads.rs`
 

--- a/docs/superpowers/plans/2026-04-02-beta-security-quick.md
+++ b/docs/superpowers/plans/2026-04-02-beta-security-quick.md
@@ -1,0 +1,178 @@
+# Beta Security Quick Fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix Megolm session cache leak on logout and `returnUrl` encoding vulnerability.
+
+**Architecture:** Two independent client-side fixes. Fix 1 clears the crypto manager in Tauri's logout command and resets E2EE frontend signals. Fix 2 adds `encodeURIComponent`/`decodeURIComponent` to the auth redirect flow.
+
+**Tech Stack:** Rust (Tauri), TypeScript/Solid.js (client)
+
+**Spec:** `docs/superpowers/specs/2026-04-02-beta-security-fixes-design.md`
+
+---
+
+## File Map
+
+| File | Responsibility |
+|------|---------------|
+| `client/src-tauri/src/commands/auth.rs` | Drop CryptoManager on logout |
+| `client/src/stores/e2ee.ts` | Add `resetE2EEState()` export |
+| `client/src/stores/auth.ts` | Call `resetE2EEState()` on logout |
+| `client/src/components/auth/AuthGuard.tsx` | Encode `returnUrl` |
+| `client/src/views/Login.tsx` | Decode `returnUrl` before validation |
+
+---
+
+## Task 1: Megolm session cache cleanup on logout
+
+**Files:**
+- Modify: `client/src-tauri/src/commands/auth.rs:301` (drop crypto state)
+- Modify: `client/src/stores/e2ee.ts:265` (add `resetE2EEState` export)
+- Modify: `client/src/stores/auth.ts:409` (call reset after logout)
+
+- [ ] **Step 1: Add `resetE2EEState` to e2ee store**
+
+At `client/src/stores/e2ee.ts`, add a new function before the `e2eeStore` export (before line 244):
+
+```typescript
+/** Reset all E2EE state signals to defaults. Called on logout. */
+export function resetE2EEState(): void {
+  setStatus({ initialized: false, device_id: null, has_identity_keys: false });
+  setIsInitializing(false);
+  setError(null);
+}
+```
+
+- [ ] **Step 2: Call `resetE2EEState` in auth logout**
+
+At `client/src/stores/auth.ts`, add the import at the top (alongside other store imports):
+
+```typescript
+import { resetE2EEState } from "./e2ee";
+```
+
+Then at line 409, after `await tauri.logout();`, add the reset call:
+
+```typescript
+    await tauri.logout();
+    resetE2EEState();
+    setAuthState({
+```
+
+- [ ] **Step 3: Drop CryptoManager in Tauri logout**
+
+At `client/src-tauri/src/commands/auth.rs:301`, after the auth state clearing block's closing brace, add:
+
+```rust
+    // Clear crypto state — drops Megolm sessions, Olm account, closes SQLite
+    *state.crypto.lock().await = None;
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `cd client/src-tauri && cargo clippy -p vc-client -- -D warnings`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src-tauri/src/commands/auth.rs client/src/stores/e2ee.ts client/src/stores/auth.ts
+git commit -m "fix(crypto): clear Megolm session cache and E2EE state on logout
+
+Drop CryptoManager from AppState.crypto on Tauri logout to release
+all Olm/Megolm sessions. Reset frontend E2EE signals to defaults
+so UI reflects logged-out state."
+```
+
+---
+
+## Task 2: `returnUrl` encoding
+
+**Files:**
+- Modify: `client/src/components/auth/AuthGuard.tsx:29` (encode)
+- Modify: `client/src/views/Login.tsx:82-85` (decode)
+
+- [ ] **Step 1: Encode returnUrl in AuthGuard**
+
+At `client/src/components/auth/AuthGuard.tsx:29`, replace the navigate call:
+
+```typescript
+// Before
+      navigate(`/login${returnUrl !== "/" ? `?returnUrl=${returnUrl}` : ""}`, {
+
+// After
+      navigate(`/login${returnUrl !== "/" ? `?returnUrl=${encodeURIComponent(returnUrl)}` : ""}`, {
+```
+
+- [ ] **Step 2: Decode returnUrl in Login**
+
+At `client/src/views/Login.tsx:81-86`, replace the returnUrl handling:
+
+```typescript
+// Before (lines 81-86)
+      const raw = searchParams.returnUrl;
+      const returnUrl = Array.isArray(raw) ? raw[0] : raw;
+      const target = returnUrl && returnUrl.startsWith("/") && !returnUrl.startsWith("//")
+        ? returnUrl
+        : "/";
+      navigate(target, { replace: true });
+
+// After
+      const raw = searchParams.returnUrl;
+      const returnUrl = Array.isArray(raw) ? raw[0] : raw;
+      const decoded = returnUrl ? decodeURIComponent(returnUrl) : null;
+      const target = decoded && decoded.startsWith("/") && !decoded.startsWith("//")
+        ? decoded
+        : "/";
+      navigate(target, { replace: true });
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/components/auth/AuthGuard.tsx client/src/views/Login.tsx
+git commit -m "fix(auth): encode returnUrl parameter in auth redirect flow
+
+Wrap returnUrl with encodeURIComponent in AuthGuard to prevent
+URL structure breakage from special characters. Decode in Login
+before validation."
+```
+
+---
+
+## Task 3: Docs — CHANGELOG and checklist
+
+**Files:**
+- Modify: `CHANGELOG.md` (add entries under `### Security`)
+- Modify: `docs/developer-guide/plans/2026-03-19-beta-checklist.md` (mark 2 items done)
+
+- [ ] **Step 1: Add CHANGELOG entries**
+
+At `CHANGELOG.md`, after the `### Fixed` section in `[Unreleased]`, add a new `### Security` section (if one doesn't exist) or add under `### Fixed`:
+
+```markdown
+- E2EE Megolm session cache is now cleared on logout — prevents stale session keys from persisting
+- `returnUrl` parameter is now URL-encoded to prevent query string injection
+```
+
+- [ ] **Step 2: Mark checklist items done**
+
+In `docs/developer-guide/plans/2026-03-19-beta-checklist.md`:
+
+Line 122: `- [ ] E2EE Megolm session cache never cleared on logout`
+→ `- [x] E2EE Megolm session cache never cleared on logout (#PR_NUMBER)`
+
+Line 123: `- [ ] returnUrl injection risk when feature is implemented`
+→ `- [x] returnUrl injection risk when feature is implemented (#PR_NUMBER)`
+
+Replace `#PR_NUMBER` with the actual PR number after creating the PR.
+
+- [ ] **Step 3: Commit, push, create PR**
+
+```bash
+git add CHANGELOG.md docs/developer-guide/plans/2026-03-19-beta-checklist.md
+git commit -m "docs: update CHANGELOG and checklist for security fixes"
+git push -u origin fix/beta-security-quick
+gh pr create --title "fix: clear E2EE sessions on logout and encode returnUrl" --body "..."
+```

--- a/docs/superpowers/plans/2026-04-02-turn-hmac-credentials.md
+++ b/docs/superpowers/plans/2026-04-02-turn-hmac-credentials.md
@@ -1,0 +1,239 @@
+# TURN HMAC Time-Limited Credentials — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace static TURN credentials with per-request HMAC-SHA1 time-limited credentials (RFC 5766 / coturn `use-auth-secret` mode).
+
+**Architecture:** Add `sha1` crate, extend config with `turn_shared_secret` and `turn_credential_ttl`, generate HMAC credentials in `get_ice_servers` handler with `AuthUser` extractor. Fall back to static credentials when shared secret is not set.
+
+**Tech Stack:** Rust (axum, hmac, sha1, base64), coturn
+
+**Spec:** `docs/superpowers/specs/2026-04-02-beta-security-fixes-design.md`
+
+---
+
+## File Map
+
+| File | Responsibility |
+|------|---------------|
+| `Cargo.toml` (workspace root) | Add `sha1 = "0.10"` workspace dependency |
+| `server/Cargo.toml` | Add `sha1.workspace = true` |
+| `server/src/config.rs` | Add `turn_shared_secret`, `turn_credential_ttl` fields + env parsing |
+| `server/src/voice/handlers.rs` | HMAC credential generation with `AuthUser` extractor |
+
+---
+
+## Task 1: Add `sha1` dependency
+
+**Files:**
+- Modify: `Cargo.toml` (workspace root, dependencies section)
+- Modify: `server/Cargo.toml`
+
+- [ ] **Step 1: Add sha1 to workspace Cargo.toml**
+
+In the root `Cargo.toml`, in the `[workspace.dependencies]` section (near `sha2 = "0.10"` at line 62), add:
+
+```toml
+sha1 = "0.10"
+```
+
+- [ ] **Step 2: Add sha1 to server Cargo.toml**
+
+In `server/Cargo.toml`, in the `[dependencies]` section (near `hmac.workspace = true` at line 47), add:
+
+```toml
+sha1.workspace = true
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `SQLX_OFFLINE=true cargo check -p vc-server`
+Expected: PASS
+
+---
+
+## Task 2: Extend config with TURN HMAC fields
+
+**Files:**
+- Modify: `server/src/config.rs:127-133` (struct fields)
+- Modify: `server/src/config.rs:313-315` (env parsing)
+- Modify: `server/src/config.rs:501-503` (test defaults)
+
+- [ ] **Step 1: Add struct fields**
+
+At `server/src/config.rs`, after `turn_credential` (line 133), add:
+
+```rust
+    /// Shared secret for TURN HMAC credential generation (coturn `use-auth-secret` mode).
+    /// When set, time-limited credentials are generated per-request instead of using static ones.
+    pub turn_shared_secret: Option<String>,
+
+    /// TURN credential TTL in seconds (default: 3600 = 1 hour).
+    pub turn_credential_ttl: u64,
+```
+
+- [ ] **Step 2: Add env parsing**
+
+At `server/src/config.rs`, after `turn_credential` env parsing (line 315), add:
+
+```rust
+            turn_shared_secret: env::var("TURN_SHARED_SECRET").ok().filter(|s| !s.is_empty()),
+            turn_credential_ttl: env::var("TURN_CREDENTIAL_TTL")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(3600),
+```
+
+- [ ] **Step 3: Add test defaults**
+
+At `server/src/config.rs`, after `turn_credential: None` in the test defaults (line 503), add:
+
+```rust
+            turn_shared_secret: None,
+            turn_credential_ttl: 3600,
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml server/Cargo.toml server/src/config.rs
+git commit -m "feat(voice): add TURN HMAC config fields and sha1 dependency
+
+Add turn_shared_secret and turn_credential_ttl to AppConfig for
+coturn use-auth-secret mode. Add sha1 0.10 workspace dependency
+for HMAC-SHA1 credential generation."
+```
+
+---
+
+## Task 3: HMAC credential generation in `get_ice_servers`
+
+**Files:**
+- Modify: `server/src/voice/handlers.rs:1-10` (imports)
+- Modify: `server/src/voice/handlers.rs:47-66` (handler)
+
+- [ ] **Step 1: Add imports**
+
+At `server/src/voice/handlers.rs`, replace the imports section (lines 1-10):
+
+```rust
+//! Voice HTTP Handlers
+//!
+//! HTTP endpoints for voice-related operations.
+//! Voice signaling (join/leave/offer/answer/ice) is handled via WebSocket.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::extract::State;
+use axum::Json;
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
+use hmac::{Hmac, Mac};
+use serde::Serialize;
+use sha1::Sha1;
+
+use crate::api::AppState;
+use crate::auth::AuthUser;
+```
+
+- [ ] **Step 2: Replace get_ice_servers handler**
+
+At `server/src/voice/handlers.rs`, replace the `get_ice_servers` function (lines 47-66):
+
+```rust
+pub async fn get_ice_servers(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+) -> Json<IceServersResponse> {
+    let mut servers = vec![IceServer {
+        urls: vec![state.config.stun_server.clone()],
+        username: None,
+        credential: None,
+    }];
+
+    // Prefer HMAC time-limited credentials when shared secret is configured
+    if let (Some(turn), Some(secret)) = (&state.config.turn_server, &state.config.turn_shared_secret) {
+        let expiry = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before UNIX epoch")
+            .as_secs()
+            + state.config.turn_credential_ttl;
+        let username = format!("{}:{}", expiry, auth_user.id);
+
+        let mut mac = Hmac::<Sha1>::new_from_slice(secret.as_bytes())
+            .expect("HMAC-SHA1 accepts any key length");
+        mac.update(username.as_bytes());
+        let credential = BASE64_STANDARD.encode(mac.finalize().into_bytes());
+
+        servers.push(IceServer {
+            urls: vec![turn.clone()],
+            username: Some(username),
+            credential: Some(credential),
+        });
+    } else if let Some(turn) = &state.config.turn_server {
+        // Fallback: static credentials for dev environments
+        servers.push(IceServer {
+            urls: vec![turn.clone()],
+            username: state.config.turn_username.clone(),
+            credential: state.config.turn_credential.clone(),
+        });
+    }
+
+    Json(IceServersResponse {
+        ice_servers: servers,
+    })
+}
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/src/voice/handlers.rs
+git commit -m "feat(voice): generate HMAC time-limited TURN credentials
+
+Replace static TURN credentials with per-request HMAC-SHA1
+credentials when TURN_SHARED_SECRET is configured. Credentials
+expire after turn_credential_ttl seconds (default 1 hour).
+Falls back to static credentials for dev environments."
+```
+
+---
+
+## Task 4: Docs — CHANGELOG, checklist, push, PR
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `docs/developer-guide/plans/2026-03-19-beta-checklist.md`
+
+- [ ] **Step 1: Add CHANGELOG entry**
+
+Under `### Security` (or `### Changed`) in `[Unreleased]`:
+
+```markdown
+- TURN relay credentials are now time-limited (1-hour HMAC-SHA1) instead of static when `TURN_SHARED_SECRET` is configured
+```
+
+- [ ] **Step 2: Mark checklist item done**
+
+In `docs/developer-guide/plans/2026-03-19-beta-checklist.md`:
+
+Line 124: `- [ ] TURN credentials are static/long-lived`
+→ `- [x] TURN credentials are static/long-lived (#PR_NUMBER)`
+
+- [ ] **Step 3: Commit, push, create PR**
+
+```bash
+git add CHANGELOG.md docs/developer-guide/plans/2026-03-19-beta-checklist.md
+git commit -m "docs: update CHANGELOG and checklist for TURN HMAC credentials"
+git push -u origin fix/turn-hmac-credentials
+gh pr create --title "feat(voice): TURN HMAC time-limited credentials" --body "..."
+```

--- a/docs/superpowers/specs/2026-04-02-beta-security-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-02-beta-security-fixes-design.md
@@ -1,0 +1,219 @@
+# Beta Security Fixes — Design Spec
+
+**Date:** 2026-04-02
+**Status:** Draft
+**Scope:** 3 security items from the beta checklist (virus scanning deferred)
+
+## Overview
+
+Three security fixes split across two branches:
+- **Branch 1 (`fix/beta-security-quick`):** Megolm session cache cleanup on logout + `returnUrl` encoding
+- **Branch 2 (`fix/turn-hmac-credentials`):** TURN HMAC time-limited credentials
+
+## Fix 1: Megolm Session Cache Cleanup on Logout
+
+### Problem
+
+`AppState.crypto` (`Arc<Mutex<Option<CryptoManager>>>`) is never cleared on logout. The `CryptoManager` holds a `LocalKeyStore` backed by encrypted SQLite (`keys.db`) containing Olm accounts, Olm sessions, and Megolm inbound/outbound group sessions. If the device is compromised after logout, cached Megolm session keys could decrypt past messages.
+
+### Current Logout Flow
+
+1. Frontend `auth.ts:logout()` calls `wsDisconnect()`, `cleanupWebSocket()`, `stopIdleDetectionCleanup()`, `cleanupPresence()`, `clearAllDrafts()`, `cleanupDrafts()`
+2. Then calls `tauri.logout()` which hits `commands/auth.rs:logout()`
+3. Tauri `logout()` invalidates refresh token on server, clears `auth` state, clears stored credentials
+4. **Neither step touches `state.crypto` or the E2EE store signals**
+
+### Design
+
+**Tauri side (`commands/auth.rs:logout()`):**
+
+After clearing auth state (line 301), drop the `CryptoManager`:
+
+```rust
+// Clear crypto state — drops Megolm sessions, Olm account, closes SQLite
+if let Ok(mut crypto) = state.crypto.lock() {
+    *crypto = None;
+}
+```
+
+Using `if let Ok` rather than `?` because logout should succeed even if the mutex is poisoned.
+
+**Frontend side (`stores/auth.ts:logout()`):**
+
+After `tauri.logout()` (line 409), reset the E2EE store:
+
+```typescript
+resetE2EEState();
+```
+
+**New export in `stores/e2ee.ts`:**
+
+```typescript
+export function resetE2EEState(): void {
+  setStatus({ initialized: false, device_id: null, has_identity_keys: false });
+  setIsInitializing(false);
+  setError(null);
+}
+```
+
+### What This Achieves
+
+- Dropping `CryptoManager` closes the SQLite connection and releases all in-memory Olm/Megolm session objects
+- The encrypted `keys.db` file remains on disk but is inaccessible without the encryption key (derived from user identity during `initE2EE`)
+- On next login, `initE2EE` creates a fresh `CryptoManager`, which opens or creates `keys.db` with the new user's key
+- Frontend signals reset to "not initialized" so E2EE UI reflects the logged-out state
+
+### Files
+
+| File | Change |
+|------|--------|
+| `client/src-tauri/src/commands/auth.rs:301` | Drop `state.crypto` after clearing auth |
+| `client/src/stores/e2ee.ts` | Add `resetE2EEState()` export |
+| `client/src/stores/auth.ts:409` | Call `resetE2EEState()` after `tauri.logout()` |
+
+---
+
+## Fix 2: `returnUrl` Encoding
+
+### Problem
+
+`AuthGuard.tsx:29` embeds `location.pathname` directly into a query string without URL encoding:
+
+```typescript
+navigate(`/login${returnUrl !== "/" ? `?returnUrl=${returnUrl}` : ""}`, { replace: true });
+```
+
+If `pathname` contains characters like `?`, `&`, `#`, or spaces, the URL structure breaks. The `Login.tsx` validation (line 83) already prevents open redirect attacks (`startsWith("/")` and `!startsWith("//")`), but the unencoded value could cause parsing issues.
+
+### Design
+
+**`AuthGuard.tsx:29`** — encode the value:
+
+```typescript
+navigate(`/login${returnUrl !== "/" ? `?returnUrl=${encodeURIComponent(returnUrl)}` : ""}`, {
+  replace: true,
+});
+```
+
+**`Login.tsx:82-85`** — decode before validating:
+
+```typescript
+const raw = searchParams.returnUrl;
+const returnUrl = Array.isArray(raw) ? raw[0] : raw;
+const decoded = returnUrl ? decodeURIComponent(returnUrl) : null;
+const target = decoded && decoded.startsWith("/") && !decoded.startsWith("//")
+  ? decoded
+  : "/";
+navigate(target, { replace: true });
+```
+
+### Files
+
+| File | Change |
+|------|--------|
+| `client/src/components/auth/AuthGuard.tsx:29` | Wrap `returnUrl` with `encodeURIComponent()` |
+| `client/src/views/Login.tsx:82-85` | Add `decodeURIComponent()` before validation |
+
+---
+
+## Fix 3: TURN HMAC Time-Limited Credentials
+
+### Problem
+
+`voice/handlers.rs:55-60` returns static TURN credentials from environment variables (`TURN_USERNAME`, `TURN_CREDENTIAL`). These never expire — if leaked, they're valid indefinitely for relay traffic.
+
+### Design
+
+Replace static credentials with per-request HMAC-SHA1 credentials per RFC 5766 / coturn `use-auth-secret` mode.
+
+**Config changes (`config.rs`):**
+
+Replace `turn_username` and `turn_credential` with:
+
+```rust
+/// Shared secret for TURN HMAC credential generation (coturn `use-auth-secret` mode).
+/// When set, credentials are generated per-request with a TTL.
+pub turn_shared_secret: Option<String>,
+
+/// TURN credential TTL in seconds (default: 3600 = 1 hour).
+pub turn_credential_ttl: u64,
+```
+
+Keep `turn_username` and `turn_credential` as fallback for dev environments without HMAC-capable TURN servers.
+
+**Credential generation (`voice/handlers.rs`):**
+
+The `get_ice_servers` handler needs the authenticated user ID. It currently takes only `State(state)` — add `AuthUser` extractor.
+
+```rust
+pub async fn get_ice_servers(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+) -> Json<IceServersResponse> {
+    // ...
+    if let (Some(turn), Some(secret)) = (&state.config.turn_server, &state.config.turn_shared_secret) {
+        let expiry = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + state.config.turn_credential_ttl;
+        let username = format!("{}:{}", expiry, auth_user.id);
+
+        let mut mac = Hmac::<Sha1>::new_from_slice(secret.as_bytes())
+            .expect("HMAC accepts any key length");
+        mac.update(username.as_bytes());
+        let credential = BASE64_STANDARD.encode(mac.finalize().into_bytes());
+
+        servers.push(IceServer {
+            urls: vec![turn.clone()],
+            username: Some(username),
+            credential: Some(credential),
+        });
+    } else if let Some(turn) = &state.config.turn_server {
+        // Fallback: static credentials for dev environments
+        servers.push(IceServer {
+            urls: vec![turn.clone()],
+            username: state.config.turn_username.clone(),
+            credential: state.config.turn_credential.clone(),
+        });
+    }
+}
+```
+
+**Dependencies:**
+
+- `sha1 = "0.10"` added to workspace `Cargo.toml` (MIT/Apache-2.0 — license-compliant)
+- `hmac` already in workspace
+- `base64` already in workspace (used via `BASE64_STANDARD`)
+
+**Coturn configuration (VPS):**
+
+```
+# /etc/turnserver.conf
+use-auth-secret
+static-auth-secret=<same-secret-as-TURN_SHARED_SECRET>
+# Remove or comment out:
+# lt-cred-mech
+# user=username:password
+```
+
+### Files
+
+| File | Change |
+|------|--------|
+| `Cargo.toml` (workspace) | Add `sha1 = "0.10"` |
+| `server/Cargo.toml` | Add `sha1.workspace = true` |
+| `server/src/config.rs:127-133` | Add `turn_shared_secret`, `turn_credential_ttl`; keep old fields as fallback |
+| `server/src/voice/handlers.rs:47-66` | HMAC credential generation with `AuthUser` extractor; fallback to static |
+
+---
+
+## Checklist Item Updates
+
+After merging both branches, mark in `docs/developer-guide/plans/2026-03-19-beta-checklist.md`:
+
+- `[x] E2EE Megolm session cache never cleared on logout` — with PR reference
+- `[x] returnUrl injection risk` — with PR reference
+- `[x] TURN credentials are static/long-lived` — with PR reference
+
+Virus scanning remains deferred: `[ ] No virus scanning for file uploads` — current MIME allowlist + magic bytes is sufficient for beta.


### PR DESCRIPTION
## Summary

- **E2EE logout cleanup:** Drop `CryptoManager` from `AppState.crypto` on Tauri logout, releasing all Olm/Megolm sessions. Reset frontend E2EE signals to defaults.
- **returnUrl encoding:** Wrap `returnUrl` with `encodeURIComponent` in AuthGuard, decode in Login before validation. Prevents query string breakage from special characters.

## Changes

- `client/src-tauri/src/commands/auth.rs` — `*state.crypto.lock().await = None` in logout
- `client/src/stores/e2ee.ts` — new `resetE2EEState()` export
- `client/src/stores/auth.ts` — call `resetE2EEState()` after `tauri.logout()`
- `client/src/components/auth/AuthGuard.tsx` — `encodeURIComponent(returnUrl)`
- `client/src/views/Login.tsx` — `decodeURIComponent()` before validation

## Test plan
- [ ] Login, navigate to a deep link, logout, verify E2EE status shows uninitialized
- [ ] Login again, verify E2EE re-initializes with fresh session
- [ ] Navigate to `/guild/123/channel/456` while logged out, verify redirect preserves the path after login

🤖 Generated with [Claude Code](https://claude.ai/code)