### PR TITLE
fix(ci): remove invalid osv-scanner flags

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -169,13 +169,14 @@ jobs:
         # newer patch tag and update if appropriate.
         uses: google/osv-scanner-action/osv-scanner-action@v2.3.5
         with:
-          # --severity=HIGH gates only on HIGH+ findings, matching the
-          # spec's recommended threshold. MEDIUM/LOW still appear in the
-          # SARIF upload (and the Security tab) but don't fail the job.
+          # Minimal flag set. osv-scanner v2.3.5 does not support
+          # --skip-git or --severity; the first-run attempt with those
+          # flags failed with "flag provided but not defined".
+          # Severity filtering can be done post-scan via the SARIF
+          # category if needed. For now, gate on ANY vulnerability
+          # exit code.
           scan-args: |-
             --recursive
-            --skip-git
-            --severity=HIGH
             --format=sarif
             --output=osv-results.sarif
             ./

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -169,14 +169,14 @@ jobs:
         # newer patch tag and update if appropriate.
         uses: google/osv-scanner-action/osv-scanner-action@v2.3.5
         with:
-          # Minimal flag set. osv-scanner v2.3.5 does not support
-          # --skip-git or --severity; the first-run attempt with those
-          # flags failed with "flag provided but not defined".
-          # Severity filtering can be done post-scan via the SARIF
-          # category if needed. For now, gate on ANY vulnerability
-          # exit code.
+          # Gates on ANY unignored vulnerability via exit code.
+          # .osv-scanner.toml at the repo root contains the ignore list
+          # (cargo-deny/rust-audit ignores + PR #517 vite exceptions).
+          # osv-scanner v2.3.5 does NOT support --skip-git or
+          # --severity — both were invalid flags in the first attempt.
           scan-args: |-
             --recursive
+            --config=/github/workspace/.osv-scanner.toml
             --format=sarif
             --output=osv-results.sarif
             ./

--- a/.osv-scanner.toml
+++ b/.osv-scanner.toml
@@ -1,0 +1,149 @@
+# osv-scanner ignore list
+#
+# This file is NOT authoritative — cargo-deny and cargo-audit remain the
+# primary advisory gates for Rust, and `bun audit` is the primary gate for
+# npm. This config just tells osv-scanner to match their tolerance so the
+# third-source check doesn't permanently block CI.
+#
+# When a new advisory appears in this file's gate, osv-scanner will fail
+# the build. Investigate, then either fix the dep or add a new entry here
+# with justification.
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2023-0071"
+# rsa crate Marvin Attack. No safe upgrade; used by openidconnect. Already
+# ignored in deny.toml.
+reason = "Accepted via deny.toml; pulled through openidconnect, no fix available."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0097"
+# rand 0.8.5 unsoundness with custom log logger. Not exploitable in Kaiku
+# because we use tracing, not the log facade. Already ignored in deny.toml.
+reason = "Accepted via deny.toml; not exploitable in our configuration (we use tracing, not log facade)."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2026-0002"
+# lru 0.12.5 unmaintained. Pulled by a transitive dep; upgrade path blocked
+# upstream. Already ignored in deny.toml.
+reason = "Accepted via deny.toml; unmaintained, no runtime vuln."
+
+# ---------------------------------------------------------------------------
+# Tauri gtk-rs 0.18 family — Linux-only deps, all marked unmaintained by
+# RustSec because gtk-rs moved to 0.20+. Tauri pins 0.18. Not runtime-critical
+# because gtk is Linux window integration, and we don't expose user-controlled
+# input to gtk APIs. Upgrade blocked on Tauri.
+# ---------------------------------------------------------------------------
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0411"
+reason = "gdkwayland-sys unmaintained; Linux-only Tauri dep."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0412"
+reason = "gdk unmaintained; Linux-only Tauri dep."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0413"
+reason = "atk unmaintained; Linux-only Tauri dep."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0414"
+reason = "gdkx11-sys unmaintained; Linux-only Tauri dep."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0415"
+reason = "gtk unmaintained; Linux-only Tauri dep."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0416"
+reason = "atk-sys unmaintained; Linux-only Tauri dep."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0417"
+reason = "gdkx11 unmaintained; Linux-only Tauri dep."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0418"
+reason = "gdk-sys unmaintained; Linux-only Tauri dep."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0419"
+reason = "gtk3-macros unmaintained; Linux-only Tauri dep."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0420"
+reason = "gtk-sys unmaintained; Linux-only Tauri dep."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0429"
+# glib 0.18.5 has a fix (0.20.0) but the upgrade is blocked by Tauri's
+# pin on the gtk-rs 0.18 stack. Track upstream.
+reason = "glib 0.18.5 Iterator soundness issue; fix in 0.20.0, blocked by Tauri's gtk-rs 0.18 pin."
+
+# ---------------------------------------------------------------------------
+# Misc unmaintained crate bindings
+# ---------------------------------------------------------------------------
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0370"
+reason = "proc-macro-error unmaintained; transitive, no runtime impact."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0384"
+reason = "instant unmaintained; transitive, no runtime impact."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0388"
+reason = "derivative unmaintained; transitive, no runtime impact."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0436"
+reason = "paste unmaintained; transitive, no runtime impact."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0057"
+reason = "fxhash unmaintained; transitive, no runtime impact."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0075"
+reason = "unic-char-range unmaintained; transitive."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0080"
+reason = "unic-common unmaintained; transitive."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0081"
+reason = "unic-char-property unmaintained; transitive."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0098"
+reason = "unic-ucd-version unmaintained; transitive."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0100"
+reason = "unic-ucd-ident unmaintained; transitive."
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2025-0141"
+reason = "bincode unmaintained; transitive."
+
+# ---------------------------------------------------------------------------
+# vite 7.3.1 / 8.0.0 — nested via vitest > @vitest/mocker
+# ---------------------------------------------------------------------------
+# These three CVEs are already documented in PR #517 as accepted dev-only
+# exceptions. vite 8.0.5 (the fix version) breaks vite-plugin-solid's JSX
+# parsing because @vitest/mocker's internal API is incompatible with vite
+# 8.x as the nested instance. See PR #517 for full analysis.
+
+[[IgnoredVulns]]
+id = "GHSA-4w7w-66w2-5vf9"
+reason = "Accepted in PR #517; vite dev-server only, nested via vitest. Fix requires unblocking the @vitest/mocker/vite 8.x compat issue."
+
+[[IgnoredVulns]]
+id = "GHSA-p9ff-h696-f583"
+reason = "Accepted in PR #517; vite dev-server only, nested via vitest."
+
+[[IgnoredVulns]]
+id = "GHSA-v2wj-q39q-566r"
+reason = "Accepted in PR #517; vite dev-server only, nested via vitest."


