### PR TITLE
feat(voice): RNNoise VAD + noise suppression for desktop client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TURN relay credentials are now time-limited (1-hour HMAC-SHA1) instead of static when `TURN_SHARED_SECRET` is configured
 
 ### Added
+- Voice activity detection (VAD) on desktop client — microphone is gated using RNNoise ML model with configurable threshold and 300ms hold-open
+- Noise suppression on desktop client — RNNoise denoises audio in real-time when enabled in voice settings
+- Local speaking indicator on desktop client — green ring animates when you're speaking
 - Password visibility toggle on all password fields (login, register, reset password)
 - Skip-to-content keyboard navigation link
 - Open Graph and Twitter Card meta tags for link previews
@@ -75,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Guild settings modal now uses vertical sidebar navigation instead of horizontal tabs — scales to any number of sections (#435)
 
 ### Changed
+- Desktop voice capture switched from stereo to mono for bandwidth efficiency and RNNoise compatibility
 - Library page now uses theme-aware colors instead of hardcoded zinc palette
 - Library now renders in the main section with sidebar visible, with a close button
 - Discover Servers page now keeps sidebar visible instead of hiding it

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "anymap3"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170433209e817da6aae2c51aa0dd443009a613425dd041ebfb2492d1c4c11a25"
+
+[[package]]
 name = "ar_archive_writer"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,6 +365,12 @@ dependencies = [
  "cpufeatures 0.2.17",
  "password-hash",
 ]
+
+[[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
 
 [[package]]
 name = "arrayvec"
@@ -2760,6 +2772,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "easyfft"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "767e39eef2ad8a3b6f1d733be3ec70364d21d437d06d4f18ea76ce08df20b75f"
+dependencies = [
+ "array-init",
+ "generic_singleton",
+ "num-complex",
+ "realfft",
+ "rustfft",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3497,6 +3522,16 @@ dependencies = [
  "typenum",
  "version_check",
  "zeroize",
+]
+
+[[package]]
+name = "generic_singleton"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab6e923c8e978e57cf63e2e200ca967d1d20f0ea2662b28f6d4e11c44aa6ab16"
+dependencies = [
+ "anymap3",
+ "parking_lot",
 ]
 
 [[package]]
@@ -5338,6 +5373,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nnnoiseless"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "805d5964d1e7a0006a7fdced7dae75084d66d18b35f1dfe81bd76929b1f8da0c"
+dependencies = [
+ "easyfft",
+ "once_cell",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5507,6 +5552,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -6747,6 +6793,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7228,6 +7283,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "realfft"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f821338fddb99d089116342c46e9f1fbf3828dba077674613e734e01d6ea8677"
+dependencies = [
+ "rustfft",
+]
+
+[[package]]
 name = "redis-protocol"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7591,6 +7655,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustfft"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21db5f9893e91f41798c88680037dba611ca6674703c1a18601b01a72c8adb89"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
 ]
 
 [[package]]
@@ -8834,6 +8912,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strength_reduce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "string_cache"
@@ -10141,6 +10225,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
+]
+
+[[package]]
 name = "tray-icon"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10551,6 +10645,7 @@ dependencies = [
  "hmac",
  "image",
  "keyring",
+ "nnnoiseless",
  "nokhwa",
  "opus",
  "reqwest 0.13.2",

--- a/LICENSE_COMPLIANCE.md
+++ b/LICENSE_COMPLIANCE.md
@@ -4,7 +4,7 @@ This document tracks all direct third-party dependencies and their licenses for 
 
 **Project License:** MIT OR Apache-2.0 (Dual License)
 
-**Last Updated:** 2026-01-31
+**Last Updated:** 2026-04-07
 
 ---
 
@@ -36,6 +36,7 @@ This document tracks all direct third-party dependencies and their licenses for 
 | cpal | 0.17 | Apache-2.0 | Cross-platform audio I/O (client) |
 | opus | 0.3 | MIT/Apache-2.0 | Opus audio codec bindings (client) |
 | rodio | 0.21 | MIT OR Apache-2.0 | Audio playback (client) |
+| nnnoiseless | 0.5 | BSD-3-Clause | Pure-Rust RNNoise port — VAD + noise suppression (client) |
 
 ### Database & Storage
 

--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -55,6 +55,9 @@ url = "2"
 keyring = "2"
 rusqlite = { version = "0.32", features = ["bundled"] }
 
+# Audio denoising + VAD
+nnnoiseless = { version = "0.5", default-features = false }
+
 # Screen capture
 scap = { git = "https://github.com/Detair/scap.git", branch = "fix/linux-frame-enum" }
 

--- a/client/src-tauri/src/audio/handle.rs
+++ b/client/src-tauri/src/audio/handle.rs
@@ -15,8 +15,8 @@ use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
 use super::{
-    AudioDevice, AudioDeviceList, AudioError, CAPTURE_CHANNELS, CHANNELS, FRAME_SIZE,
-    RNNOISE_FRAME_SIZE, SAMPLE_RATE, VadConfig,
+    AudioDevice, AudioDeviceList, AudioError, VadConfig, CAPTURE_CHANNELS, CHANNELS, FRAME_SIZE,
+    RNNOISE_FRAME_SIZE, SAMPLE_RATE,
 };
 
 /// Audio handle that can be safely shared across threads
@@ -196,7 +196,14 @@ impl AudioHandle {
 
         // Spawn capture task that owns the Stream
         tokio::task::spawn_blocking(move || {
-            run_capture_task(device, muted, output_tx, &mut control_rx, vad_config, app_handle);
+            run_capture_task(
+                device,
+                muted,
+                output_tx,
+                &mut control_rx,
+                vad_config,
+                app_handle,
+            );
         });
 
         info!("Audio capture started");
@@ -299,7 +306,10 @@ impl AudioHandle {
     pub fn set_vad_config(&self, enabled: bool, threshold: f32) {
         self.vad_config.set_enabled(enabled);
         self.vad_config.set_threshold(threshold);
-        debug!("VAD config: enabled={}, threshold={:.2}", enabled, threshold);
+        debug!(
+            "VAD config: enabled={}, threshold={:.2}",
+            enabled, threshold
+        );
     }
 
     /// Set noise suppression
@@ -394,8 +404,7 @@ fn run_capture_task(
     };
 
     // Mono Opus encoder — capture is mono, playback remains stereo
-    let mut encoder = match Encoder::new(SAMPLE_RATE, OpusChannels::Mono, opus::Application::Voip)
-    {
+    let mut encoder = match Encoder::new(SAMPLE_RATE, OpusChannels::Mono, opus::Application::Voip) {
         Ok(enc) => enc,
         Err(e) => {
             error!("Failed to create encoder: {}", e);
@@ -450,8 +459,7 @@ fn run_capture_task(
                 if rnnoise_input.len() == RNNOISE_FRAME_SIZE {
                     // Run RNNoise: denoises and returns VAD probability
                     rnnoise_output.fill(0.0);
-                    let vad_prob =
-                        denoiser.process_frame(&mut rnnoise_output, &rnnoise_input);
+                    let vad_prob = denoiser.process_frame(&mut rnnoise_output, &rnnoise_input);
 
                     if first_frame {
                         // First frame output has fade-in artifact — discard

--- a/client/src-tauri/src/audio/handle.rs
+++ b/client/src-tauri/src/audio/handle.rs
@@ -12,7 +12,10 @@ use opus::{Channels as OpusChannels, Decoder, Encoder};
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
-use super::{AudioDevice, AudioDeviceList, AudioError, CHANNELS, FRAME_SIZE, SAMPLE_RATE};
+use super::{
+    AudioDevice, AudioDeviceList, AudioError, CAPTURE_CHANNELS, CHANNELS, FRAME_SIZE,
+    RNNOISE_FRAME_SIZE, SAMPLE_RATE, VadConfig,
+};
 
 /// Audio handle that can be safely shared across threads
 pub struct AudioHandle {
@@ -42,6 +45,12 @@ pub struct AudioHandle {
 
     /// Selected output device name
     output_device_name: Option<String>,
+
+    /// VAD + noise suppression configuration
+    vad_config: VadConfig,
+
+    /// Tauri app handle for emitting events from capture thread
+    app_handle: Option<tauri::AppHandle>,
 }
 
 /// Control messages for capture task
@@ -69,6 +78,8 @@ impl AudioHandle {
             mic_test_control: None,
             input_device_name: None,
             output_device_name: None,
+            vad_config: VadConfig::new(),
+            app_handle: None,
         })
     }
 
@@ -278,6 +289,29 @@ impl AudioHandle {
     /// Get deafened state
     pub fn is_deafened(&self) -> bool {
         self.deafened.load(Ordering::Relaxed)
+    }
+
+    /// Set VAD configuration
+    pub fn set_vad_config(&self, enabled: bool, threshold: f32) {
+        self.vad_config.set_enabled(enabled);
+        self.vad_config.set_threshold(threshold);
+        debug!("VAD config: enabled={}, threshold={:.2}", enabled, threshold);
+    }
+
+    /// Set noise suppression
+    pub fn set_noise_suppression(&self, enabled: bool) {
+        self.vad_config.set_denoise(enabled);
+        debug!("Noise suppression: {}", enabled);
+    }
+
+    /// Get VAD config (for passing to capture task)
+    pub fn vad_config(&self) -> VadConfig {
+        self.vad_config.clone()
+    }
+
+    /// Set Tauri app handle (call during voice initialization before start_capture)
+    pub fn set_app_handle(&mut self, handle: tauri::AppHandle) {
+        self.app_handle = Some(handle);
     }
 
     /// Start microphone test

--- a/client/src-tauri/src/audio/handle.rs
+++ b/client/src-tauri/src/audio/handle.rs
@@ -5,10 +5,12 @@
 
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::Arc;
+use std::time::Instant;
 
 use cpal::traits::{DeviceTrait, HostTrait};
 use cpal::{Device, Host};
 use opus::{Channels as OpusChannels, Decoder, Encoder};
+use tauri::Emitter;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
@@ -185,6 +187,8 @@ impl AudioHandle {
 
         let device = self.get_device(self.input_device_name.as_deref(), true)?;
         let muted = self.muted.clone();
+        let vad_config = self.vad_config.clone();
+        let app_handle = self.app_handle.clone();
 
         // Create control channel
         let (control_tx, mut control_rx) = mpsc::channel::<CaptureControl>(1);
@@ -192,7 +196,7 @@ impl AudioHandle {
 
         // Spawn capture task that owns the Stream
         tokio::task::spawn_blocking(move || {
-            run_capture_task(device, muted, output_tx, &mut control_rx);
+            run_capture_task(device, muted, output_tx, &mut control_rx, vad_config, app_handle);
         });
 
         info!("Audio capture started");
@@ -363,71 +367,164 @@ impl AudioHandle {
     }
 }
 
+/// Speech hold-open duration: keep gate open for 300ms after last speech detection
+/// to avoid clipping word endings.
+const SPEECH_HOLD_MS: u128 = 300;
+
 /// Run capture task (owns the Stream)
+///
+/// Captures mono audio, runs each 480-sample (10ms) chunk through RNNoise for
+/// VAD probability + denoising, accumulates 960-sample (20ms) Opus frames, and
+/// gates output based on VAD state.
 fn run_capture_task(
     device: Device,
     muted: Arc<AtomicBool>,
     output_tx: mpsc::Sender<Vec<u8>>,
     control_rx: &mut mpsc::Receiver<CaptureControl>,
+    vad_config: VadConfig,
+    app_handle: Option<tauri::AppHandle>,
 ) {
     use cpal::traits::StreamTrait;
     use cpal::{BufferSize, StreamConfig};
 
     let config = StreamConfig {
-        channels: CHANNELS,
+        channels: CAPTURE_CHANNELS,
         sample_rate: SAMPLE_RATE,
         buffer_size: BufferSize::Default,
     };
 
-    let encoder = match Encoder::new(SAMPLE_RATE, OpusChannels::Stereo, opus::Application::Voip) {
-        Ok(enc) => Arc::new(std::sync::Mutex::new(enc)),
+    // Mono Opus encoder — capture is mono, playback remains stereo
+    let mut encoder = match Encoder::new(SAMPLE_RATE, OpusChannels::Mono, opus::Application::Voip)
+    {
+        Ok(enc) => enc,
         Err(e) => {
             error!("Failed to create encoder: {}", e);
             return;
         }
     };
 
-    let sample_buffer = Arc::new(std::sync::Mutex::new(Vec::with_capacity(
-        FRAME_SIZE * CHANNELS as usize * 2,
-    )));
-    let frame_samples = FRAME_SIZE * CHANNELS as usize;
+    // RNNoise denoiser — processes 480-sample frames, returns VAD probability
+    let mut denoiser = nnnoiseless::DenoiseState::new();
+    let mut first_frame = true;
 
-    let encoder_clone = encoder;
-    let sample_buffer_clone = sample_buffer;
-    let muted_clone = muted;
-    let output_tx_clone = output_tx;
+    // RNNoise accumulator (480 mono samples = 10ms)
+    let mut rnnoise_input: Vec<f32> = Vec::with_capacity(RNNOISE_FRAME_SIZE);
+
+    // Opus frame accumulators (960 mono samples = 20ms)
+    let frame_samples = FRAME_SIZE * CAPTURE_CHANNELS as usize; // 960
+    let mut denoised_accumulator: Vec<f32> = Vec::with_capacity(frame_samples);
+    let mut original_accumulator: Vec<f32> = Vec::with_capacity(frame_samples);
+
+    // VAD gate state
+    let mut gate_open = false;
+    let mut indicator_speaking = false;
+    let mut last_speech_time = Instant::now();
+
+    // Opus encode buffer (reused across frames)
+    let mut encode_buf = vec![0u8; 4000];
 
     let stream = match device.build_input_stream(
         &config,
         move |data: &[f32], _| {
-            if muted_clone.load(Ordering::Relaxed) {
+            // When muted, skip all processing but emit not-speaking if needed
+            if muted.load(Ordering::Relaxed) {
+                if indicator_speaking {
+                    indicator_speaking = false;
+                    gate_open = false;
+                    if let Some(ref app) = app_handle {
+                        let _ = app.emit("voice:speaking", false);
+                    }
+                }
                 return;
             }
 
-            let mut buffer = sample_buffer_clone.lock().unwrap();
-            buffer.extend_from_slice(data);
+            // Process incoming mono samples
+            for &sample in data {
+                // Accumulate into RNNoise 480-sample input buffer (i16 range)
+                rnnoise_input.push(sample * 32767.0);
 
-            while buffer.len() >= frame_samples {
-                let frame: Vec<f32> = buffer.drain(..frame_samples).collect();
+                // Also keep the original f32 sample for non-denoised path
+                original_accumulator.push(sample);
 
-                let samples_i16: Vec<i16> = frame
-                    .iter()
-                    .map(|&s| (s * 32767.0).clamp(-32768.0, 32767.0) as i16)
-                    .collect();
+                if rnnoise_input.len() == RNNOISE_FRAME_SIZE {
+                    // Run RNNoise: denoises in-place and returns VAD probability
+                    let mut rnnoise_output = vec![0.0f32; RNNOISE_FRAME_SIZE];
+                    let vad_prob =
+                        denoiser.process_frame(&mut rnnoise_output, &rnnoise_input);
 
-                let mut encoded = vec![0u8; 4000];
-                if let Ok(mut enc) = encoder_clone.lock() {
-                    match enc.encode(&samples_i16, &mut encoded) {
-                        Ok(len) => {
-                            encoded.truncate(len);
-                            if let Err(e) = output_tx_clone.try_send(encoded) {
-                                warn!("Failed to send encoded audio: {}", e);
+                    if first_frame {
+                        // First frame output has fade-in artifact — discard
+                        // but still use it for accumulator sizing
+                        first_frame = false;
+                        rnnoise_output.fill(0.0);
+                    }
+
+                    // Scale denoised output back to f32 [-1.0, 1.0] range
+                    for s in &mut rnnoise_output {
+                        *s /= 32768.0;
+                    }
+                    denoised_accumulator.extend_from_slice(&rnnoise_output);
+                    rnnoise_input.clear();
+
+                    // --- VAD gate logic ---
+                    let threshold = vad_config.get_threshold();
+
+                    if vad_prob > threshold {
+                        if !indicator_speaking {
+                            indicator_speaking = true;
+                            if let Some(ref app) = app_handle {
+                                let _ = app.emit("voice:speaking", true);
                             }
                         }
-                        Err(e) => {
-                            error!("Opus encode error: {}", e);
+                        last_speech_time = Instant::now();
+                    } else if indicator_speaking
+                        && last_speech_time.elapsed().as_millis() > SPEECH_HOLD_MS
+                    {
+                        indicator_speaking = false;
+                        if let Some(ref app) = app_handle {
+                            let _ = app.emit("voice:speaking", false);
                         }
                     }
+
+                    // Gate decision: if VAD disabled, always open
+                    gate_open = if vad_config.is_enabled() {
+                        indicator_speaking
+                    } else {
+                        true
+                    };
+                }
+
+                // Check if we have a full Opus frame (960 mono samples)
+                if denoised_accumulator.len() >= frame_samples {
+                    if gate_open {
+                        // Choose denoised or original audio
+                        let source = if vad_config.is_denoise_enabled() {
+                            &denoised_accumulator[..frame_samples]
+                        } else {
+                            &original_accumulator[..frame_samples]
+                        };
+
+                        let samples_i16: Vec<i16> = source
+                            .iter()
+                            .map(|&s| (s * 32767.0).clamp(-32768.0, 32767.0) as i16)
+                            .collect();
+
+                        match encoder.encode(&samples_i16, &mut encode_buf) {
+                            Ok(len) => {
+                                let encoded = encode_buf[..len].to_vec();
+                                if let Err(e) = output_tx.try_send(encoded) {
+                                    warn!("Failed to send encoded audio: {}", e);
+                                }
+                            }
+                            Err(e) => {
+                                error!("Opus encode error: {}", e);
+                            }
+                        }
+                    }
+
+                    // Drain consumed samples from both accumulators
+                    denoised_accumulator.drain(..frame_samples);
+                    original_accumulator.drain(..frame_samples);
                 }
             }
         },

--- a/client/src-tauri/src/audio/handle.rs
+++ b/client/src-tauri/src/audio/handle.rs
@@ -407,8 +407,9 @@ fn run_capture_task(
     let mut denoiser = nnnoiseless::DenoiseState::new();
     let mut first_frame = true;
 
-    // RNNoise accumulator (480 mono samples = 10ms)
+    // RNNoise I/O buffers (480 mono samples = 10ms) — pre-allocated to avoid RT allocation
     let mut rnnoise_input: Vec<f32> = Vec::with_capacity(RNNOISE_FRAME_SIZE);
+    let mut rnnoise_output: Vec<f32> = vec![0.0f32; RNNOISE_FRAME_SIZE];
 
     // Opus frame accumulators (960 mono samples = 20ms)
     let frame_samples = FRAME_SIZE * CAPTURE_CHANNELS as usize; // 960
@@ -447,8 +448,8 @@ fn run_capture_task(
                 original_accumulator.push(sample);
 
                 if rnnoise_input.len() == RNNOISE_FRAME_SIZE {
-                    // Run RNNoise: denoises in-place and returns VAD probability
-                    let mut rnnoise_output = vec![0.0f32; RNNOISE_FRAME_SIZE];
+                    // Run RNNoise: denoises and returns VAD probability
+                    rnnoise_output.fill(0.0);
                     let vad_prob =
                         denoiser.process_frame(&mut rnnoise_output, &rnnoise_input);
 

--- a/client/src-tauri/src/audio/mod.rs
+++ b/client/src-tauri/src/audio/mod.rs
@@ -5,6 +5,9 @@
 //! This module provides a Send + Sync audio handle that moves non-thread-safe
 //! `cpal::Stream` objects into background tasks.
 
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::Arc;
+
 use thiserror::Error;
 
 mod handle;
@@ -16,6 +19,59 @@ pub const SAMPLE_RATE: u32 = 48000;
 pub const CHANNELS: u16 = 2;
 pub const FRAME_SIZE_MS: usize = 20;
 pub const FRAME_SIZE: usize = (SAMPLE_RATE as usize * FRAME_SIZE_MS) / 1000; // 960 samples per channel
+
+/// Capture-only channel count (mono for RNNoise compatibility).
+/// Playback/mixer stays stereo (`CHANNELS`) since remote peers may send stereo.
+pub const CAPTURE_CHANNELS: u16 = 1;
+
+/// RNNoise processes 480-sample frames (10ms at 48kHz mono)
+pub const RNNOISE_FRAME_SIZE: usize = 480;
+
+/// Shared VAD + noise suppression state, accessible from CPAL callback thread
+#[derive(Clone)]
+pub struct VadConfig {
+    /// Whether VAD gating is enabled
+    pub enabled: Arc<AtomicBool>,
+    /// VAD threshold (0–100, mapped from 0.0–1.0 × 100 for atomic storage)
+    pub threshold: Arc<AtomicU8>,
+    /// Whether noise suppression (denoised output) is active
+    pub denoise_enabled: Arc<AtomicBool>,
+}
+
+impl VadConfig {
+    pub fn new() -> Self {
+        Self {
+            enabled: Arc::new(AtomicBool::new(false)),
+            threshold: Arc::new(AtomicU8::new(50)), // 0.5 default
+            denoise_enabled: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub fn set_enabled(&self, enabled: bool) {
+        self.enabled.store(enabled, Ordering::Relaxed);
+    }
+
+    pub fn set_threshold(&self, threshold: f32) {
+        let t = (threshold.clamp(0.0, 1.0) * 100.0) as u8;
+        self.threshold.store(t, Ordering::Relaxed);
+    }
+
+    pub fn get_threshold(&self) -> f32 {
+        self.threshold.load(Ordering::Relaxed) as f32 / 100.0
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.load(Ordering::Relaxed)
+    }
+
+    pub fn set_denoise(&self, enabled: bool) {
+        self.denoise_enabled.store(enabled, Ordering::Relaxed);
+    }
+
+    pub fn is_denoise_enabled(&self) -> bool {
+        self.denoise_enabled.load(Ordering::Relaxed)
+    }
+}
 
 /// Audio errors
 #[derive(Error, Debug)]
@@ -85,6 +141,34 @@ mod tests {
 
         handle.set_muted(false);
         assert!(!handle.is_muted());
+    }
+
+    #[test]
+    fn test_vad_config_defaults() {
+        let config = VadConfig::new();
+        assert!(!config.is_enabled());
+        assert!((config.get_threshold() - 0.5).abs() < 0.01);
+        assert!(!config.is_denoise_enabled());
+    }
+
+    #[test]
+    fn test_vad_config_setters() {
+        let config = VadConfig::new();
+        config.set_enabled(true);
+        config.set_threshold(0.7);
+        config.set_denoise(true);
+        assert!(config.is_enabled());
+        assert!((config.get_threshold() - 0.7).abs() < 0.02); // u8 quantization
+        assert!(config.is_denoise_enabled());
+    }
+
+    #[test]
+    fn test_vad_config_threshold_clamping() {
+        let config = VadConfig::new();
+        config.set_threshold(1.5); // above max
+        assert!((config.get_threshold() - 1.0).abs() < 0.01);
+        config.set_threshold(-0.5); // below min
+        assert!(config.get_threshold() < 0.01);
     }
 
     #[test]

--- a/client/src-tauri/src/commands/voice.rs
+++ b/client/src-tauri/src/commands/voice.rs
@@ -39,6 +39,9 @@ pub async fn join_voice(
     let mut voice = state.voice.write().await;
     let voice_state = voice.as_mut().ok_or("Voice not initialized")?;
 
+    // Set app handle for speaking indicator events
+    voice_state.audio.set_app_handle(app.clone());
+
     // Check if already in a channel
     if voice_state.channel_id.is_some() {
         return Err("Already in a voice channel. Leave first.".into());
@@ -556,6 +559,7 @@ pub async fn set_vad_config(
 ) -> Result<(), String> {
     debug!("Setting VAD config: enabled={}, threshold={:.2}", enabled, threshold);
 
+    state.ensure_voice().await?;
     let voice = state.voice.read().await;
     let voice_state = voice.as_ref().ok_or("Voice not initialized")?;
 
@@ -572,6 +576,7 @@ pub async fn set_noise_suppression(
 ) -> Result<(), String> {
     debug!("Setting noise suppression: {}", enabled);
 
+    state.ensure_voice().await?;
     let voice = state.voice.read().await;
     let voice_state = voice.as_ref().ok_or("Voice not initialized")?;
 

--- a/client/src-tauri/src/commands/voice.rs
+++ b/client/src-tauri/src/commands/voice.rs
@@ -557,7 +557,10 @@ pub async fn set_vad_config(
     threshold: f32,
     state: State<'_, AppState>,
 ) -> Result<(), String> {
-    debug!("Setting VAD config: enabled={}, threshold={:.2}", enabled, threshold);
+    debug!(
+        "Setting VAD config: enabled={}, threshold={:.2}",
+        enabled, threshold
+    );
 
     state.ensure_voice().await?;
     let voice = state.voice.read().await;

--- a/client/src-tauri/src/commands/voice.rs
+++ b/client/src-tauri/src/commands/voice.rs
@@ -547,6 +547,39 @@ pub async fn set_deafen(deafened: bool, state: State<'_, AppState>) -> Result<()
     Ok(())
 }
 
+/// Set VAD configuration (enabled + threshold).
+#[command]
+pub async fn set_vad_config(
+    enabled: bool,
+    threshold: f32,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    debug!("Setting VAD config: enabled={}, threshold={:.2}", enabled, threshold);
+
+    let voice = state.voice.read().await;
+    let voice_state = voice.as_ref().ok_or("Voice not initialized")?;
+
+    voice_state.audio.set_vad_config(enabled, threshold);
+
+    Ok(())
+}
+
+/// Set noise suppression (uses RNNoise denoised output when enabled).
+#[command]
+pub async fn set_noise_suppression(
+    enabled: bool,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    debug!("Setting noise suppression: {}", enabled);
+
+    let voice = state.voice.read().await;
+    let voice_state = voice.as_ref().ok_or("Voice not initialized")?;
+
+    voice_state.audio.set_noise_suppression(enabled);
+
+    Ok(())
+}
+
 /// Start microphone test (local only, no server connection).
 #[command]
 pub async fn start_mic_test(

--- a/client/src-tauri/src/lib.rs
+++ b/client/src-tauri/src/lib.rs
@@ -107,6 +107,8 @@ pub fn run() {
             commands::voice::leave_voice,
             commands::voice::set_mute,
             commands::voice::set_deafen,
+            commands::voice::set_vad_config,
+            commands::voice::set_noise_suppression,
             commands::voice::handle_voice_publisher_answer,
             commands::voice::handle_voice_subscriber_offer,
             commands::voice::handle_voice_ice_candidate,

--- a/client/src/lib/webrtc/tauri.ts
+++ b/client/src/lib/webrtc/tauri.ts
@@ -124,18 +124,15 @@ export class TauriVoiceAdapter implements VoiceAdapter {
       this.noiseSuppression = enabled;
       return { ok: true, value: undefined };
     } catch (err) {
-      // Noise suppression might not be implemented in Tauri backend yet
-      // Fall back to just storing the state locally
-      console.warn(
-        "[TauriVoiceAdapter] Noise suppression not implemented in backend",
-      );
-      this.noiseSuppression = enabled;
-      return { ok: true, value: undefined };
+      console.error("[TauriVoiceAdapter] Failed to set noise suppression:", err);
+      return { ok: false, error: { type: "unknown", message: String(err) } };
     }
   }
 
-  setVadConfig(_enabled: boolean, _threshold: number): void {
-    // Tauri backend handles VAD natively; config will be forwarded when implemented
+  setVadConfig(enabled: boolean, threshold: number): void {
+    invoke("set_vad_config", { enabled, threshold }).catch((err) =>
+      console.error("[TauriVoiceAdapter] Failed to set VAD config:", err),
+    );
   }
 
   // Signaling — dual PeerConnection model
@@ -599,6 +596,13 @@ export class TauriVoiceAdapter implements VoiceAdapter {
       await listen<{ user_id: string; stream_id: string; source_type: string }>("voice:webcam_track_removed", (event) => {
         console.log(`[TauriVoiceAdapter] Webcam removed: ${event.payload.user_id}`);
         this.eventHandlers.onWebcamTrackRemoved?.(event.payload.user_id);
+      }),
+    );
+
+    // VAD speaking indicator
+    this.unlisteners.push(
+      await listen<boolean>("voice:speaking", (event) => {
+        this.eventHandlers.onSpeakingChange?.(event.payload);
       }),
     );
   }

--- a/docs/superpowers/plans/2026-04-03-tauri-vad-rnnoise.md
+++ b/docs/superpowers/plans/2026-04-03-tauri-vad-rnnoise.md
@@ -1,0 +1,484 @@
+# Tauri VAD + Noise Suppression Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement RNNoise-based voice activity detection and noise suppression in the Tauri desktop client's audio capture pipeline.
+
+**Architecture:** Integrate the `nnnoiseless` crate into the CPAL capture callback. Switch local capture from stereo to mono. Process 480-sample (10ms) frames through RNNoise to get VAD probability + denoised audio. Gate Opus encoding based on VAD state. Emit speaking events to the frontend.
+
+**Tech Stack:** Rust, nnnoiseless 0.5, CPAL, Opus, Tauri events, TypeScript
+
+**Spec:** `docs/superpowers/specs/2026-04-03-tauri-vad-rnnoise-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `client/src-tauri/Cargo.toml` | Modify | Add `nnnoiseless` dependency |
+| `client/src-tauri/src/audio/mod.rs` | Modify | Add `CAPTURE_CHANNELS` constant, `VadState` struct |
+| `client/src-tauri/src/audio/handle.rs` | Modify | Mono capture, RNNoise integration, VAD gating, speaking events |
+| `client/src-tauri/src/commands/voice.rs` | Modify | Add `set_vad_config` Tauri command |
+| `client/src/lib/webrtc/tauri.ts` | Modify | Wire `setVadConfig`, listen for `voice:speaking` |
+
+---
+
+### Task 1: Add nnnoiseless dependency
+
+**Files:**
+- Modify: `client/src-tauri/Cargo.toml`
+
+- [ ] **Step 1: Add nnnoiseless to Cargo.toml**
+
+The dependency may already exist commented-out. Uncomment or add under `[dependencies]`:
+```toml
+# Audio denoising + VAD
+nnnoiseless = { version = "0.5", default-features = false }
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd client/src-tauri && cargo check`
+Expected: PASS (dependency resolves)
+
+- [ ] **Step 3: Verify license**
+
+Run: `cargo deny check licenses`
+Expected: PASS (BSD-3-Clause is on allowed list)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src-tauri/Cargo.toml client/src-tauri/Cargo.lock
+git commit -m "chore(client): add nnnoiseless dependency for VAD + noise suppression"
+```
+
+---
+
+### Task 2: Add CAPTURE_CHANNELS constant and VadState
+
+**Files:**
+- Modify: `client/src-tauri/src/audio/mod.rs`
+
+- [ ] **Step 1: Add CAPTURE_CHANNELS and VadState**
+
+Add after the existing constants (line 18):
+
+```rust
+/// Capture-only channel count (mono for RNNoise compatibility).
+/// Playback/mixer stays stereo (`CHANNELS`) since remote peers may send stereo.
+pub const CAPTURE_CHANNELS: u16 = 1;
+
+/// RNNoise processes 480-sample frames (10ms at 48kHz mono)
+pub const RNNOISE_FRAME_SIZE: usize = 480;
+```
+
+Add before the `AudioError` enum:
+
+```rust
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+/// Shared VAD + noise suppression state, accessible from CPAL callback thread
+#[derive(Clone)]
+pub struct VadConfig {
+    /// Whether VAD gating is enabled
+    pub enabled: Arc<AtomicBool>,
+    /// VAD threshold (0–100, mapped from 0.0–1.0 × 100 for atomic storage)
+    pub threshold: Arc<std::sync::atomic::AtomicU8>,
+    /// Whether noise suppression (denoised output) is active
+    pub denoise_enabled: Arc<AtomicBool>,
+}
+
+impl VadConfig {
+    pub fn new() -> Self {
+        Self {
+            enabled: Arc::new(AtomicBool::new(false)),
+            threshold: Arc::new(std::sync::atomic::AtomicU8::new(50)), // 0.5 default
+            denoise_enabled: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub fn set_enabled(&self, enabled: bool) {
+        self.enabled.store(enabled, Ordering::Relaxed);
+    }
+
+    pub fn set_threshold(&self, threshold: f32) {
+        let t = (threshold.clamp(0.0, 1.0) * 100.0) as u8;
+        self.threshold.store(t, Ordering::Relaxed);
+    }
+
+    pub fn get_threshold(&self) -> f32 {
+        self.threshold.load(Ordering::Relaxed) as f32 / 100.0
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.load(Ordering::Relaxed)
+    }
+
+    pub fn set_denoise(&self, enabled: bool) {
+        self.denoise_enabled.store(enabled, Ordering::Relaxed);
+    }
+
+    pub fn is_denoise_enabled(&self) -> bool {
+        self.denoise_enabled.load(Ordering::Relaxed)
+    }
+}
+```
+
+- [ ] **Step 2: Add test for VadConfig**
+
+Add to the existing `#[cfg(test)] mod tests` block:
+
+```rust
+#[test]
+fn test_vad_config_defaults() {
+    let config = VadConfig::new();
+    assert!(!config.is_enabled());
+    assert!((config.get_threshold() - 0.5).abs() < 0.01);
+    assert!(!config.is_denoise_enabled());
+}
+
+#[test]
+fn test_vad_config_setters() {
+    let config = VadConfig::new();
+    config.set_enabled(true);
+    config.set_threshold(0.7);
+    config.set_denoise(true);
+    assert!(config.is_enabled());
+    assert!((config.get_threshold() - 0.7).abs() < 0.02); // u8 quantization
+    assert!(config.is_denoise_enabled());
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd client/src-tauri && cargo test -p vc-client -- audio`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src-tauri/src/audio/mod.rs
+git commit -m "feat(client): add VadConfig and CAPTURE_CHANNELS constant"
+```
+
+---
+
+### Task 3: Add VadConfig to AudioHandle
+
+**Files:**
+- Modify: `client/src-tauri/src/audio/handle.rs`
+
+- [ ] **Step 1: Add VadConfig and AppHandle fields to AudioHandle**
+
+Update the import line to include new types:
+```rust
+use super::{AudioDevice, AudioDeviceList, AudioError, CAPTURE_CHANNELS, CHANNELS, FRAME_SIZE, RNNOISE_FRAME_SIZE, SAMPLE_RATE, VadConfig};
+```
+
+Add fields to `AudioHandle`:
+
+```rust
+/// VAD + noise suppression configuration
+vad_config: VadConfig,
+
+/// Tauri app handle for emitting events from capture thread
+app_handle: Option<tauri::AppHandle>,
+```
+
+Initialize in `AudioHandle::new()`:
+
+```rust
+vad_config: VadConfig::new(),
+app_handle: None,
+```
+
+- [ ] **Step 2: Add VAD setter methods**
+
+Add methods to `AudioHandle`:
+
+```rust
+/// Set VAD configuration
+pub fn set_vad_config(&self, enabled: bool, threshold: f32) {
+    self.vad_config.set_enabled(enabled);
+    self.vad_config.set_threshold(threshold);
+    debug!("VAD config: enabled={}, threshold={:.2}", enabled, threshold);
+}
+
+/// Set noise suppression
+pub fn set_noise_suppression(&self, enabled: bool) {
+    self.vad_config.set_denoise(enabled);
+    debug!("Noise suppression: {}", enabled);
+}
+
+/// Get VAD config (for passing to capture task)
+pub fn vad_config(&self) -> VadConfig {
+    self.vad_config.clone()
+}
+
+/// Set Tauri app handle (call during voice initialization before start_capture)
+pub fn set_app_handle(&mut self, handle: tauri::AppHandle) {
+    self.app_handle = Some(handle);
+}
+```
+
+- [ ] **Step 3: Verify compile**
+
+Run: `cd client/src-tauri && cargo check -p vc-client`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src-tauri/src/audio/handle.rs
+git commit -m "feat(client): wire VadConfig into AudioHandle"
+```
+
+---
+
+### Task 4: Switch capture to mono + integrate RNNoise
+
+**Files:**
+- Modify: `client/src-tauri/src/audio/handle.rs`
+
+This is the core task. Modify `run_capture_task` to use mono capture, process through RNNoise, and gate output.
+
+- [ ] **Step 1: Update run_capture_task signature**
+
+Add `vad_config: VadConfig` and `app_handle: tauri::AppHandle` parameters to `run_capture_task`. Update the call site in `start_capture` to pass them.
+
+- [ ] **Step 2: Switch to mono capture**
+
+In `run_capture_task`, change:
+```rust
+let config = StreamConfig {
+    channels: CAPTURE_CHANNELS,  // was: CHANNELS
+    sample_rate: SAMPLE_RATE,
+    buffer_size: BufferSize::Default,
+};
+
+let encoder = match Encoder::new(SAMPLE_RATE, OpusChannels::Mono, opus::Application::Voip) {
+    // was: OpusChannels::Stereo
+```
+
+Update `frame_samples`:
+```rust
+let frame_samples = FRAME_SIZE * CAPTURE_CHANNELS as usize; // 960 × 1 = 960
+```
+
+- [ ] **Step 3: Create RNNoise DenoiseState**
+
+All RNNoise processing and Opus encoding happen inside the CPAL callback closure, so these variables are moved into the closure — no Mutex needed (the callback owns them exclusively). Create them before `build_input_stream` so they're captured by move:
+
+```rust
+let mut denoiser = nnnoiseless::DenoiseState::new();
+let mut rnnoise_input = [0.0f32; RNNOISE_FRAME_SIZE];
+let mut rnnoise_output = [0.0f32; RNNOISE_FRAME_SIZE];
+let mut rnnoise_pos: usize = 0;
+let mut denoised_accumulator: Vec<f32> = Vec::with_capacity(FRAME_SIZE);
+let mut original_accumulator: Vec<f32> = Vec::with_capacity(FRAME_SIZE);
+let mut first_frame = true;
+
+// VAD gate state
+let mut gate_open = false;
+let mut indicator_speaking = false; // separate from gate for VAD-disabled mode
+let mut last_speech_time = std::time::Instant::now();
+const VAD_HOLD_MS: u128 = 300;
+```
+
+Remove the existing `sample_buffer` Mutex — all buffering now happens in the closure-owned accumulators.
+
+- [ ] **Step 4: Rewrite the CPAL callback**
+
+Replace the inner callback logic. Remove the existing `sample_buffer` Mutex pattern — everything now lives in the closure. For each incoming f32 sample:
+
+1. If `muted`: return early (existing behavior; also covers PTT since PTT toggles mute)
+2. Store original sample, accumulate into `rnnoise_input[rnnoise_pos]` scaled to i16 range (`* 32767.0`)
+3. Increment `rnnoise_pos`; when it reaches `RNNOISE_FRAME_SIZE` (480):
+   a. Call `denoiser.process_frame(&mut rnnoise_output, &rnnoise_input)` → returns VAD probability
+   b. If `first_frame`: discard output, set `first_frame = false`, reset `rnnoise_pos`, continue
+   c. Scale denoised output back (`/ 32768.0`), push 480 samples to `denoised_accumulator`
+   d. Push original 480 samples to `original_accumulator`
+   e. Update speaking indicator: if `vad_prob > threshold` → `indicator_speaking = true`, reset timer. Else if `elapsed > VAD_HOLD_MS` → `indicator_speaking = false`. Emit `voice:speaking` on transitions via `app_handle.emit("voice:speaking", indicator_speaking)`. Note: `AppHandle::emit()` is synchronous, safe to call from the CPAL thread.
+   f. Update gate: if VAD enabled → `gate_open = indicator_speaking`. If VAD disabled → `gate_open = true` (always open, but speaking events still fire for the UI indicator).
+   g. Reset `rnnoise_pos = 0`
+4. When `denoised_accumulator.len() >= FRAME_SIZE` (960 samples):
+   a. If `gate_open`: choose denoised vs original based on `denoise_enabled`, convert to i16 (`(s * 32767.0).clamp(...) as i16`), Opus encode, send via `output_tx`
+   b. Drain both accumulators
+
+- [ ] **Step 5: Update start_capture to pass new params**
+
+Modify `start_capture` to pass `self.vad_config.clone()` and `self.app_handle.clone()` to the capture task. The `app_handle` field was added in Task 3; ensure `set_app_handle()` is called during voice initialization (in `ensure_voice()` or `handle_voice_publisher_answer` in `commands/voice.rs`) before `start_capture`.
+
+- [ ] **Step 6: Verify compile**
+
+Run: `cd client/src-tauri && cargo check -p vc-client`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add client/src-tauri/src/audio/handle.rs
+git commit -m "feat(client): RNNoise VAD + denoising in mono capture pipeline"
+```
+
+---
+
+### Task 5: Add set_vad_config Tauri command
+
+**Files:**
+- Modify: `client/src-tauri/src/commands/voice.rs`
+
+- [ ] **Step 1: Add set_vad_config command**
+
+Follow the pattern of `set_mute` (line 509). Add:
+
+```rust
+#[tauri::command]
+pub async fn set_vad_config(
+    enabled: bool,
+    threshold: f32,
+    state: State<'_, AppState>,
+) -> Result<(), String> {
+    debug!("Setting VAD config: enabled={}, threshold={:.2}", enabled, threshold);
+
+    let voice = state.voice.read().await;
+    let voice_state = voice.as_ref().ok_or("Voice not initialized")?;
+
+    voice_state.audio.set_vad_config(enabled, threshold);
+
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Add set_noise_suppression command**
+
+```rust
+#[tauri::command]
+pub async fn set_noise_suppression(enabled: bool, state: State<'_, AppState>) -> Result<(), String> {
+    debug!("Setting noise suppression: {}", enabled);
+
+    let voice = state.voice.read().await;
+    let voice_state = voice.as_ref().ok_or("Voice not initialized")?;
+
+    voice_state.audio.set_noise_suppression(enabled);
+
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Register commands in main.rs**
+
+Find the `invoke_handler` in `main.rs` and add `set_vad_config` and `set_noise_suppression` to the list.
+
+- [ ] **Step 4: Verify compile**
+
+Run: `cd client/src-tauri && cargo check -p vc-client`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src-tauri/src/commands/voice.rs client/src-tauri/src/main.rs
+git commit -m "feat(client): add set_vad_config and set_noise_suppression Tauri commands"
+```
+
+---
+
+### Task 6: Wire TypeScript adapter
+
+**Files:**
+- Modify: `client/src/lib/webrtc/tauri.ts`
+
+- [ ] **Step 1: Wire setVadConfig to Tauri command**
+
+Replace the no-op `setVadConfig` (line 137-139):
+
+```typescript
+setVadConfig(enabled: boolean, threshold: number): void {
+  invoke("set_vad_config", { enabled, threshold }).catch((err) =>
+    console.error("[TauriVoiceAdapter] Failed to set VAD config:", err),
+  );
+}
+```
+
+- [ ] **Step 2: Clean up setNoiseSuppression**
+
+The existing code already invokes `set_noise_suppression` but has a fallback catch that logs "not implemented." Remove the fallback now that the backend exists (around line 125-134):
+
+```typescript
+async setNoiseSuppression(
+  enabled: boolean,
+): Promise<VoiceResult<void>> {
+  try {
+    await invoke("set_noise_suppression", { enabled });
+    this.noiseSuppression = enabled;
+    return { ok: true, value: undefined };
+  } catch (err) {
+    console.error("[TauriVoiceAdapter] Failed to set noise suppression:", err);
+    return { ok: false, error: { type: "unknown", message: String(err) } };
+  }
+}
+```
+
+- [ ] **Step 3: Add voice:speaking event listener**
+
+In the `setupEventListeners` method (around line 528), add after the existing listeners:
+
+```typescript
+this.unlisteners.push(
+  await listen<boolean>("voice:speaking", (event) => {
+    this.events.onSpeakingChange?.(event.payload);
+  }),
+);
+```
+
+- [ ] **Step 4: Run client tests**
+
+Run: `cd client && bun run test:run`
+Expected: 577+ tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/lib/webrtc/tauri.ts
+git commit -m "feat(client): wire VAD config and speaking events in Tauri adapter"
+```
+
+---
+
+### Task 7: Update CHANGELOG and final verification
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add CHANGELOG entries**
+
+Under `[Unreleased] > ### Added`:
+```markdown
+- Voice activity detection (VAD) on desktop client — microphone is gated using RNNoise ML model with configurable threshold and 300ms hold-open
+- Noise suppression on desktop client — RNNoise denoises audio in real-time when enabled in voice settings
+- Local speaking indicator on desktop client — green ring animates when you're speaking
+```
+
+Under `[Unreleased] > ### Changed`:
+```markdown
+- Desktop voice capture switched from stereo to mono for bandwidth efficiency and RNNoise compatibility
+```
+
+- [ ] **Step 2: Run full verification**
+
+```bash
+SQLX_OFFLINE=true cargo clippy -p vc-client -- -D warnings
+cd client && bun run tsc --noEmit && bun run test:run
+```
+Expected: All pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: add CHANGELOG entries for desktop VAD + noise suppression"
+```

--- a/docs/superpowers/specs/2026-04-03-tauri-vad-rnnoise-design.md
+++ b/docs/superpowers/specs/2026-04-03-tauri-vad-rnnoise-design.md
@@ -1,0 +1,153 @@
+# Tauri VAD + Noise Suppression via RNNoise
+
+**Date:** 2026-04-03
+**Status:** Approved
+**Scope:** Desktop client (Tauri) — voice activity detection and noise suppression
+
+## Problem
+
+The Tauri desktop client's VAD toggle is a no-op. `setVadConfig` in the TypeScript adapter discards its arguments. Desktop users see a working VAD toggle in settings but it does nothing — audio transmits continuously regardless. The speaking indicator never animates. Noise suppression is also unimplemented on the backend.
+
+## Solution
+
+Integrate the `nnnoiseless` crate (pure Rust RNNoise port, BSD-3-Clause) into the CPAL audio capture pipeline. RNNoise provides both VAD probability and denoised audio in a single pass, closing two gaps at once.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| VAD approach | RNNoise (ML-based) | Better than RMS: handles non-speech noise (fans, typing). Also provides denoising for free. |
+| RNNoise binding | `nnnoiseless` (pure Rust, BSD-3-Clause) | No native dependency, no FFI. Cross-platform build stays simple. Use `default-features = false` to avoid CLI/DAP deps. |
+| Channel count | Mono (was stereo) | Voice chat has no use for stereo mic input. Halves processing, aligns with RNNoise's mono requirement. Discord and most voice apps use mono. |
+| Speaking indicator | Rust → Tauri event | CPAL callback is the source of truth for gate state. Emits `voice:speaking` event on transitions. |
+
+## Pipeline Architecture
+
+```
+Microphone (CPAL, mono 48kHz f32)
+    │
+    ▼
+Accumulate 480 samples (10ms)
+    │
+    ▼
+Scale f32 [-1.0, 1.0] → i16 range [-32768.0, 32767.0]
+(nnnoiseless expects i16-range f32 values)
+    │
+    ▼
+RNNoise process_frame()
+    ├─ Output: denoised PCM (480 samples, i16-range f32)
+    ├─ Output: VAD probability (0.0–1.0)
+    └─ Note: discard first frame output (fade-in artifact)
+    │
+    ▼
+Scale back → f32 [-1.0, 1.0] (for denoised path)
+    │
+    ▼
+Accumulate 2 frames → 960 samples (20ms)
+    │
+    ▼
+VAD Gate Decision
+    ├─ probability > threshold → gate OPEN
+    ├─ 300ms hold-open after last speech
+    ├─ PTT active → bypass VAD (gate OPEN)
+    └─ Muted → skip everything
+    │
+    ▼
+Opus Encode (mono, 48kHz, 960 samples)
+    │
+    ▼
+Send to WebRTC track (or discard if gate closed)
+```
+
+## VAD Gate Logic
+
+The gate is a simple state machine:
+
+- **CLOSED → OPEN**: VAD probability exceeds user threshold on any 10ms frame.
+- **OPEN → HOLD**: VAD probability drops below threshold. Start 300ms timer.
+- **HOLD → OPEN**: VAD probability exceeds threshold before timer expires.
+- **HOLD → CLOSED**: Timer expires without speech detected.
+
+State transitions emit `voice:speaking` Tauri events. The frontend Tauri adapter listens and calls `onSpeakingChange(speaking)` to drive the UI speaking ring.
+
+**When VAD is disabled:** RNNoise still runs for noise suppression. The gate stays permanently open. `voice:speaking` events are still emitted based on VAD probability (for the speaking indicator UI), but the gate does not close.
+
+Priority chain: **Mute > PTT > VAD**. If muted, no audio captured. If PTT active, VAD bypassed. Otherwise VAD controls the gate.
+
+## Noise Suppression
+
+RNNoise always runs in the pipeline. The `setNoiseSuppression(enabled)` toggle controls which samples go to Opus:
+- **Enabled**: Denoised samples from RNNoise output (scaled back to f32 range).
+- **Disabled**: Original samples (but RNNoise still runs for VAD probability).
+
+This avoids conditional pipeline branching and gives noise suppression with zero additional cost.
+
+## Mono Pipeline Migration
+
+Current: stereo (2 channels), 960 samples/channel per 20ms frame.
+New: mono (1 channel), 960 samples per 20ms frame.
+
+The mono change affects multiple sites — use a separate `CAPTURE_CHANNELS = 1` constant for the local capture pipeline while keeping `CHANNELS = 2` for the playback/mixer path (remote peers may send stereo from browsers):
+
+- **CPAL input config**: use `CAPTURE_CHANNELS` (1) for mic capture
+- **Opus encoder**: stereo → mono (VoIP profile unchanged)
+- **Remote Opus decoder** (`commands/voice.rs`): stays stereo — browser peers send stereo
+- **Audio mixer** (`voice/audio_mixer.rs`): stays stereo — mixes remote tracks for playback
+- **Playback buffer cap** (`handle.rs`): stays stereo-based for output path
+- **RNNoise**: processes 480-sample mono frames (10ms at 48kHz)
+- Two RNNoise frames = one 960-sample Opus frame
+
+## Files to Change
+
+### Rust (client/src-tauri/src/)
+
+1. **`audio/mod.rs`** — Add `CAPTURE_CHANNELS = 1` constant (keep `CHANNELS = 2` for playback). Add VAD state struct (enabled, threshold, hold timer, gate state, noise suppression toggle).
+
+2. **`audio/handle.rs`** — Core changes:
+   - Switch CPAL capture config to mono (`CAPTURE_CHANNELS`)
+   - Create `nnnoiseless::DenoiseState` on capture start (heap-allocated via `Box`)
+   - Discard first `process_frame` output (fade-in artifact)
+   - In audio callback: accumulate 480 samples, scale to i16 range, run `process_frame()`, collect VAD probability and denoised output
+   - Scale denoised output back to f32 range
+   - Accumulate two processed frames (960 samples) for Opus
+   - Apply gate logic (threshold + hold timer) before encoding
+   - Emit `voice:speaking` on gate transitions
+   - Choose denoised vs original based on noise suppression flag
+
+3. **`commands/voice.rs`** — Add `set_vad_config` Tauri command that sets enabled + threshold on the shared audio state. Add `set_noise_suppression` forwarding if not already wired.
+
+### TypeScript (client/src/lib/webrtc/)
+
+4. **`tauri.ts`** — Wire `setVadConfig(enabled, threshold)` to invoke `set_vad_config` Tauri command. Register listener for `voice:speaking` events, call `onSpeakingChange` callback.
+
+### Build
+
+5. **`client/src-tauri/Cargo.toml`** — Add `nnnoiseless = { version = "0.5", default-features = false }`.
+
+## Constants
+
+| Constant | Value | Source |
+|----------|-------|--------|
+| Sample rate | 48000 Hz | Existing |
+| Capture channels | 1 (mono) | New — local capture only |
+| Playback channels | 2 (stereo) | Existing — remote audio unchanged |
+| RNNoise frame size | 480 samples (10ms) | RNNoise requirement |
+| Opus frame size | 960 samples (20ms) | Existing |
+| VAD hold time | 300ms | Matches browser |
+| Default threshold | 0.5 | Matches browser default |
+
+## Success Criteria
+
+- Desktop VAD toggle gates audio transmission (no more no-op)
+- Speaking ring animates for local user on desktop
+- Noise suppression toggle produces audibly cleaner audio
+- No latency increase (RNNoise processes 10ms frames within 20ms Opus cadence)
+- `cargo clippy` passes, `bun run test:run` passes
+- License check passes (`nnnoiseless` is BSD-3-Clause — on allowed list)
+
+## Out of Scope
+
+- VP8 video decoding (separate spec)
+- Custom RNNoise models / training
+- Per-user noise suppression profiles
+- Simulcast encoding improvements


### PR DESCRIPTION
## Summary
Integrates `nnnoiseless` (pure Rust RNNoise port) into the Tauri desktop client's audio capture pipeline, closing three desktop parity gaps:

- **VAD gating**: Microphone is gated using RNNoise's ML-based voice activity detection with configurable threshold and 300ms hold-open. The desktop VAD toggle was previously a no-op.
- **Noise suppression**: RNNoise denoises audio in real-time. The toggle now controls whether denoised or original audio is sent.
- **Speaking indicator**: `voice:speaking` Tauri events drive the green speaking ring for the local user. Was never emitted on desktop.

### Pipeline changes
- **Mono capture**: Switched from stereo to mono — voice chat doesn't benefit from stereo mic, and RNNoise requires mono input. Playback/mixer remain stereo for remote peers.
- **RNNoise integration**: Every 480 samples (10ms) → `process_frame()` → VAD probability + denoised PCM. Two frames accumulated → 960-sample Opus frame.
- **No Mutex**: Removed the `Arc<Mutex<Vec<f32>>>` sample buffer pattern — all processing now lives inside the CPAL closure.

### Files changed
- `client/src-tauri/Cargo.toml` — `nnnoiseless` dependency
- `client/src-tauri/src/audio/mod.rs` — `VadConfig`, `CAPTURE_CHANNELS`, `RNNOISE_FRAME_SIZE`
- `client/src-tauri/src/audio/handle.rs` — Core pipeline rewrite
- `client/src-tauri/src/commands/voice.rs` — `set_vad_config`, `set_noise_suppression` commands
- `client/src-tauri/src/lib.rs` — Register new commands
- `client/src/lib/webrtc/tauri.ts` — Wire adapter to commands + speaking events

## Test plan
- [ ] Desktop: enable VAD → speak → audio transmits; stop speaking → audio stops after 300ms
- [ ] Desktop: disable VAD → audio transmits continuously (speaking indicator still animates)
- [ ] Desktop: enable noise suppression → background noise reduced
- [ ] Desktop: mute → no audio regardless of VAD state
- [ ] Desktop: speaking ring animates when talking
- [ ] Browser: no regression — browser VAD/voice unaffected
- [ ] `bun run tsc --noEmit` and `bun run test:run` pass

**Note:** `cargo check -p vc-client` cannot be verified on the dev machine due to a pre-existing `libspa` 0.8 / PipeWire 1.6 incompatibility in the `scap` dependency. The Rust code follows existing patterns and the `nnnoiseless` API docs. Full compilation will be verified on a machine with compatible PipeWire or after updating the scap fork.

🤖 Generated with [Claude Code](https://claude.com/claude-code)