### PR TITLE
test(infra): serialize setup-state tests across nextest processes (#509)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,3 +3,17 @@
 slow-timeout = { period = "120s", terminate-after = 1 }
 # Continue running other tests even if one fails or times out
 fail-fast = false
+
+# Cross-process serialization for tests that mutate the singleton
+# `server_config.setup_complete` row. Each nextest test runs in its own process,
+# so the in-process `#[serial(setup)]` lock from `serial_test` does NOT serialize
+# tests across processes. Without this group, two parallel processes can both
+# call `set_setup_complete(false)` and then race their CAS UPDATE against each
+# other, producing 5×403 (or any-x-403) instead of the expected 1×204.
+# See issue #509.
+[test-groups]
+setup-state = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = 'test(setup_http::) + test(setup_concurrent_http::)'
+test-group = 'setup-state'

--- a/server/tests/integration/setup_concurrent_http.rs
+++ b/server/tests/integration/setup_concurrent_http.rs
@@ -8,6 +8,12 @@
 //! auth middleware, JSON deserialization, validation, compare-and-swap,
 //! and response serialization — all under concurrent load.
 //!
+//! Cross-process serialization with other tests that mutate
+//! `server_config.setup_complete` is enforced by the `setup-state`
+//! nextest test-group in `.config/nextest.toml`. The in-process
+//! `#[serial(setup)]` lock below provides defense in depth for
+//! plain `cargo test` runs (which run all tests in a single process).
+//!
 //! Run with: `cargo test --test integration setup_concurrent_http -- --nocapture`
 
 use axum::body::Body;
@@ -44,7 +50,6 @@ async fn set_setup_complete(pool: &sqlx::PgPool, complete: bool) -> bool {
 /// while the other gets 403 (`SETUP_ALREADY_COMPLETE`).
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial(setup)]
-#[ignore = "Flaky: race condition timing depends on CI load"]
 async fn test_concurrent_http_setup_completion() {
     let app = TestApp::new().await;
 
@@ -126,7 +131,6 @@ async fn test_concurrent_http_setup_completion() {
 /// Test that concurrent completion with 5 admins still results in exactly one success.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[serial(setup)]
-#[ignore = "Flaky: race condition timing depends on CI load"]
 async fn test_concurrent_http_setup_five_admins() {
     let app = TestApp::new().await;
 


### PR DESCRIPTION
## Summary

Fix the flaky `setup_http::test_complete_succeeds_for_admin` and re-enable both ignored `setup_concurrent_http::*` tests.

The hypothesis recorded in #509 (`CleanupGuard` async drop racing the `serial_test` lock release) is **incorrect**: `CleanupGuard::drop` is fully synchronous (`std::thread::spawn(...).join()` blocks until cleanup completes), so the in-process timing story doesn't apply.

**Real root cause:** CI runs `cargo nextest run -j 4`, which spawns each test in its own process. `serial_test`'s `#[serial(setup)]` is a process-local mutex from `lazy_static!`, so it cannot serialize across nextest worker processes. Two or more processes from the same integration binary could simultaneously mutate the singleton `server_config.setup_complete` row — a test that had just called `set_setup_complete(false)` could then observe `true` (set by another process) by the time its CAS UPDATE ran, producing the "got 0 successes" / 403-instead-of-204 symptom on whichever setup-mutating test was unlucky on a given run.

This explains every observation in #509:
- Why the failure says "got 0 successes" — another concurrent process flipped `setup_complete=true` between this test's `set_setup_complete(false)` and its CAS UPDATE.
- Why it's "load dependent" — only happens when nextest schedules ≥2 setup-mutating tests in parallel (`-j ≥ 2`).
- Why local `cargo test` doesn't repro it — single-process thread-based parallelism, where `#[serial(setup)]` does work.
- Why the same flake bit `setup_http::test_complete_succeeds_for_admin` on the latest main CI run, not a `setup_concurrent_http::*` test — *any* setup-mutating test can lose this race; the ignored ones are not special.

## The fix

Declare a `setup-state` nextest test-group with `max-threads = 1` covering all 10 tests under ``test(setup_http::) + test(setup_concurrent_http::)`` in ``.config/nextest.toml``. nextest enforces this limit **globally across worker processes**, so at most one setup-mutating test runs at a time even with ``-j 4``.

```toml
[test-groups]
setup-state = { max-threads = 1 }

[[profile.default.overrides]]
filter = 'test(setup_http::) + test(setup_concurrent_http::)'
test-group = 'setup-state'
```

The existing ``#[serial(setup)]`` annotations are kept as defense in depth for plain ``cargo test`` runs (single-process, thread-based). Both previously-ignored concurrent tests (``test_concurrent_http_setup_completion``, ``test_concurrent_http_setup_five_admins``) are re-enabled.

Verified that nextest correctly assigns all 10 tests to the group:

```
$ cargo nextest show-config test-groups -p vc-server
group: setup-state (max threads = 1)
  * override for default profile with filter 'test(setup_http::) + test(setup_concurrent_http::)':
      vc-server::integration:
          setup_concurrent_http::test_concurrent_http_setup_completion
          setup_concurrent_http::test_concurrent_http_setup_five_admins
          setup_http::test_complete_already_done
          setup_http::test_complete_rejects_invalid_body
          setup_http::test_complete_requires_admin
          setup_http::test_complete_requires_auth
          setup_http::test_complete_succeeds_for_admin
          setup_http::test_config_returns_403_when_setup_complete
          setup_http::test_config_returns_values_when_setup_incomplete
          setup_http::test_status_returns_setup_state
```

## Test plan

- [x] ``cargo nextest run -p vc-server --test integration -j 4 -E 'test(setup_http::) + test(setup_concurrent_http::)'`` — 10/10 stress runs pass, all 10 tests serialize cleanly
- [x] ``cargo nextest run -p vc-server --test integration -j 4 --no-fail-fast`` — 446/446 pass (CI parity)
- [x] ``cargo fmt -p vc-server --check`` — clean
- [x] Clippy clean on touched file (``setup_concurrent_http.rs``); pre-existing clippy errors elsewhere on main are unrelated
- [ ] CI passes on this PR with the previously-ignored tests now running
- [ ] Watch CI for ~5 runs after merge to confirm the flake is gone

## Notes

- ``CHANGELOG.md`` intentionally not updated: per project guidance, test-only changes without user-facing impact don't need a changelog entry.
- ``#[ignore]`` removed from both concurrent tests; they now run in the regular CI pass, not the ``--run-ignored ignored-only`` second pass.
- Branch was originally named ``fix/setup-cleanup-guard-race`` based on the (disproven) #509 hypothesis; renamed before push.

Closes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)