### PR TITLE
infra: switch coturn to HMAC shared secret auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,11 @@ STUN_SERVER=stun:stun.l.google.com:19302
 
 # TURN server for relaying (recommended for production)
 TURN_SERVER=
+# HMAC shared secret for time-limited TURN credentials (coturn use-auth-secret mode)
+# When set, per-request credentials are generated with a TTL instead of using static ones
+TURN_SHARED_SECRET=
+TURN_CREDENTIAL_TTL=3600
+# Legacy static credentials (fallback when TURN_SHARED_SECRET is not set)
 TURN_USERNAME=
 TURN_CREDENTIAL=
 

--- a/infra/compose/.env.beta
+++ b/infra/compose/.env.beta
@@ -50,8 +50,11 @@ PUBLIC_IP=CHANGEME
 
 # TURN server (coturn in docker-compose, setup-beta.sh fills DOMAIN automatically)
 TURN_SERVER=CHANGEME_TURN
-TURN_USERNAME=kaiku
-TURN_CREDENTIAL=CHANGEME
+TURN_SHARED_SECRET=CHANGEME_TURN_SECRET
+TURN_CREDENTIAL_TTL=3600
+# Legacy static credentials (fallback when TURN_SHARED_SECRET is not set)
+# TURN_USERNAME=kaiku
+# TURN_CREDENTIAL=
 
 # =============================================================================
 # Rate Limiting

--- a/infra/compose/docker-compose.yml
+++ b/infra/compose/docker-compose.yml
@@ -40,6 +40,8 @@ services:
       - OIDC_CLIENT_SECRET=${OIDC_CLIENT_SECRET:-}
       - STUN_SERVER=${STUN_SERVER:-stun:stun.l.google.com:19302}
       - TURN_SERVER=${TURN_SERVER:-}
+      - TURN_SHARED_SECRET=${TURN_SHARED_SECRET:-}
+      - TURN_CREDENTIAL_TTL=${TURN_CREDENTIAL_TTL:-3600}
       - TURN_USERNAME=${TURN_USERNAME:-}
       - TURN_CREDENTIAL=${TURN_CREDENTIAL:-}
       - MFA_ENCRYPTION_KEY=${MFA_ENCRYPTION_KEY:-}
@@ -132,8 +134,8 @@ services:
       - "-n"
       - "--realm=${DOMAIN}"
       - "--fingerprint"
-      - "--lt-cred-mech"
-      - "--user=${TURN_USERNAME:-kaiku}:${TURN_CREDENTIAL}"
+      - "--use-auth-secret"
+      - "--static-auth-secret=${TURN_SHARED_SECRET}"
       - "--external-ip=${PUBLIC_IP}"
       - "--listening-port=3478"
       - "--min-port=49152"

--- a/infra/scripts/setup-beta.sh
+++ b/infra/scripts/setup-beta.sh
@@ -131,7 +131,7 @@ if [[ "${SKIP_ENV:-0}" != "1" ]]; then
     MFA_ENCRYPTION_KEY=$(openssl rand -hex 32)
     VALKEY_PASSWORD=$(openssl rand -base64 16)
     GRAFANA_ADMIN_PASSWORD=$(openssl rand -base64 16)
-    TURN_CREDENTIAL=$(openssl rand -hex 16)
+    TURN_SHARED_SECRET=$(openssl rand -hex 32)
 
     log "Writing ${ENV_FILE}..."
     cp "${INSTALL_DIR}/infra/compose/.env.beta" "$ENV_FILE"
@@ -144,7 +144,7 @@ if [[ "${SKIP_ENV:-0}" != "1" ]]; then
     sed -i "s|MFA_ENCRYPTION_KEY=CHANGEME|MFA_ENCRYPTION_KEY=${MFA_ENCRYPTION_KEY}|" "$ENV_FILE"
     sed -i "s|VALKEY_PASSWORD=CHANGEME|VALKEY_PASSWORD=${VALKEY_PASSWORD}|" "$ENV_FILE"
     sed -i "s|GRAFANA_ADMIN_PASSWORD=CHANGEME|GRAFANA_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}|" "$ENV_FILE"
-    sed -i "s|TURN_CREDENTIAL=CHANGEME|TURN_CREDENTIAL=${TURN_CREDENTIAL}|" "$ENV_FILE"
+    sed -i "s|TURN_SHARED_SECRET=CHANGEME_TURN_SECRET|TURN_SHARED_SECRET=${TURN_SHARED_SECRET}|" "$ENV_FILE"
 
     # Detect public IP for WebRTC and TURN
     if [[ -n "$SERVER_IP" && "$SERVER_IP" != "unknown" ]]; then


### PR DESCRIPTION
## Summary

Switch coturn from static long-term credentials to HMAC shared secret authentication, matching the server-side HMAC credential generation from #499.

## Changes

- `infra/compose/docker-compose.yml` — coturn: `--use-auth-secret` + `--static-auth-secret` replaces `--lt-cred-mech` + `--user`; server: add `TURN_SHARED_SECRET` and `TURN_CREDENTIAL_TTL` env vars
- `infra/compose/.env.beta` — replace `TURN_USERNAME`/`TURN_CREDENTIAL` with `TURN_SHARED_SECRET`
- `infra/scripts/setup-beta.sh` — generate 32-byte hex shared secret instead of static credential
- `.env.example` — document new TURN HMAC variables

## Deployment

After merging, on the VPS:
1. Generate a shared secret: `openssl rand -hex 32`
2. Add `TURN_SHARED_SECRET=<secret>` to `.env`
3. Remove `TURN_USERNAME` and `TURN_CREDENTIAL` from `.env` (or leave them — server ignores when shared secret is set)
4. `docker compose up -d coturn server` to restart both services

🤖 Generated with [Claude Code](https://claude.ai/code)