### PR DESCRIPTION
## Summary

Fixes two issues with the osv-scanner CI job added in #518:

1. **Invalid flags** — `--skip-git` and `--severity=HIGH` were both non-existent. First-run failed with `flag provided but not defined: -skip-git`.

2. **Noisy findings** — after removing the invalid flags, osv-scanner found 34 advisories (mostly unmaintained-crate warnings that cargo-audit treats as warnings, not errors, plus the 3 vite CVEs already documented in PR #517 as accepted dev-only exceptions).

## Fix

- Commit 1 `3cf6e3e`: Strip to minimal valid flags (`--recursive --format=sarif --output ./`).
- Commit 2 `adec7e0`: Add `.osv-scanner.toml` ignore config with 28 entries (accepted deny.toml advisories + gtk-rs 0.18 family unmaintained warnings + vite PR #517 exceptions). Pass `--config=/github/workspace/.osv-scanner.toml` to the scanner.

## Ignore list structure (28 entries)

| Category | Count | Notes |
|---|---|---|
| deny.toml already-ignored | 3 | rsa Marvin, rand 0.8.5, lru unmaintained |
| gtk-rs 0.18 family (Tauri Linux) | 11 | Blocked on Tauri's gtk-rs pin |
| Misc unmaintained crates | 11 | proc-macro-error, paste, instant, derivative, fxhash, unic-*, bincode |
| vite dev-server CVEs | 3 | Already documented in PR #517 |

Each entry has a `reason` field with justification.

## Verification

Local run:
```
osv-scanner --config=.osv-scanner.toml --recursive ./
Filtered 36 vulnerabilities from output
No issues found
```

CI run on branch (https://github.com/Detair/kaiku/actions/runs/24293183995):
- OSV Scanner: **completed/success** ✅

## Refs

- First-run failure: https://github.com/Detair/kaiku/actions/runs/24292956710
- Second-run (noisy): https://github.com/Detair/kaiku/actions/runs/24293038310
- Third-run (pass): https://github.com/Detair/kaiku/actions/runs/24293183995
- Original job: #518
- Spec: docs/superpowers/specs/2026-04-11-security-audit-followups-design.md (Topic 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)