### PR TITLE
fix(client): UX and accessibility polish batch

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -287,7 +287,7 @@ const NotFoundPage = () => (
 // Export routes as JSX Route elements
 export const AppRoutes = (): JSX.Element => (
   <>
-    <Route path="/demo" component={ThemeDemoPage} />
+    {import.meta.env.DEV && <Route path="/demo" component={ThemeDemoPage} />}
     <Route path="/login" component={LoginPage} />
     <Route path="/register" component={RegisterPage} />
     <Route path="/forgot-password" component={ForgotPasswordPage} />

--- a/client/src/components/channels/ChannelItem.tsx
+++ b/client/src/components/channels/ChannelItem.tsx
@@ -152,14 +152,13 @@ const ChannelItem: Component<ChannelItemProps> = (props) => {
 
   return (
     <div class="relative" onContextMenu={handleContextMenu}>
-      <div
-        role="button"
+      <button
+        type="button"
         data-testid="channel-item"
         data-channel-id={props.channel.id}
         data-channel-name={props.channel.name}
         data-channel-type={props.channel.channel_type}
-        tabIndex={0}
-        class="w-full flex items-center gap-2 px-2 py-1.5 rounded-xl text-sm transition-all duration-200 group cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50"
+        class="w-full flex items-center gap-2 px-2 py-1.5 rounded-xl text-sm transition-all duration-200 group cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-accent-primary/50 border-none bg-transparent text-left"
         classList={{
           // Voice connected/connecting state (green glow)
           "bg-accent-primary/20 text-text-primary border border-accent-primary/30":
@@ -174,15 +173,6 @@ const ChannelItem: Component<ChannelItemProps> = (props) => {
             !isActive() && !props.isSelected,
         }}
         onClick={props.onClick}
-        onKeyDown={(e) => {
-          if (
-            e.target === e.currentTarget &&
-            (e.key === "Enter" || e.key === " ")
-          ) {
-            e.preventDefault();
-            props.onClick();
-          }
-        }}
         onMouseEnter={() => setShowTooltip(true)}
         onMouseLeave={() => setShowTooltip(false)}
         title={
@@ -300,7 +290,7 @@ const ChannelItem: Component<ChannelItemProps> = (props) => {
             <Settings class="w-3.5 h-3.5" />
           </button>
         </Show>
-      </div>
+      </button>
 
       {/* Tooltip showing participants (on hover for voice channels) */}
       <Show when={isVoice() && showTooltip() && participantCount() > 0}>

--- a/client/src/components/layout/ServerRail.tsx
+++ b/client/src/components/layout/ServerRail.tsx
@@ -63,7 +63,8 @@ const ServerRail: Component = () => {
   };
 
   return (
-    <aside
+    <nav
+      aria-label="Servers"
       class="w-[72px] flex flex-col items-center py-3 gap-2 bg-surface-base border-r border-border-solid z-20"
       data-testid="server-rail"
     >
@@ -83,6 +84,7 @@ const ServerRail: Component = () => {
             "border-radius": getBorderRadius("home"),
             opacity: isActive("home") || isHovered("home") ? 1 : 0.85,
           }}
+          aria-current={isActive("home") ? "page" : undefined}
           onMouseEnter={() => setHoveredServerId("home")}
           onMouseLeave={() => setHoveredServerId(null)}
           onClick={() => selectHome()}
@@ -124,6 +126,7 @@ const ServerRail: Component = () => {
                     opacity:
                       isActive(guild.id) || isHovered(guild.id) ? 1 : 0.85,
                   }}
+                  aria-current={isActive(guild.id) ? "page" : undefined}
                   onMouseEnter={() => setHoveredServerId(guild.id)}
                   onMouseLeave={() => setHoveredServerId(null)}
                   onClick={() => selectGuild(guild.id)}
@@ -248,7 +251,7 @@ const ServerRail: Component = () => {
           </Suspense>
         </LazyErrorBoundary>
       </Show>
-    </aside>
+    </nav>
   );
 };
 

--- a/client/src/components/messages/MessageInput.tsx
+++ b/client/src/components/messages/MessageInput.tsx
@@ -147,7 +147,7 @@ const MessageInput: Component<MessageInputProps> = (props) => {
     const validationError = validateFileSize(file, 'attachment');
     if (validationError) {
       setUploadError(validationError);
-      setTimeout(() => setUploadError(null), 5000); // Clear after 5 seconds
+      setTimeout(() => setUploadError(null), 8000); // Clear after 8 seconds (toast convention)
       return;
     }
 

--- a/client/src/views/Main.tsx
+++ b/client/src/views/Main.tsx
@@ -131,7 +131,7 @@ const Main: Component = () => {
     }
   };
 
-  createEffect(() => {
+  onMount(() => {
     window.addEventListener("keydown", handleGlobalKeydown);
 
     // Listen for custom event from /? slash command
@@ -237,7 +237,7 @@ const Main: Component = () => {
                     >
                       <Volume2 class="w-5 h-5 text-text-secondary mr-2" />
                     </Show>
-                    <span class="font-semibold text-text-primary">
+                    <span class="font-semibold text-text-primary truncate" title={channel()?.name}>
                       {channel()?.name}
                     </span>
                     <Show when={channel()?.topic}>


### PR DESCRIPTION
## Summary

6 small client fixes from the beta nice-to-have checklist:

- **Toast dismiss timing:** Upload error toast 5s→8s to match project convention
- **onMount:** Replace `createEffect` with `onMount` for static keydown listeners in Main.tsx
- **Channel name tooltip:** Add `title` attribute for long channel names that truncate in the header
- **Demo route:** Gate `/demo` theme route to dev mode only (`import.meta.env.DEV`)
- **ServerRail semantics:** `<aside>`→`<nav aria-label="Servers">`, add `aria-current="page"` on active buttons
- **ChannelItem semantics:** `<div role="button">`→`<button>`, remove manual keyboard handler (native button handles Enter/Space)

## Test plan
- [x] `bun run build` passes
- [x] `bun run test:run` — 577/577 passing
- [ ] Manual: verify channel items still respond to clicks/keyboard
- [ ] Manual: verify `/demo` route returns 404 in production build

🤖 Generated with [Claude Code](https://claude.ai/code)