### PR TITLE
fix(client): fix same-hue contrast violations in admin badges and banners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Opening a channel with unreads scrolls to your last read position
 
 ### Fixed
+- Admin dashboard status badges, elevation buttons, and warning banners now have readable text instead of invisible same-hue text on colored backgrounds (#524)
 - Clicking another user's reaction emoji now correctly toggles your own reaction instead of removing theirs (#454)
 - Sent friend requests now show "Cancel" button instead of Accept/Decline buttons in the pending view (#453)
 - Rejecting or cancelling a friend request now updates the other user's UI in real time via WebSocket

--- a/client/src/components/admin/AdminQuickModal.tsx
+++ b/client/src/components/admin/AdminQuickModal.tsx
@@ -156,7 +156,7 @@ const AdminQuickModal: Component<AdminQuickModalProps> = (props) => {
                 {/* Elevated State */}
                 <div class="p-4 rounded-lg bg-status-warning/15 border border-status-warning/50 space-y-3">
                   <div class="flex items-center justify-between">
-                    <div class="flex items-center gap-2 text-status-warning">
+                    <div class="flex items-center gap-2 text-text-primary">
                       <ShieldAlert class="w-4 h-4" />
                       <span class="text-sm font-semibold">Session Elevated</span>
                     </div>
@@ -212,7 +212,7 @@ const AdminQuickModal: Component<AdminQuickModalProps> = (props) => {
 
             {/* Error Display */}
             <Show when={adminState.error}>
-              <div class="p-3 rounded-lg bg-status-error/15 border border-status-error/50 text-status-error text-sm font-medium">
+              <div class="p-3 rounded-lg bg-status-error/15 border border-status-error/50 text-text-primary text-sm font-medium">
                 {adminState.error}
               </div>
             </Show>

--- a/client/src/components/admin/AdminSettings.tsx
+++ b/client/src/components/admin/AdminSettings.tsx
@@ -303,7 +303,7 @@ const AdminSettings: Component = () => {
           </div>
         </Show>
         <Show when={state.success}>
-          <div class="p-3 rounded-lg text-sm bg-status-success/10 border border-status-success/30 text-status-success">
+          <div class="p-3 rounded-lg text-sm bg-status-success/10 border border-status-success/30 text-text-primary">
             {state.success}
           </div>
         </Show>
@@ -472,7 +472,7 @@ const AdminSettings: Component = () => {
                           <span
                             class="text-xs px-2 py-0.5 rounded-full"
                             classList={{
-                              "bg-status-success/20 text-status-success":
+                              "bg-status-success/20 text-text-primary":
                                 provider.enabled,
                               "bg-white/10 text-text-secondary": !provider.enabled,
                             }}

--- a/client/src/components/admin/CommandCenterPanel.tsx
+++ b/client/src/components/admin/CommandCenterPanel.tsx
@@ -281,9 +281,9 @@ const LevelBadge: Component<{ level: string }> = (props) => {
   const colors = () => {
     switch (props.level) {
       case "ERROR":
-        return "bg-status-error/20 text-status-error";
+        return "bg-status-error/20 text-text-primary";
       case "WARN":
-        return "bg-status-warning/20 text-status-warning";
+        return "bg-status-warning/20 text-text-primary";
       case "INFO":
         return "bg-accent-primary/20 text-text-primary";
       case "DEBUG":
@@ -307,12 +307,12 @@ const LevelBadge: Component<{ level: string }> = (props) => {
 const StatusBadge: Component<{ statusCode: string | null; isError: boolean }> =
   (props) => {
     const color = () => {
-      if (props.isError) return "bg-status-error/20 text-status-error";
+      if (props.isError) return "bg-status-error/20 text-text-primary";
       const code = parseInt(props.statusCode ?? "", 10);
       if (isNaN(code)) return "bg-surface-highlight text-text-secondary";
-      if (code >= 500) return "bg-status-error/20 text-status-error";
-      if (code >= 400) return "bg-status-warning/20 text-status-warning";
-      return "bg-status-success/20 text-status-success";
+      if (code >= 500) return "bg-status-error/20 text-text-primary";
+      if (code >= 400) return "bg-status-warning/20 text-text-primary";
+      return "bg-status-success/20 text-text-primary";
     };
 
     return (
@@ -459,7 +459,7 @@ const CommandCenterPanel: Component = () => {
           </div>
           <div class="flex items-center gap-3">
             <Show when={isStale()}>
-              <div class="flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-status-warning/15 text-status-warning text-xs font-medium">
+              <div class="flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-status-warning/15 text-text-primary text-xs font-medium">
                 <AlertTriangle class="w-3 h-3" />
                 Stale data
               </div>

--- a/client/src/components/admin/GuildsPanel.tsx
+++ b/client/src/components/admin/GuildsPanel.tsx
@@ -470,13 +470,13 @@ const GuildsPanel: Component = () => {
                     <Show
                       when={guild.suspended_at}
                       fallback={
-                        <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-status-success/20 text-status-success">
+                        <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-status-success/20 text-text-primary">
                           <CheckCircle class="w-3 h-3" />
                           Active
                         </span>
                       }
                     >
-                      <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-status-error/20 text-status-error">
+                      <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-status-error/20 text-text-primary">
                         <Ban class="w-3 h-3" />
                         Suspended
                       </span>
@@ -620,13 +620,13 @@ const GuildsPanel: Component = () => {
                     <Show
                       when={guild().suspended_at}
                       fallback={
-                        <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-status-success/20 text-status-success">
+                        <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-status-success/20 text-text-primary">
                           <CheckCircle class="w-3 h-3" />
                           Active
                         </span>
                       }
                     >
-                      <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-status-error/20 text-status-error">
+                      <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-status-error/20 text-text-primary">
                         <Ban class="w-3 h-3" />
                         Suspended
                       </span>

--- a/client/src/components/admin/ReportsPanel.tsx
+++ b/client/src/components/admin/ReportsPanel.tsx
@@ -209,7 +209,7 @@ const ReportsPanel: Component = () => {
                 <span class="px-2 py-1 rounded-full text-xs font-medium bg-status-warning/10 text-text-primary border border-status-warning/30">
                   {stats()!.pending} pending
                 </span>
-                <span class="px-2 py-1 rounded-full text-xs font-medium bg-blue-400/10 text-blue-400 border border-blue-400/30">
+                <span class="px-2 py-1 rounded-full text-xs font-medium bg-blue-400/10 text-text-primary border border-blue-400/30">
                   {stats()!.reviewing} reviewing
                 </span>
               </div>

--- a/client/src/components/admin/ReportsPanel.tsx
+++ b/client/src/components/admin/ReportsPanel.tsx
@@ -30,9 +30,9 @@ import Skeleton from "@/components/ui/Skeleton";
 const PAGE_SIZE = 20;
 
 const STATUS_COLORS: Record<string, string> = {
-  pending: "text-status-warning bg-status-warning/10 border-status-warning/30",
-  reviewing: "text-blue-400 bg-blue-400/10 border-blue-400/30",
-  resolved: "text-status-success bg-status-success/10 border-status-success/30",
+  pending: "text-text-primary bg-status-warning/10 border-status-warning/30",
+  reviewing: "text-text-primary bg-blue-400/10 border-blue-400/30",
+  resolved: "text-text-primary bg-status-success/10 border-status-success/30",
   dismissed: "text-text-secondary bg-white/5 border-white/10",
 };
 
@@ -206,7 +206,7 @@ const ReportsPanel: Component = () => {
           >
             <Show when={stats()}>
               <div class="flex items-center gap-2">
-                <span class="px-2 py-1 rounded-full text-xs font-medium bg-status-warning/10 text-status-warning border border-status-warning/30">
+                <span class="px-2 py-1 rounded-full text-xs font-medium bg-status-warning/10 text-text-primary border border-status-warning/30">
                   {stats()!.pending} pending
                 </span>
                 <span class="px-2 py-1 rounded-full text-xs font-medium bg-blue-400/10 text-blue-400 border border-blue-400/30">

--- a/client/src/components/admin/UsersPanel.tsx
+++ b/client/src/components/admin/UsersPanel.tsx
@@ -481,13 +481,13 @@ const UsersPanel: Component = () => {
                     <Show
                       when={user.is_banned}
                       fallback={
-                        <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-status-success/20 text-status-success">
+                        <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-status-success/20 text-text-primary">
                           <CheckCircle class="w-3 h-3" />
                           Active
                         </span>
                       }
                     >
-                      <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-status-error/20 text-status-error">
+                      <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-status-error/20 text-text-primary">
                         <Ban class="w-3 h-3" />
                         Banned
                       </span>
@@ -590,13 +590,13 @@ const UsersPanel: Component = () => {
                     <Show
                       when={user().is_banned}
                       fallback={
-                        <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-status-success/20 text-status-success">
+                        <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-status-success/20 text-text-primary">
                           <CheckCircle class="w-3 h-3" />
                           Active
                         </span>
                       }
                     >
-                      <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-status-error/20 text-status-error">
+                      <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-status-error/20 text-text-primary">
                         <Ban class="w-3 h-3" />
                         Banned
                       </span>
@@ -682,7 +682,7 @@ const UsersPanel: Component = () => {
                 </div>
 
                 <Show when={!adminState.isElevated}>
-                  <div class="p-3 rounded-lg bg-status-warning/10 border border-status-warning/30 text-status-warning text-xs">
+                  <div class="p-3 rounded-lg bg-status-warning/10 border border-status-warning/30 text-text-primary text-xs">
                     Requires elevation to perform actions
                   </div>
                 </Show>

--- a/client/src/components/modals/BlockConfirmModal.tsx
+++ b/client/src/components/modals/BlockConfirmModal.tsx
@@ -87,7 +87,7 @@ const BlockConfirmModal: Component<BlockConfirmModalProps> = (props) => {
             </p>
 
             {error() && (
-              <div class="p-3 rounded-lg bg-status-error/10 border border-status-error/30 text-status-error text-sm">
+              <div class="p-3 rounded-lg bg-status-error/10 border border-status-error/30 text-text-primary text-sm">
                 {error()}
               </div>
             )}

--- a/client/src/components/modals/ReportModal.tsx
+++ b/client/src/components/modals/ReportModal.tsx
@@ -176,7 +176,7 @@ const ReportModal: Component<ReportModalProps> = (props) => {
                 </div>
 
                 {error() && (
-                  <div class="p-3 rounded-lg bg-status-error/10 border border-status-error/30 text-status-error text-sm">
+                  <div class="p-3 rounded-lg bg-status-error/10 border border-status-error/30 text-text-primary text-sm">
                     {error()}
                   </div>
                 )}

--- a/client/src/components/settings/ChangePasswordModal.tsx
+++ b/client/src/components/settings/ChangePasswordModal.tsx
@@ -160,7 +160,7 @@ const ChangePasswordModal: Component<ChangePasswordModalProps> = (props) => {
                     </div>
                 }>
                     <div class="p-6 space-y-4">
-                        <div class="flex items-center gap-3 p-4 bg-status-success/10 border border-status-success/20 rounded-xl text-status-success">
+                        <div class="flex items-center gap-3 p-4 bg-status-success/10 border border-status-success/20 rounded-xl text-text-primary">
                             <CheckCircle2 class="w-5 h-5 shrink-0" />
                             <p class="text-sm font-medium">Password changed successfully!</p>
                         </div>

--- a/client/src/components/settings/SessionsSection.tsx
+++ b/client/src/components/settings/SessionsSection.tsx
@@ -117,7 +117,7 @@ const SessionsSection: Component = () => {
                         {session.device}
                       </span>
                       <Show when={session.is_current}>
-                        <span class="px-1.5 py-0.5 text-[10px] rounded-md bg-status-success/20 text-status-success font-medium">
+                        <span class="px-1.5 py-0.5 text-[10px] rounded-md bg-status-success/20 text-text-primary font-medium">
                           Current
                         </span>
                       </Show>

--- a/client/src/views/AdminDashboard.tsx
+++ b/client/src/views/AdminDashboard.tsx
@@ -136,14 +136,14 @@ const AdminDashboard: Component = () => {
             fallback={
               <button
                 onClick={() => setShowElevateModal(true)}
-                class="flex items-center gap-2 px-3 py-1.5 rounded-full bg-status-warning/20 text-status-warning text-sm font-medium hover:bg-status-warning/30 transition-colors cursor-pointer"
+                class="flex items-center gap-2 px-3 py-1.5 rounded-full bg-status-warning/20 text-text-primary text-sm font-medium hover:bg-status-warning/30 transition-colors cursor-pointer"
               >
                 <ShieldAlert class="w-4 h-4" />
                 Not Elevated
               </button>
             }
           >
-            <div class="flex items-center gap-2 px-3 py-1.5 rounded-full bg-status-success/25 text-status-success text-sm font-medium">
+            <div class="flex items-center gap-2 px-3 py-1.5 rounded-full bg-status-success/25 text-text-primary text-sm font-medium">
               <Shield class="w-4 h-4" />
               Elevated ({timeRemaining()})
             </div>
@@ -279,7 +279,7 @@ const AdminDashboard: Component = () => {
                         <div class="flex items-start gap-3">
                           <ShieldAlert class="w-5 h-5 text-status-warning flex-shrink-0 mt-0.5" />
                           <div>
-                            <h3 class="text-sm font-semibold text-status-warning">
+                            <h3 class="text-sm font-semibold text-text-primary">
                               Session Not Elevated
                             </h3>
                             <p class="text-sm text-text-primary mt-1">


### PR DESCRIPTION
## Summary
- Status badges (Users, Guilds), elevation button/banner, log level badges, and info boxes all used same-hue text on same-hue backgrounds (e.g. `text-status-warning` on `bg-status-warning/20`), making text invisible or barely readable
- Changed text color to `text-text-primary` across 11 files while keeping colored backgrounds for semantic meaning and colored icons for decoration
- Fixes apply to admin dashboard components, settings modals, and shared modals (ReportModal, BlockConfirmModal, etc.)

## Test plan
- [ ] Open admin dashboard Overview — "Not Elevated" button text visible, elevation banner text readable
- [ ] Check Users page — "Active"/"Banned" status badges have readable text
- [ ] Check Guilds page — "Active"/"Suspended" status badges have readable text  
- [ ] Check Command Center — log level badges (ERROR, WARN), status badges, and "Stale data" indicator readable
- [ ] Check Reports page — pending/reviewing/resolved status badges readable
- [ ] Check Settings → Sessions — "Current" session badge readable
- [ ] Verify across all themes (Nord Dark, Solarized, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)