### PR TITLE
docs(client): record scap upstream re-check result

### DIFF
--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -64,10 +64,12 @@ nnnoiseless = { version = "0.5", default-features = false }
 # Linux pipewire backend, breaking the Linux build. Our fork (commit 4d1304e9)
 # adapts the Linux backend to the new enum structure plus a Windows typo fix.
 #
-# Upstream PR that would fix this: https://github.com/CapSoftware/scap/pull/178
-# (open since 2025-10-26, broader scope: adds sequence numbers + SystemTime +
-# latest-buffer grab). Once merged and released, drop this git dep and pin to
-# the next scap release. Track in #TODO (or file an issue).
+# Upstream tracking:
+# - CapSoftware/scap#178 — broader fix, open since 2025-10-26, no updates
+# - Last re-check 2026-04-12: upstream main HEAD still fails Linux build
+#   (see closed PR #520 for the test run)
+# - Issue #521 tracks periodic re-checks — drop this git dep when upstream
+#   publishes a new release with the Linux fix
 scap = { git = "https://github.com/Detair/scap.git", branch = "fix/linux-frame-enum" }
 
 # Webcam capture


### PR DESCRIPTION
## Summary

Completes Topic 3 of the security audit follow-ups by updating the `scap` Cargo.toml comment with the 2026-04-12 re-check result and a link to the new tracking issue.

**No code change.** The scap dep still points at `Detair/scap@fix/linux-frame-enum`. The comment now accurately reflects why.

## Re-check result (2026-04-12)

- Upstream `CapSoftware/scap` main HEAD (`c03f15a4`): ubuntu build **fails** (Frame enum regression still unfixed)
- Test PR: #520 (closed)
- Upstream PR #178 still open since 2025-10-26, no updates
- No Linux-related commits on upstream main since 2025-03-04

## Tracking

Issue #521 captures:
- Re-check history (first row: 2026-04-12)
- Upstream watch list (PR #178, Linux commit path)
- Re-check procedure (clone upstream main, point Cargo.toml, test CI)
- When to re-check (new scap release, PR #178 merge, quarterly)

## Topic 3 status

Per the plan's acceptance criteria:
> Either \`Cargo.toml\` no longer references \`Detair/scap\` (best case, Step 2a) **or** there is a tracked upstream PR with our targeted fix submitted (acceptable case, Step 2b)

Neither is achievable right now:
- Step 2a blocked (upstream still broken)
- Step 2b declined by maintainer bandwidth concerns — PR #178 has been sitting for 5+ months with no upstream activity, so a duplicate narrow PR is unlikely to fare better

Topic 3 is closed as "blocked on upstream, tracked via issue #521 for periodic re-check."

## Refs

- Spec: docs/superpowers/specs/2026-04-11-security-audit-followups-design.md (Topic 3)
- Plan: docs/superpowers/plans/2026-04-11-scap-fork-cleanup.md
- Test PR: #520 (closed)
- Tracking issue: #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)