### PR TITLE
ci(security): add osv-scanner job for OSV database coverage

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -141,3 +141,48 @@ jobs:
         uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"
+
+  # ===========================================================================
+  # OSV Scanner — independent advisory source (OSV database)
+  # ===========================================================================
+  osv-scan:
+    name: OSV Scanner
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write  # for SARIF upload to Code Scanning
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run osv-scanner
+        # Exit code is the gate. Do NOT set continue-on-error.
+        # SARIF upload below uses if: always() to publish results
+        # to Code Scanning even on scanner failure.
+        #
+        # Pinned to v2.3.5 specifically because:
+        # 1. Upstream has no `v2` floating tag — only patch tags exist.
+        # 2. Upstream warns: "the scanner action behavior might change in
+        #    a minor patch update." Pin precisely.
+        #
+        # Before merging this PR, check
+        # https://github.com/google/osv-scanner-action/releases for any
+        # newer patch tag and update if appropriate.
+        uses: google/osv-scanner-action/osv-scanner-action@v2.3.5
+        with:
+          # --severity=HIGH gates only on HIGH+ findings, matching the
+          # spec's recommended threshold. MEDIUM/LOW still appear in the
+          # SARIF upload (and the Security tab) but don't fail the job.
+          scan-args: |-
+            --recursive
+            --skip-git
+            --severity=HIGH
+            --format=sarif
+            --output=osv-results.sarif
+            ./
+
+      - name: Upload SARIF to Code Scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: osv-results.sarif
+          category: osv-scanner


### PR DESCRIPTION
## Summary

Adds an osv-scanner job to `.github/workflows/security.yml`. Uses the OSV vulnerability database, independent from RustSec (covered by cargo-audit/deny) and GHSA (covered by CodeQL). Provides a third independent advisory source.

## Failure semantics

- Scanner exit code is the gate at **HIGH+ severity**. No `continue-on-error`.
- MEDIUM/LOW findings still appear in the SARIF upload (and Security tab) but don't fail the job.
- SARIF upload runs on `if: always()` so failed scans still publish to GitHub Security tab for tracking.

## Action versioning

Pinned to `google/osv-scanner-action@v2.3.5`. Upstream has **no `v2` floating tag** — only patch tags exist, and upstream warns that action behavior may change in minor patch updates. See https://github.com/google/osv-scanner-action/releases for newer patch tags.

## Expected first-run outcomes

a) **Zero HIGH+ vulnerabilities (job passes):** ideal outcome. Topic 1 (#517) just cleared 11 of 17 devtime advisories; the remaining 3 unique CVEs are vite dev-server issues which may or may not be reachable via osv-scanner's lockfile parsing.

b) **osv-scanner finds HIGH+ vulnerabilities (job fails):** informative. The OSV database may flag advisories that RustSec/GHSA don't. These would be real issues to investigate in a follow-up PR — don't fix here.

c) **osv-scanner can't read bun.lock (Rust-only coverage):** osv-scanner's lockfile parser has historically lagged on bun. If the scan is Rust-only, that's still additive value (OSV is the third independent source for Rust advisories).

## Test plan

- [x] YAML validates with python3 yaml.safe_load
- [x] `jobs` list shows: rust-audit, dependencies, bun-audit, secrets-scan, codeql, osv-scan
- [ ] osv-scan job runs on this PR (first CI run)
- [ ] Job either passes or reports real HIGH+ vulnerabilities
- [ ] SARIF results visible in GitHub Security tab under `osv-scanner` category

## Refs

- Spec: docs/superpowers/specs/2026-04-11-security-audit-followups-design.md (Topic 2)
- Plan: docs/superpowers/plans/2026-04-11-osv-scanner-ci.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)