### PR TITLE
feat(voice): TURN HMAC time-limited credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - E2EE Megolm session cache is now cleared on logout — prevents stale session keys from persisting
 - `returnUrl` parameter is now URL-encoded to prevent query string injection
+- TURN relay credentials are now time-limited (1-hour HMAC-SHA1) instead of static when `TURN_SHARED_SECRET` is configured
 
 ### Added
 - Password visibility toggle on all password fields (login, register, reset password)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10659,6 +10659,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "sha1",
  "sha2",
  "sqlx",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ openidconnect = "4"
 rustls = { version = "0.23", features = ["ring"] }
 aes-gcm = "0.10"
 hkdf = "0.12"
+sha1 = "0.10"
 sha2 = "0.10"
 hmac = "0.12"
 vodozemac = "0.9"

--- a/docs/developer-guide/plans/2026-03-19-beta-checklist.md
+++ b/docs/developer-guide/plans/2026-03-19-beta-checklist.md
@@ -121,7 +121,7 @@
 
 - [x] E2EE Megolm session cache never cleared on logout — `client/src/stores/messages.ts:618`
 - [x] `returnUrl` injection risk when feature is implemented — validate relative URL — `client/src/components/auth/AuthGuard.tsx:28-30`
-- [ ] TURN credentials are static/long-lived — consider time-limited HMAC credentials — `server/src/voice/handlers.rs:47-66`
+- [x] TURN credentials are static/long-lived — consider time-limited HMAC credentials — `server/src/voice/handlers.rs:47-66`
 - [ ] No virus scanning for file uploads (MIME + magic bytes is current defense) — `server/src/chat/uploads.rs`
 
 ### UX Polish

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -43,6 +43,7 @@ openidconnect.workspace = true
 
 # Crypto
 rustls.workspace = true
+sha1.workspace = true
 sha2.workspace = true
 hmac.workspace = true
 aes-gcm.workspace = true

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -132,6 +132,13 @@ pub struct Config {
     /// WebRTC TURN credential (optional)
     pub turn_credential: Option<String>,
 
+    /// Shared secret for TURN HMAC credential generation (coturn `use-auth-secret` mode).
+    /// When set, time-limited credentials are generated per-request instead of using static ones.
+    pub turn_shared_secret: Option<String>,
+
+    /// TURN credential TTL in seconds (default: 3600 = 1 hour).
+    pub turn_credential_ttl: u64,
+
     /// Public IP for WebRTC NAT traversal.
     /// Required when the SFU runs behind NAT/Docker so ICE candidates
     /// advertise the reachable IP instead of the container-internal IP.
@@ -313,6 +320,11 @@ impl Config {
             turn_server: env::var("TURN_SERVER").ok().filter(|s| !s.is_empty()),
             turn_username: env::var("TURN_USERNAME").ok().filter(|s| !s.is_empty()),
             turn_credential: env::var("TURN_CREDENTIAL").ok().filter(|s| !s.is_empty()),
+            turn_shared_secret: env::var("TURN_SHARED_SECRET").ok().filter(|s| !s.is_empty()),
+            turn_credential_ttl: env::var("TURN_CREDENTIAL_TTL")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(3600),
             public_ip: env::var("PUBLIC_IP").ok(),
             mfa_encryption_key: env::var("MFA_ENCRYPTION_KEY").ok(),
             require_e2ee_setup: env::var("REQUIRE_E2EE_SETUP")
@@ -501,6 +513,8 @@ impl Config {
             turn_server: None,
             turn_username: None,
             turn_credential: None,
+            turn_shared_secret: None,
+            turn_credential_ttl: 3600,
             public_ip: None,
             mfa_encryption_key: Some(TEST_MFA_ENCRYPTION_KEY.into()),
             require_e2ee_setup: false,

--- a/server/src/voice/handlers.rs
+++ b/server/src/voice/handlers.rs
@@ -3,11 +3,17 @@
 //! HTTP endpoints for voice-related operations.
 //! Voice signaling (join/leave/offer/answer/ice) is handled via WebSocket.
 
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use axum::extract::State;
 use axum::Json;
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
+use hmac::{Hmac, Mac};
 use serde::Serialize;
+use sha1::Sha1;
 
 use crate::api::AppState;
+use crate::auth::AuthUser;
 
 /// ICE server configuration.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -44,15 +50,37 @@ pub struct IceServersResponse {
     ),
     security(("bearer_auth" = [])),
 )]
-pub async fn get_ice_servers(State(state): State<AppState>) -> Json<IceServersResponse> {
+pub async fn get_ice_servers(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+) -> Json<IceServersResponse> {
     let mut servers = vec![IceServer {
         urls: vec![state.config.stun_server.clone()],
         username: None,
         credential: None,
     }];
 
-    // Add TURN server if configured
-    if let Some(turn) = &state.config.turn_server {
+    // Prefer HMAC time-limited credentials when shared secret is configured
+    if let (Some(turn), Some(secret)) = (&state.config.turn_server, &state.config.turn_shared_secret) {
+        let expiry = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before UNIX epoch")
+            .as_secs()
+            + state.config.turn_credential_ttl;
+        let username = format!("{}:{}", expiry, auth_user.id);
+
+        let mut mac = Hmac::<Sha1>::new_from_slice(secret.as_bytes())
+            .expect("HMAC-SHA1 accepts any key length");
+        mac.update(username.as_bytes());
+        let credential = BASE64_STANDARD.encode(mac.finalize().into_bytes());
+
+        servers.push(IceServer {
+            urls: vec![turn.clone()],
+            username: Some(username),
+            credential: Some(credential),
+        });
+    } else if let Some(turn) = &state.config.turn_server {
+        // Fallback: static credentials for dev environments
         servers.push(IceServer {
             urls: vec![turn.clone()],
             username: state.config.turn_username.clone(),


### PR DESCRIPTION
## Summary

- Replace static TURN credentials with per-request HMAC-SHA1 time-limited credentials (RFC 5766 / coturn `use-auth-secret` mode)
- Credentials expire after `TURN_CREDENTIAL_TTL` seconds (default 3600 = 1 hour)
- Falls back to static `TURN_USERNAME`/`TURN_CREDENTIAL` when `TURN_SHARED_SECRET` is not configured

## Changes

- `Cargo.toml` / `server/Cargo.toml` — Add `sha1 = "0.10"` dependency (MIT/Apache-2.0)
- `server/src/config.rs` — Add `turn_shared_secret` and `turn_credential_ttl` config fields
- `server/src/voice/handlers.rs` — HMAC credential generation with `AuthUser` extractor, fallback to static

## Deployment

Requires coturn config update on the VPS:
```
use-auth-secret
static-auth-secret=<same value as TURN_SHARED_SECRET env var>
```

## Test plan
- [ ] Set `TURN_SHARED_SECRET` env var, verify `/api/voice/ice-servers` returns time-limited username (`<epoch>:<user_id>`) and HMAC credential
- [ ] Unset `TURN_SHARED_SECRET`, verify fallback to static credentials still works
- [ ] Join a voice channel with HMAC credentials, verify TURN relay works

🤖 Generated with [Claude Code](https://claude.ai/code)