### PR TITLE
fix(client): Android auth & network security hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Android: tokens are no longer persisted until user identity is verified, preventing orphaned credentials on process death
 - Android: WebSocket reconnect checks token expiry before attempting handshake, preventing 401 loops
 - Android: network connectivity detection uses `NET_CAPABILITY_VALIDATED` to avoid false positives on captive portals
+- Android: OIDC PKCE state is persisted synchronously, preventing intermittent CSRF-error login failures on low-memory devices
+- Android: TLS 1.3 provider failure now prompts users to update Play Services instead of failing silently on every network call
 
 ### Fixed
+- Android: OIDC callback path matching is now exact instead of prefix-based, preventing potential intent collisions
+- Android: WebSocket connection state correctly waits for server authentication confirmation before reporting Connected
 - Admin dashboard status badges, elevation buttons, and warning banners now have readable text instead of invisible same-hue text on colored backgrounds (#524)
 - Clicking another user's reaction emoji now correctly toggles your own reaction instead of removing theirs (#454)
 - Sent friend requests now show "Cancel" button instead of Accept/Decline buttons in the pending view (#453)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - "New Messages" divider shows where you left off when returning to a channel
 - Opening a channel with unreads scrolls to your last read position
 
+### Security
+- Android: enforce TLS 1.3 on all network connections (HTTP and WebSocket)
+- Android: WebSocket authentication moved from header to post-connect frame, preventing token exposure in proxy logs
+- Android: OIDC login now uses PKCE and state nonce to prevent authorization code interception and CSRF
+- Android: OIDC callback supports Android App Links (`https://`) in addition to custom scheme (`kaiku://`)
+- Android: tokens are no longer persisted until user identity is verified, preventing orphaned credentials on process death
+- Android: WebSocket reconnect checks token expiry before attempting handshake, preventing 401 loops
+- Android: network connectivity detection uses `NET_CAPABILITY_VALIDATED` to avoid false positives on captive portals
+
 ### Fixed
 - Admin dashboard status badges, elevation buttons, and warning banners now have readable text instead of invisible same-hue text on colored backgrounds (#524)
 - Clicking another user's reaction emoji now correctly toggles your own reaction instead of removing theirs (#454)

--- a/docs/superpowers/plans/2026-04-13-android-auth-network.md
+++ b/docs/superpowers/plans/2026-04-13-android-auth-network.md
@@ -1,0 +1,609 @@
+# Android Auth & Network Fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden Android auth security (OIDC, token storage, TLS) and fix network robustness issues (WebSocket reconnect, connectivity detection).
+
+**Architecture:** Nine targeted fixes across auth, network, and DI layers. The WebSocket auth migration (#1) requires a coordinated server+client change with backwards compatibility. All other fixes are client-only.
+
+**Tech Stack:** Kotlin, OkHttp, Ktor, Hilt, EncryptedSharedPreferences, WebSocket
+
+**Spec:** `docs/superpowers/specs/2026-04-13-mobile-implementation-fixes-design.md` — Sub-Project 1
+
+**Branch:** `fix/android-auth-network`
+
+---
+
+## File Map
+
+| File | Responsibility |
+|------|---------------|
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/data/ws/KaikuWebSocket.kt` | WebSocket auth, token expiry check, scope tracking |
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/data/ws/ConnectivityMonitor.kt` | NET_CAPABILITY_VALIDATED, Closeable |
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/data/api/KaikuHttpClient.kt` | TLS 1.3 via shared OkHttp config |
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/auth/OidcHandler.kt` | PKCE + state nonce |
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/data/repository/AuthRepository.kt` | Defer token persistence until getMe |
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/di/NetworkModule.kt` | TLS 1.3 ConnectionSpec, ProviderInstaller |
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/di/WebSocketModule.kt` | TLS 1.3 for WebSocket OkHttpClient |
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/KaikuApplication.kt` | ProviderInstaller in onCreate |
+| `mobile/android/app/src/main/AndroidManifest.xml` | App Links intent filter, BLUETOOTH maxSdkVersion |
+| `server/src/ws/events.rs` | Authenticate ClientEvent variant |
+| `server/src/ws/handlers.rs` | Dual-auth support (header + frame) |
+| `mobile/android/app/src/test/java/io/wolftown/kaiku/data/ws/KaikuWebSocketTest.kt` | Updated auth tests |
+
+---
+
+## Task 1: TLS 1.3 enforcement (#2)
+
+**Files:**
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/di/NetworkModule.kt:30`
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/di/WebSocketModule.kt:29`
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/KaikuApplication.kt:6`
+
+- [ ] **Step 1: Add ProviderInstaller to KaikuApplication**
+
+At `KaikuApplication.kt`, add an `onCreate` override that calls `ProviderInstaller.installIfNeeded(this)` to ensure TLS 1.3 is available on API 26-28:
+
+```kotlin
+import android.app.Application
+import com.google.android.gms.security.ProviderInstaller
+import dagger.hilt.android.HiltAndroidApp
+import java.util.logging.Logger
+
+@HiltAndroidApp
+class KaikuApplication : Application() {
+    private val logger = Logger.getLogger("KaikuApplication")
+
+    override fun onCreate() {
+        super.onCreate()
+        try {
+            ProviderInstaller.installIfNeeded(this)
+        } catch (e: Exception) {
+            logger.warning("Failed to install security provider: ${e.message}")
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Create TLS 1.3 ConnectionSpec in NetworkModule**
+
+At `NetworkModule.kt`, add a `@Provides @Singleton` function for the `ConnectionSpec` and apply it to the HTTP client:
+
+```kotlin
+import okhttp3.ConnectionSpec
+import okhttp3.TlsVersion
+
+@Provides
+@Singleton
+fun provideTls13Spec(): ConnectionSpec {
+    return ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+        .tlsVersions(TlsVersion.TLS_1_3)
+        .build()
+}
+```
+
+Update the existing OkHttp engine provision to use this spec. The Ktor `OkHttp.create()` call at line 30 needs the engine configured with `.config { connectionSpecs(listOf(tls13Spec)) }`.
+
+- [ ] **Step 3: Apply TLS 1.3 spec to WebSocket OkHttpClient**
+
+At `WebSocketModule.kt:29`, inject the `ConnectionSpec` and apply it:
+
+```kotlin
+@Provides
+@Singleton
+fun provideWebSocketClient(tls13Spec: ConnectionSpec): OkHttpClient {
+    return OkHttpClient.Builder()
+        .connectionSpecs(listOf(tls13Spec))
+        .pingInterval(0, TimeUnit.SECONDS)
+        .readTimeout(0, TimeUnit.SECONDS)
+        .build()
+}
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `cd mobile/android && ./gradlew test`
+Expected: PASS — TLS spec is configuration-only, no behavioral change in tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/android/app/src/main/java/io/wolftown/kaiku/di/NetworkModule.kt \
+  mobile/android/app/src/main/java/io/wolftown/kaiku/di/WebSocketModule.kt \
+  mobile/android/app/src/main/java/io/wolftown/kaiku/KaikuApplication.kt
+git commit -m "fix(client): enforce TLS 1.3 on all Android network connections (#2)"
+```
+
+---
+
+## Task 2: ConnectivityMonitor fixes (#15, #18)
+
+**Files:**
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/data/ws/ConnectivityMonitor.kt`
+
+- [ ] **Step 1: Add NET_CAPABILITY_VALIDATED and Closeable**
+
+In `ConnectivityMonitor.kt`:
+1. Add `NET_CAPABILITY_VALIDATED` alongside `NET_CAPABILITY_INTERNET` in `checkCurrentConnectivity()` (line 46) and in `onCapabilitiesChanged` (inside the NetworkCallback).
+2. Implement `Closeable` interface with a `close()` method that calls `connectivityManager.unregisterNetworkCallback(networkCallback)`.
+
+```kotlin
+import java.io.Closeable
+
+@Singleton
+class ConnectivityMonitor @Inject constructor(
+    @ApplicationContext private val context: Context
+) : Closeable {
+    // ... existing code ...
+
+    // In checkCurrentConnectivity:
+    // Change: hasCapability(NET_CAPABILITY_INTERNET)
+    // To:     hasCapability(NET_CAPABILITY_INTERNET) && hasCapability(NET_CAPABILITY_VALIDATED)
+
+    // In onCapabilitiesChanged:
+    // Add same NET_CAPABILITY_VALIDATED check
+
+    override fun close() {
+        try {
+            connectivityManager.unregisterNetworkCallback(networkCallback)
+        } catch (_: IllegalArgumentException) {
+            // Already unregistered
+        }
+        _isConnected.value = false
+    }
+}
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `cd mobile/android && ./gradlew test`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mobile/android/app/src/main/java/io/wolftown/kaiku/data/ws/ConnectivityMonitor.kt
+git commit -m "fix(client): require NET_CAPABILITY_VALIDATED and add Closeable to ConnectivityMonitor (#15, #18)"
+```
+
+---
+
+## Task 3: WebSocket token expiry check and scope tracking (#16, #17)
+
+**Files:**
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/data/ws/KaikuWebSocket.kt:57,75,123`
+
+- [ ] **Step 1: Track connectivity collector job**
+
+At `KaikuWebSocket.kt:57`, add a field:
+
+```kotlin
+private var connectivityJob: Job? = null
+```
+
+At `setConnectivityMonitor` (line 75), cancel any existing collector before launching a new one:
+
+```kotlin
+fun setConnectivityMonitor(monitor: ConnectivityMonitor) {
+    connectivityJob?.cancel()
+    connectivityJob = scope.launch {
+        monitor.isConnected.collect { connected ->
+            // ... existing reconnect logic
+        }
+    }
+}
+```
+
+In `disconnect()`, add `connectivityJob?.cancel()` alongside the existing `pingJob?.cancel()` and `reconnectJob?.cancel()`.
+
+- [ ] **Step 2: Add token expiry check before reconnect**
+
+At `doConnect()` (line 123), before building the WebSocket request, add:
+
+```kotlin
+if (tokenStorage.isAccessTokenExpired()) {
+    _connectionState.value = ConnectionState.TokenExpired
+    return
+}
+```
+
+Add `TokenExpired` to the `ConnectionState` enum at `KaikuWebSocket.kt:28-32` (top-level enum in the same file).
+
+- [ ] **Step 3: Update existing WebSocket test**
+
+At `KaikuWebSocketTest.kt`, update the test `connect uses Sec-WebSocket-Protocol header with token` (line 176) to account for the new `TokenExpired` state. Add a test for expired token behavior.
+
+- [ ] **Step 4: Build and verify**
+
+Run: `cd mobile/android && ./gradlew test`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/android/app/src/main/java/io/wolftown/kaiku/data/ws/KaikuWebSocket.kt \
+  mobile/android/app/src/test/java/io/wolftown/kaiku/data/ws/KaikuWebSocketTest.kt
+git commit -m "fix(client): check token expiry before WS reconnect, track connectivity collector (#16, #17)"
+```
+
+---
+
+## Task 4: WebSocket auth migration — server dual-auth (#1, server side)
+
+**Files:**
+- Modify: `server/src/ws/events.rs:65`
+- Modify: `server/src/ws/handlers.rs:36-96,420`
+
+- [ ] **Step 1: Add Authenticate variant to ClientEvent**
+
+At `server/src/ws/events.rs:65`, inside `pub enum ClientEvent`, add a new variant:
+
+```rust
+/// Post-connect authentication (replaces header-based auth for new clients).
+Authenticate {
+    /// JWT access token.
+    token: String,
+},
+```
+
+- [ ] **Step 2: Modify ws_handler to support dual auth**
+
+At `server/src/ws/handlers.rs`, the current flow at line 87-96 calls `extract_token_from_protocol()` and returns 401 if no token found — *before* upgrading the WebSocket. Restructure to:
+
+1. Try `extract_token_from_protocol()` first (header auth — existing path).
+2. If header auth succeeds: upgrade with existing logic (backwards compatible, no behavior change).
+3. If header auth fails (no header present): upgrade the WebSocket anyway, then enter a pre-auth message loop.
+
+The pre-auth loop:
+
+```rust
+// In ws_handler, after the header auth check fails:
+// Accept the WebSocket upgrade without authentication
+let (response, ws_stream) = /* upgrade without requiring token */;
+
+// Pre-auth loop: wait for Authenticate frame with 5s timeout
+let user_id = match tokio::time::timeout(
+    std::time::Duration::from_secs(5),
+    wait_for_authenticate(&mut ws_stream, &state),
+).await {
+    Ok(Ok(uid)) => uid,
+    Ok(Err(e)) => {
+        // Invalid token — close with error
+        let _ = ws_stream.close(Some(CloseFrame { code: CloseCode::Policy, reason: e.into() })).await;
+        return;
+    }
+    Err(_) => {
+        // Timeout — close connection
+        let _ = ws_stream.close(Some(CloseFrame { code: CloseCode::Policy, reason: "Auth timeout".into() })).await;
+        return;
+    }
+};
+
+// Continue with the existing authenticated message loop using user_id
+```
+
+Create `wait_for_authenticate` as a helper:
+
+```rust
+async fn wait_for_authenticate(
+    ws_stream: &mut WebSocketStream,
+    state: &AppState,
+) -> Result<Uuid, String> {
+    while let Some(Ok(msg)) = ws_stream.next().await {
+        if let Message::Text(text) = msg {
+            if let Ok(ClientEvent::Authenticate { token }) = serde_json::from_str(&text) {
+                // Validate JWT using the same logic as extract_token_from_protocol
+                let user_id = validate_jwt_token(&token, &state.jwt_keys)
+                    .map_err(|e| format!("Invalid token: {e}"))?;
+                return Ok(user_id);
+            }
+            // Ignore non-Authenticate events during pre-auth
+        }
+    }
+    Err("Connection closed before authentication".to_string())
+}
+```
+
+- [ ] **Step 3: Handle Authenticate in dispatch (post-auth, ignore)**
+
+At `handlers.rs:420`, in `handle_client_message`, add:
+
+```rust
+ClientEvent::Authenticate { .. } => {
+    // Already authenticated — ignore duplicate
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Build and verify server**
+
+Run: `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings && cargo test -p vc-server`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/src/ws/events.rs server/src/ws/handlers.rs
+git commit -m "feat(ws): support post-connect Authenticate frame alongside header auth (#1)"
+```
+
+---
+
+## Task 5: WebSocket auth migration — Android client (#1, client side)
+
+**Files:**
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/data/ws/ClientEvent.kt`
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/data/ws/KaikuWebSocket.kt:145`
+- Modify: `mobile/android/app/src/test/java/io/wolftown/kaiku/data/ws/KaikuWebSocketTest.kt:176`
+
+- [ ] **Step 1: Add Authenticate variant to Kotlin ClientEvent**
+
+At `data/ws/ClientEvent.kt`, inside the `sealed class ClientEvent`, add:
+
+```kotlin
+@Serializable
+@SerialName("authenticate")
+data class Authenticate(val token: String) : ClientEvent()
+```
+
+This uses `@SerialName("authenticate")` matching the server's `#[serde(rename_all = "snake_case")]` convention. The existing sealed class serialization will produce `{"type":"authenticate","token":"..."}`.
+
+- [ ] **Step 2: Remove token from header, send Authenticate frame**
+
+At `KaikuWebSocket.kt:145`, remove `.addHeader("Sec-WebSocket-Protocol", "access_token.$token")` from the request builder.
+
+In the `onOpen` callback of the WebSocket listener, send an Authenticate event as the first frame using the typed sealed class (not raw JSON):
+
+```kotlin
+override fun onOpen(webSocket: WebSocket, response: Response) {
+    val authEvent = json.encodeToString(
+        ClientEvent.serializer(),
+        ClientEvent.Authenticate(token)
+    )
+    webSocket.send(authEvent)
+    // ... existing onOpen logic
+}
+```
+
+Capture `token` in the listener's closure (it's already available from `doConnect`).
+
+- [ ] **Step 3: Update WebSocket tests**
+
+At `KaikuWebSocketTest.kt:176`, update `connect uses Sec-WebSocket-Protocol header with token` to verify:
+1. No `Sec-WebSocket-Protocol` header is sent.
+2. First message after open is `{"type":"authenticate","token":"..."}`.
+
+- [ ] **Step 4: Build and verify**
+
+Run: `cd mobile/android && ./gradlew test`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/android/app/src/main/java/io/wolftown/kaiku/data/ws/ClientEvent.kt \
+  mobile/android/app/src/main/java/io/wolftown/kaiku/data/ws/KaikuWebSocket.kt \
+  mobile/android/app/src/test/java/io/wolftown/kaiku/data/ws/KaikuWebSocketTest.kt
+git commit -m "fix(client): move WS auth from header to post-connect Authenticate frame (#1)"
+```
+
+---
+
+## Task 6: OIDC PKCE + state nonce (#3, Part A)
+
+**Files:**
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/auth/OidcHandler.kt:42,79`
+
+- [ ] **Step 1: Generate and persist PKCE + state in launchOidcLogin**
+
+At `OidcHandler.kt:42`, in `launchOidcLogin()`:
+
+```kotlin
+import java.security.MessageDigest
+import java.security.SecureRandom
+import android.util.Base64
+
+// Generate code_verifier (43-128 chars, URL-safe base64)
+val codeVerifier = ByteArray(32).also { SecureRandom().nextBytes(it) }
+    .let { Base64.encodeToString(it, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING) }
+
+// Compute code_challenge = BASE64URL(SHA256(code_verifier))
+val codeChallenge = MessageDigest.getInstance("SHA-256")
+    .digest(codeVerifier.toByteArray(Charsets.US_ASCII))
+    .let { Base64.encodeToString(it, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING) }
+
+// Generate state nonce
+val state = ByteArray(32).also { SecureRandom().nextBytes(it) }
+    .let { Base64.encodeToString(it, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING) }
+
+// Persist to EncryptedSharedPreferences
+tokenStorage.saveOidcPkceState(codeVerifier, state)
+
+// Add to authorization URL
+// &code_challenge=$codeChallenge&code_challenge_method=S256&state=$state
+```
+
+- [ ] **Step 2: Validate state and include code_verifier in handleCallback**
+
+At `OidcHandler.kt:79`, in `handleCallback()`:
+
+For the **primary token path** (lines 82-93, where `access_token` is in the URI):
+
+```kotlin
+// Before calling authRepository.completeOidcLogin:
+val savedState = tokenStorage.getOidcState()
+val uriState = uri.getQueryParameter("state")
+if (savedState == null || uriState != savedState) {
+    tokenStorage.clearOidcPkceState()
+    return Result.failure(IllegalStateException("OIDC state mismatch — possible CSRF"))
+}
+tokenStorage.clearOidcPkceState()
+// Then proceed with completeOidcLogin as before
+```
+
+For the **authorization code path** (lines 95-105, where `code` is in the URI):
+
+```kotlin
+val code = uri.getQueryParameter("code") ?: return Result.failure(...)
+val uriState = uri.getQueryParameter("state") ?: return Result.failure(...)
+
+val savedState = tokenStorage.getOidcState()
+if (savedState == null || uriState != savedState) {
+    tokenStorage.clearOidcPkceState()
+    return Result.failure(IllegalStateException("OIDC state mismatch — possible CSRF"))
+}
+
+val codeVerifier = tokenStorage.getOidcCodeVerifier()
+tokenStorage.clearOidcPkceState()
+
+// Pass code_verifier to the code exchange
+return authRepository.exchangeOidcCode(code, uriState, codeVerifier)
+```
+
+- [ ] **Step 2b: Update AuthRepository.exchangeOidcCode to accept codeVerifier**
+
+At `AuthRepository.kt:162`, update the method signature:
+
+```kotlin
+suspend fun exchangeOidcCode(code: String, state: String, codeVerifier: String?): Result<User>
+```
+
+Pass `codeVerifier` through to the API call that performs the token exchange. The token exchange HTTP request body should include `code_verifier=$codeVerifier` when non-null.
+
+- [ ] **Step 3: Add PKCE storage methods to TokenStorage**
+
+Add `saveOidcPkceState(codeVerifier, state)`, `getOidcState()`, `getOidcCodeVerifier()`, `clearOidcPkceState()` methods using the existing `EncryptedSharedPreferences` instance.
+
+- [ ] **Step 4: Build and verify**
+
+Run: `cd mobile/android && ./gradlew test`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/android/app/src/main/java/io/wolftown/kaiku/ui/auth/OidcHandler.kt \
+  mobile/android/app/src/main/java/io/wolftown/kaiku/data/local/TokenStorage.kt
+git commit -m "fix(auth): add PKCE and state nonce to OIDC flow (#3)"
+```
+
+---
+
+## Task 7: App Links intent filter (#3, Part B)
+
+**Files:**
+- Modify: `mobile/android/app/src/main/AndroidManifest.xml`
+
+- [ ] **Step 1: Add App Links intent filter**
+
+In `AndroidManifest.xml`, add a second intent filter for the `https://` scheme alongside the existing `kaiku://` filter:
+
+```xml
+<intent-filter android:autoVerify="true">
+    <action android:name="android.intent.action.VIEW" />
+    <category android:name="android.intent.category.DEFAULT" />
+    <category android:name="android.intent.category.BROWSABLE" />
+    <data android:scheme="https"
+          android:host="kaiku.pmind.de"
+          android:pathPrefix="/auth/callback" />
+</intent-filter>
+```
+
+- [ ] **Step 2: Scope legacy BLUETOOTH permission (#27)**
+
+In the same file, change:
+```xml
+<uses-permission android:name="android.permission.BLUETOOTH" />
+```
+To:
+```xml
+<uses-permission android:name="android.permission.BLUETOOTH"
+    android:maxSdkVersion="30" />
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mobile/android/app/src/main/AndroidManifest.xml
+git commit -m "fix(auth): add App Links for OIDC callback, scope BLUETOOTH permission (#3, #27)"
+```
+
+---
+
+## Task 8: Defer token persistence until getMe (#4)
+
+**Files:**
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/data/repository/AuthRepository.kt`
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/data/api/KaikuHttpClient.kt`
+
+There are **5 auth flows** with the double-save pattern: `login` (line 31), `register` (line 69), `completeOidcLogin` (line 131), `exchangeOidcCode` (line 167), and `redeemQrToken` (line 207). All must be fixed.
+
+- [ ] **Step 1: Add authenticatedGetMe to KaikuHttpClient**
+
+The current `getMe()` reads the token from `TokenStorage` via the auth interceptor. Add an overload that accepts tokens directly:
+
+```kotlin
+suspend fun getMe(accessToken: String): User {
+    return client.get("${baseUrl}/api/users/me") {
+        header("Authorization", "Bearer $accessToken")
+    }.body()
+}
+```
+
+This bypasses the interceptor chain and uses the provided token directly.
+
+- [ ] **Step 2: Refactor all 5 auth flows to defer persistence**
+
+In `AuthRepository.kt`, for each flow, replace the double-save pattern:
+
+```kotlin
+// BEFORE (e.g., login at lines 31-46):
+tokenStorage.saveTokens(response.accessToken, response.refreshToken, "")
+val user = authApi.getMe()
+tokenStorage.saveTokens(response.accessToken, response.refreshToken, user.id)
+
+// AFTER:
+val user = try {
+    httpClient.getMe(response.accessToken)
+} catch (e: Exception) {
+    throw e  // No tokens persisted on failure
+}
+tokenStorage.saveTokens(response.accessToken, response.refreshToken, user.id)
+```
+
+Apply to all 5 flows: `login` (line 31), `register` (line 69), `completeOidcLogin` (line 131), `exchangeOidcCode` (line 167), `redeemQrToken` (line 207).
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cd mobile/android && ./gradlew test`
+Expected: PASS — existing auth tests should still work since the external behavior is the same
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mobile/android/app/src/main/java/io/wolftown/kaiku/data/repository/AuthRepository.kt \
+  mobile/android/app/src/main/java/io/wolftown/kaiku/data/api/KaikuHttpClient.kt
+git commit -m "fix(auth): defer token persistence until getMe succeeds (#4)"
+```
+
+---
+
+## Task 9: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+cd mobile/android && ./gradlew test
+SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings
+cargo test -p vc-server
+```
+Expected: ALL PASS
+
+- [ ] **Step 2: Self-review the branch diff**
+
+```bash
+git diff main...HEAD --stat
+git log --oneline main..HEAD
+```
+
+Verify: no secrets, correct scope, proper error handling, all 9 issues addressed.

--- a/docs/superpowers/plans/2026-04-13-android-ui-architecture.md
+++ b/docs/superpowers/plans/2026-04-13-android-ui-architecture.md
@@ -1,0 +1,390 @@
+# Android UI & Architecture Fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix navigation event drops, channel name display, auto-scroll behavior, CoroutineScope hygiene, accessibility, and ViewModel lifecycle patterns.
+
+**Architecture:** Seven independent fixes across UI and architecture layers. Most are small (1-5 line changes). The channel name resolution (#7) and navigation Channel pattern (#8) are the most involved, requiring ViewModel constructor changes.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Hilt, Coroutines, Channel/Flow
+
+**Spec:** `docs/superpowers/specs/2026-04-13-mobile-implementation-fixes-design.md` — Sub-Project 3
+
+**Branch:** `fix/android-ui-architecture`
+
+---
+
+## File Map
+
+| File | Responsibility |
+|------|---------------|
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/home/HomeViewModel.kt` | SharedFlow → Channel for nav events |
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/auth/LoginViewModel.kt` | SharedFlow → Channel for OIDC callback |
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/KaikuNavGraph.kt` | Remove channelName param from routes |
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/channel/TextChannelViewModel.kt` | Add channel name resolution via GuildRepository |
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/channel/TextChannelScreen.kt` | Auto-scroll guard, read channelName from ViewModel |
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/voice/VoiceViewModel.kt` | Add channel name resolution |
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/voice/VoiceChannelScreen.kt` | Read channelName from ViewModel |
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/data/local/AuthState.kt` | Named scope, Closeable |
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/home/GuildSidebar.kt` | Button semantics |
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/channel/MessageItem.kt` | remember(formatTimestamp) |
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/settings/SettingsViewModel.kt` | Channel-based logout event |
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/settings/SettingsScreen.kt` | Collect logout event |
+
+---
+
+## Task 1: Navigation SharedFlow → Channel (#8)
+
+**Files:**
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/home/HomeViewModel.kt:50`
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/auth/LoginViewModel.kt:39`
+
+- [ ] **Step 1: Replace SharedFlow with Channel in HomeViewModel**
+
+At `HomeViewModel.kt:50`, change:
+
+```kotlin
+private val _navigateToChannel = MutableSharedFlow<ChannelNavEvent>(extraBufferCapacity = 1)
+val navigateToChannel: SharedFlow<ChannelNavEvent> = _navigateToChannel.asSharedFlow()
+```
+
+To:
+
+```kotlin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
+
+private val _navigateToChannel = Channel<ChannelNavEvent>(Channel.BUFFERED)
+val navigateToChannel = _navigateToChannel.receiveAsFlow()
+```
+
+Change all `_navigateToChannel.tryEmit(...)` calls to `_navigateToChannel.trySend(...)`.
+
+- [ ] **Step 2: Apply same pattern in LoginViewModel**
+
+At `LoginViewModel.kt:39`, apply the same `SharedFlow → Channel` change to `_oidcCallbackUri`.
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cd mobile/android && ./gradlew test`
+Expected: PASS — HomeViewModelTest and LoginViewModelTest should pass since the external API is similar
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mobile/android/app/src/main/java/io/wolftown/kaiku/ui/home/HomeViewModel.kt \
+  mobile/android/app/src/main/java/io/wolftown/kaiku/ui/auth/LoginViewModel.kt
+git commit -m "fix(client): replace navigation SharedFlow with Channel to prevent event drops (#8)"
+```
+
+---
+
+## Task 2: Channel name resolution (#7)
+
+**Files:**
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/channel/TextChannelViewModel.kt:18`
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/channel/TextChannelScreen.kt`
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/voice/VoiceViewModel.kt`
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/voice/VoiceChannelScreen.kt`
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/KaikuNavGraph.kt:116`
+
+- [ ] **Step 1: Add GuildRepository injection and channelName flow to TextChannelViewModel**
+
+At `TextChannelViewModel.kt:18`, add `GuildRepository` to the constructor:
+
+```kotlin
+@HiltViewModel
+class TextChannelViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val chatRepository: ChatRepository,
+    private val guildRepository: GuildRepository
+) : ViewModel() {
+```
+
+Add a `channelName` StateFlow:
+
+```kotlin
+val channelName: StateFlow<String> = guildRepository.channels
+    .map { channels -> channels.find { it.id == channelId }?.name ?: channelId }
+    .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), channelId)
+```
+
+- [ ] **Step 2: Update TextChannelScreen to use ViewModel's channelName**
+
+In `TextChannelScreen.kt`, remove the `channelName` parameter from the composable function signature. Instead, collect from the ViewModel:
+
+```kotlin
+val channelName by viewModel.channelName.collectAsState()
+```
+
+Use this in the TopAppBar title: `Text("#$channelName")`
+
+- [ ] **Step 3: Apply same pattern to VoiceViewModel and VoiceChannelScreen**
+
+Add `GuildRepository` injection and `channelName: StateFlow<String>` to `VoiceViewModel`. Update `VoiceChannelScreen` to read from the ViewModel.
+
+- [ ] **Step 4: Remove channelName parameter from KaikuNavGraph**
+
+At `KaikuNavGraph.kt:116`, remove `channelName = channelId` from both the `TextChannelScreen` and `VoiceChannelScreen` composable calls.
+
+- [ ] **Step 5: Build and verify**
+
+Run: `cd mobile/android && ./gradlew test`
+Expected: PASS — TextChannelViewModelTest may need updating to provide a mock GuildRepository
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mobile/android/app/src/main/java/io/wolftown/kaiku/ui/channel/TextChannelViewModel.kt \
+  mobile/android/app/src/main/java/io/wolftown/kaiku/ui/channel/TextChannelScreen.kt \
+  mobile/android/app/src/main/java/io/wolftown/kaiku/ui/voice/VoiceViewModel.kt \
+  mobile/android/app/src/main/java/io/wolftown/kaiku/ui/voice/VoiceChannelScreen.kt \
+  mobile/android/app/src/main/java/io/wolftown/kaiku/ui/KaikuNavGraph.kt
+git commit -m "fix(client): resolve channel name from GuildRepository instead of displaying UUID (#7)"
+```
+
+---
+
+## Task 3: Auto-scroll guard (#9)
+
+**Files:**
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/channel/TextChannelScreen.kt:41`
+
+- [ ] **Step 1: Replace unconditional scroll with guarded version**
+
+At `TextChannelScreen.kt:41`, replace:
+
+```kotlin
+LaunchedEffect(messages.size) {
+    if (messages.isNotEmpty()) {
+        listState.animateScrollToItem(messages.size - 1)
+    }
+}
+```
+
+With:
+
+```kotlin
+var lastMessageId by remember { mutableStateOf<String?>(null) }
+
+LaunchedEffect(messages.lastOrNull()?.id) {
+    val newLastId = messages.lastOrNull()?.id
+    if (newLastId != null && newLastId != lastMessageId) {
+        lastMessageId = newLastId
+        val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+        if (lastVisible >= messages.size - 4) {
+            listState.animateScrollToItem(messages.size - 1)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `cd mobile/android && ./gradlew test`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mobile/android/app/src/main/java/io/wolftown/kaiku/ui/channel/TextChannelScreen.kt
+git commit -m "fix(client): guard auto-scroll to only fire on new messages when near bottom (#9)"
+```
+
+---
+
+## Task 4: AuthState named scope (#20)
+
+**Files:**
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/data/local/AuthState.kt:25`
+
+- [ ] **Step 1: Replace anonymous scopes with named field**
+
+At `AuthState.kt:25`, replace:
+
+```kotlin
+val isLoggedIn: StateFlow<Boolean> = _session.map { ... }
+    .stateIn(CoroutineScope(Dispatchers.Default), SharingStarted.Eagerly, false)
+
+val currentUserId: StateFlow<String?> = _session.map { ... }
+    .stateIn(CoroutineScope(Dispatchers.Default), SharingStarted.Eagerly, null)
+```
+
+With:
+
+```kotlin
+import java.io.Closeable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+
+// Add Closeable to class declaration
+class AuthState @Inject constructor() : Closeable {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    val isLoggedIn: StateFlow<Boolean> = _session.map { ... }
+        .stateIn(scope, SharingStarted.Eagerly, false)
+
+    val currentUserId: StateFlow<String?> = _session.map { ... }
+        .stateIn(scope, SharingStarted.Eagerly, null)
+
+    override fun close() {
+        scope.cancel()
+    }
+}
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `cd mobile/android && ./gradlew test`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mobile/android/app/src/main/java/io/wolftown/kaiku/data/local/AuthState.kt
+git commit -m "fix(client): replace anonymous CoroutineScopes in AuthState with named cancellable scope (#20)"
+```
+
+---
+
+## Task 5: Small fixes — GuildIcon semantics (#24), formatTimestamp remember (#25)
+
+**Files:**
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/home/GuildSidebar.kt:73`
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/channel/MessageItem.kt:90`
+
+- [ ] **Step 1: Add button semantics to GuildIcon**
+
+At `GuildSidebar.kt:73`, on the `Box` modifier chain for guild icons, add:
+
+```kotlin
+.semantics { role = Role.Button }
+.clickable(
+    onClick = onClick,
+    onClickLabel = "Select ${guild.name}"
+)
+```
+
+Import: `import androidx.compose.ui.semantics.Role`
+
+- [ ] **Step 2: Wrap formatTimestamp in remember**
+
+At `MessageItem.kt:90`, change:
+
+```kotlin
+Text(formatTimestamp(message.createdAt))
+```
+
+To:
+
+```kotlin
+val formattedTime = remember(message.createdAt) { formatTimestamp(message.createdAt) }
+Text(formattedTime)
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cd mobile/android && ./gradlew test`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mobile/android/app/src/main/java/io/wolftown/kaiku/ui/home/GuildSidebar.kt \
+  mobile/android/app/src/main/java/io/wolftown/kaiku/ui/channel/MessageItem.kt
+git commit -m "fix(client): add GuildIcon button semantics and memoize formatTimestamp (#24, #25)"
+```
+
+---
+
+## Task 6: SettingsViewModel logout event (#26)
+
+**Files:**
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/settings/SettingsViewModel.kt:65`
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/settings/SettingsScreen.kt:129`
+
+- [ ] **Step 1: Replace UI callback with Channel event in SettingsViewModel**
+
+At `SettingsViewModel.kt:65`, replace:
+
+```kotlin
+fun logout(onLogoutComplete: () -> Unit) {
+    viewModelScope.launch {
+        try { authRepository.logout() } catch (...) { }
+        onLogoutComplete()
+    }
+}
+```
+
+With:
+
+```kotlin
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
+
+private val _logoutComplete = Channel<Unit>(Channel.CONFLATED)
+val logoutComplete = _logoutComplete.receiveAsFlow()
+
+fun logout() {
+    viewModelScope.launch {
+        try {
+            authRepository.logout()
+        } catch (e: Exception) {
+            logger.log(Level.WARNING, "Logout failed", e)
+        }
+        _logoutComplete.send(Unit)
+    }
+}
+```
+
+- [ ] **Step 2: Update SettingsScreen to collect logout event**
+
+At `SettingsScreen.kt:129`, replace the direct callback:
+
+```kotlin
+// Remove: viewModel.logout { onLogout() }
+// Add:
+viewModel.logout()
+```
+
+Add a `LaunchedEffect` to collect the event:
+
+```kotlin
+LaunchedEffect(Unit) {
+    viewModel.logoutComplete.collect { onLogout() }
+}
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cd mobile/android && ./gradlew test`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mobile/android/app/src/main/java/io/wolftown/kaiku/ui/settings/SettingsViewModel.kt \
+  mobile/android/app/src/main/java/io/wolftown/kaiku/ui/settings/SettingsScreen.kt
+git commit -m "fix(client): replace logout UI callback with Channel event for lifecycle safety (#26)"
+```
+
+---
+
+## Task 7: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+cd mobile/android && ./gradlew test
+```
+Expected: ALL PASS
+
+- [ ] **Step 2: Self-review the branch diff**
+
+```bash
+git diff main...HEAD --stat
+git log --oneline main..HEAD
+```
+
+Verify: 7 issues addressed, no regressions.

--- a/docs/superpowers/plans/2026-04-13-android-voice-webrtc.md
+++ b/docs/superpowers/plans/2026-04-13-android-voice-webrtc.md
@@ -1,0 +1,487 @@
+# Android Voice/WebRTC Fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix WebRTC lifecycle bugs (SDP ordering, ICE buffering, resource leaks), replace static VoiceCallService callbacks with SharedFlow events, and fix audio routing issues.
+
+**Architecture:** Nine targeted fixes centered on `WebRtcManager.kt` and `VoiceRepository.kt`. The largest structural change is replacing static companion object callbacks on `VoiceCallService` with a DI-injected `VoiceServiceEvents` SharedFlow. All other fixes are small (5-15 lines each).
+
+**Tech Stack:** Kotlin, stream-webrtc-android, Hilt, Coroutines, Jetpack Compose
+
+**Spec:** `docs/superpowers/specs/2026-04-13-mobile-implementation-fixes-design.md` — Sub-Project 2
+
+**Branch:** `fix/android-voice-webrtc`
+
+---
+
+## File Map
+
+| File | Responsibility |
+|------|---------------|
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/data/voice/WebRtcManager.kt` | SDP ordering, ICE buffering, dispose(), AudioDeviceModule lifecycle |
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/data/voice/AudioRouteManager.kt` | Async Bluetooth SCO routing |
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/data/repository/VoiceRepository.kt` | leaveChannel mutex, scope cleanup, service event collection |
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/service/VoiceCallService.kt` | Replace static callbacks with VoiceServiceEvents |
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/data/voice/VoiceServiceEvents.kt` | NEW — SharedFlow event bus for service actions |
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/voice/VoiceChannelScreen.kt` | Remove findVideoTrackForStream fallback |
+| `mobile/android/app/src/test/java/io/wolftown/kaiku/data/voice/WebRtcManagerTest.kt` | Updated tests |
+| `mobile/android/app/src/test/java/io/wolftown/kaiku/ui/voice/VoiceViewModelTest.kt` | Updated tests |
+
+---
+
+## Task 1: WebRtcManager — SDP ordering fix (#5)
+
+**Files:**
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/data/voice/WebRtcManager.kt:223`
+
+- [ ] **Step 1: Move onLocalDescription into onSetSuccess**
+
+At `WebRtcManager.kt:223`, find the `setLocalDescription` call. The current code calls `onLocalDescription` immediately after enqueuing. Replace the no-op `SdpObserverAdapter` with an inline object:
+
+```kotlin
+pc.setLocalDescription(object : SdpObserverAdapter("setLocalDescription", onError) {
+    override fun onSetSuccess() {
+        super.onSetSuccess()
+        onLocalDescription?.invoke(desc.description)
+        logger.info("SDP answer created and set")
+    }
+}, desc)
+```
+
+Remove the `onLocalDescription?.invoke(desc.description)` line that currently follows the `setLocalDescription` call.
+
+- [ ] **Step 2: Build and verify**
+
+Run: `cd mobile/android && ./gradlew test`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mobile/android/app/src/main/java/io/wolftown/kaiku/data/voice/WebRtcManager.kt
+git commit -m "fix(voice): send SDP answer only after setLocalDescription completes (#5)"
+```
+
+---
+
+## Task 2: WebRtcManager — ICE candidate buffering (#10)
+
+**Files:**
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/data/voice/WebRtcManager.kt:245,172`
+
+- [ ] **Step 1: Add ICE buffering fields and logic**
+
+At `WebRtcManager.kt`, add fields near the other peer connection fields:
+
+```kotlin
+private var remoteDescriptionSet = false
+private val pendingCandidates = mutableListOf<String>()  // buffered JSON strings
+```
+
+Note: `addIceCandidate` takes `candidateJson: String` (not `IceCandidate`), so the buffer stores raw JSON strings.
+
+In `handleOffer` (or wherever `setRemoteDescription` is called), set `remoteDescriptionSet = false` at the start. In the `setRemoteDescription` observer's `onSetSuccess`, drain the buffer by calling the existing `addIceCandidate` method for each:
+
+```kotlin
+override fun onSetSuccess() {
+    super.onSetSuccess()
+    remoteDescriptionSet = true
+    val candidates = pendingCandidates.toList()
+    pendingCandidates.clear()
+    candidates.forEach { addIceCandidate(it) }
+}
+```
+
+Modify `addIceCandidate` (line 245) — add the buffering guard at the top of the existing method, before the JSON parsing:
+
+```kotlin
+fun addIceCandidate(candidateJson: String) {
+    if (!remoteDescriptionSet) {
+        pendingCandidates.add(candidateJson)
+        return
+    }
+
+    val pc = peerConnection ?: run {
+        // ... existing null guard
+    }
+    // ... existing JSON parse and addIceCandidate logic
+}
+```
+
+In `closePeerConnection()` (line 172), add:
+
+```kotlin
+remoteDescriptionSet = false
+pendingCandidates.clear()
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `cd mobile/android && ./gradlew test`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mobile/android/app/src/main/java/io/wolftown/kaiku/data/voice/WebRtcManager.kt
+git commit -m "fix(voice): buffer ICE candidates until remote description is set (#10)"
+```
+
+---
+
+## Task 3: WebRtcManager — Resource cleanup (#12, #13)
+
+**Files:**
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/data/voice/WebRtcManager.kt:115,172`
+
+- [ ] **Step 1: Store and release JavaAudioDeviceModule**
+
+At `WebRtcManager.kt:115`, change the local `audioDeviceModule` variable to a field:
+
+```kotlin
+private var audioDeviceModule: AudioDeviceModule? = null
+```
+
+In the `initialize()` function, assign:
+
+```kotlin
+audioDeviceModule = JavaAudioDeviceModule.builder(context)
+    .createAudioDeviceModule()
+```
+
+In `dispose()`, release it after the factory but before EglBase:
+
+```kotlin
+fun dispose() {
+    closePeerConnection()
+    factory?.dispose()
+    factory = null
+    audioDeviceModule?.release()
+    audioDeviceModule = null
+    // ... EglBase release
+}
+```
+
+- [ ] **Step 2: Add PeerConnection.dispose() to closePeerConnection**
+
+At `WebRtcManager.kt:172`, in `closePeerConnection()`, change:
+
+```kotlin
+peerConnection?.close()
+peerConnection = null
+```
+
+To:
+
+```kotlin
+peerConnection?.close()
+peerConnection?.dispose()
+peerConnection = null
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cd mobile/android && ./gradlew test`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mobile/android/app/src/main/java/io/wolftown/kaiku/data/voice/WebRtcManager.kt
+git commit -m "fix(voice): release AudioDeviceModule and dispose PeerConnection (#12, #13)"
+```
+
+---
+
+## Task 4: VoiceServiceEvents — Replace static callbacks (#6)
+
+**Files:**
+- Create: `mobile/android/app/src/main/java/io/wolftown/kaiku/data/voice/VoiceServiceEvents.kt`
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/service/VoiceCallService.kt:44`
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/data/repository/VoiceRepository.kt:132`
+
+- [ ] **Step 1: Create VoiceServiceEvents**
+
+Create new file `data/voice/VoiceServiceEvents.kt`:
+
+```kotlin
+package io.wolftown.kaiku.data.voice
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+sealed class VoiceServiceEvent {
+    data object MuteToggle : VoiceServiceEvent()
+    data object Disconnect : VoiceServiceEvent()
+}
+
+@Singleton
+class VoiceServiceEvents @Inject constructor() {
+    private val _events = MutableSharedFlow<VoiceServiceEvent>(extraBufferCapacity = 5)
+    val events: SharedFlow<VoiceServiceEvent> = _events.asSharedFlow()
+
+    fun emit(event: VoiceServiceEvent) {
+        _events.tryEmit(event)
+    }
+}
+```
+
+- [ ] **Step 2: Update VoiceCallService to use VoiceServiceEvents**
+
+At `VoiceCallService.kt` (the Hilt plugin `com.google.dagger.hilt.android` is already in `build.gradle.kts:8`):
+1. Add `@AndroidEntryPoint` annotation to the service class.
+2. Inject `VoiceServiceEvents`: `@Inject lateinit var voiceServiceEvents: VoiceServiceEvents`
+3. Add an `onCreate` override — Hilt injects fields during `super.onCreate()`, so this must be called before any access:
+
+```kotlin
+@AndroidEntryPoint
+class VoiceCallService : Service() {
+    @Inject lateinit var voiceServiceEvents: VoiceServiceEvents
+
+    override fun onCreate() {
+        super.onCreate()  // REQUIRED: Hilt injects fields here
+    }
+    // ...
+}
+```
+
+4. Remove the `companion object` block with `onMuteToggle` and `onDisconnect` vars.
+5. In `onStartCommand`, replace `onMuteToggle?.invoke()` with `voiceServiceEvents.emit(VoiceServiceEvent.MuteToggle)` and `onDisconnect?.invoke()` with `voiceServiceEvents.emit(VoiceServiceEvent.Disconnect)`.
+
+- [ ] **Step 3: Update VoiceRepository to collect VoiceServiceEvents**
+
+At `VoiceRepository.kt:132`:
+1. Inject `VoiceServiceEvents` in the constructor.
+2. Remove the static callback assignments (`VoiceCallService.onMuteToggle = { ... }` and `VoiceCallService.onDisconnect = { ... }`).
+3. In `joinChannel()`, after starting the service, launch a collector:
+
+```kotlin
+serviceEventJob = scope.launch {
+    voiceServiceEvents.events.collect { event ->
+        when (event) {
+            VoiceServiceEvent.MuteToggle -> toggleMute()
+            VoiceServiceEvent.Disconnect -> leaveChannel()
+        }
+    }
+}
+```
+
+4. Add `private var serviceEventJob: Job? = null` field.
+5. In `cleanUp()`, add `serviceEventJob?.cancel()`.
+
+- [ ] **Step 4: Build and verify**
+
+Run: `cd mobile/android && ./gradlew test`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/android/app/src/main/java/io/wolftown/kaiku/data/voice/VoiceServiceEvents.kt \
+  mobile/android/app/src/main/java/io/wolftown/kaiku/service/VoiceCallService.kt \
+  mobile/android/app/src/main/java/io/wolftown/kaiku/data/repository/VoiceRepository.kt
+git commit -m "fix(voice): replace static VoiceCallService callbacks with SharedFlow events (#6)"
+```
+
+---
+
+## Task 5: VoiceRepository — leaveChannel mutex (#14) and scope cleanup (#32)
+
+**Files:**
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/data/repository/VoiceRepository.kt:50,158`
+
+- [ ] **Step 1: Add Mutex to leaveChannel**
+
+At `VoiceRepository.kt`, add:
+
+```kotlin
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.io.Closeable
+
+private val leaveMutex = Mutex()
+```
+
+Wrap `leaveChannel()` (line 158):
+
+```kotlin
+suspend fun leaveChannel() {
+    leaveMutex.withLock {
+        val channelId = _currentChannelId.value ?: return@withLock
+        // ... all existing cleanup logic
+    }
+}
+```
+
+- [ ] **Step 2: Implement Closeable**
+
+Add `Closeable` to the class declaration and implement `close()`:
+
+```kotlin
+@Singleton
+class VoiceRepository @Inject constructor(...) : Closeable {
+    // ...
+    override fun close() {
+        scope.cancel()
+    }
+}
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cd mobile/android && ./gradlew test`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mobile/android/app/src/main/java/io/wolftown/kaiku/data/repository/VoiceRepository.kt
+git commit -m "fix(voice): add leaveChannel mutex and Closeable to VoiceRepository (#14, #32)"
+```
+
+---
+
+## Task 6: AudioRouteManager — Async Bluetooth SCO (#21)
+
+**Files:**
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/data/voice/AudioRouteManager.kt:130,208`
+
+- [ ] **Step 1: Add CoroutineScope and BroadcastReceiver for SCO state**
+
+`AudioRouteManager` currently has no `CoroutineScope` (it's a `@Singleton` with synchronous state). Add one for the SCO timeout:
+
+```kotlin
+private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+```
+
+Cancel it in `release()`: `scope.cancel()`
+
+Then add a `BroadcastReceiver` that listens for `ACTION_SCO_AUDIO_STATE_UPDATED`:
+
+```kotlin
+private val scoReceiver = object : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val state = intent.getIntExtra(AudioManager.EXTRA_SCO_AUDIO_STATE, -1)
+        when (state) {
+            AudioManager.SCO_AUDIO_STATE_CONNECTED -> {
+                audioManager.isBluetoothScoOn = true
+                _currentRoute.value = AudioRoute.Bluetooth
+                scoTimeoutJob?.cancel()
+            }
+            AudioManager.SCO_AUDIO_STATE_ERROR,
+            AudioManager.SCO_AUDIO_STATE_DISCONNECTED -> {
+                audioManager.isBluetoothScoOn = false
+                _currentRoute.value = AudioRoute.Speaker
+                scoTimeoutJob?.cancel()
+            }
+        }
+    }
+}
+
+private var scoTimeoutJob: Job? = null
+```
+
+Register the receiver in the class init or constructor. Unregister in `release()`.
+
+- [ ] **Step 2: Update startBluetoothSco to be async**
+
+At line 208, change `startBluetoothSco()`:
+
+```kotlin
+private fun startBluetoothSco() {
+    try {
+        @Suppress("DEPRECATION")
+        audioManager.startBluetoothSco()
+        // Do NOT set isBluetoothScoOn here — wait for BroadcastReceiver
+        // Set a 3-second timeout fallback
+        scoTimeoutJob?.cancel()
+        scoTimeoutJob = scope.launch {
+            delay(3000)
+            if (_currentRoute.value != AudioRoute.Bluetooth) {
+                logger.warning("Bluetooth SCO timeout — falling back to speaker")
+                _currentRoute.value = AudioRoute.Speaker
+            }
+        }
+    } catch (e: Exception) {
+        logger.log(Level.WARNING, "Failed to start Bluetooth SCO", e)
+        _currentRoute.value = AudioRoute.Speaker
+    }
+}
+```
+
+- [ ] **Step 3: Update switchRoute to defer Bluetooth route**
+
+At `switchRoute()` (line 130), for the Bluetooth case, do not set `_currentRoute.value = route` synchronously. Let the BroadcastReceiver handle it:
+
+```kotlin
+AudioRoute.Bluetooth -> {
+    startBluetoothSco()
+    // Route will be updated by scoReceiver when SCO connects
+}
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `cd mobile/android && ./gradlew test`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/android/app/src/main/java/io/wolftown/kaiku/data/voice/AudioRouteManager.kt
+git commit -m "fix(voice): async Bluetooth SCO routing with BroadcastReceiver (#21)"
+```
+
+---
+
+## Task 7: VoiceChannelScreen — Remove fallback (#23)
+
+**Files:**
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/ui/voice/VoiceChannelScreen.kt:335`
+
+- [ ] **Step 1: Remove size-1 fallback in findVideoTrackForStream**
+
+At `VoiceChannelScreen.kt:335`, in `findVideoTrackForStream`, remove the block:
+
+```kotlin
+if (remoteVideoTracks.size == 1) {
+    return remoteVideoTracks.values.firstOrNull()
+}
+```
+
+Keep only the direct `streamId` lookup. Return null if no match found.
+
+- [ ] **Step 2: Build and verify**
+
+Run: `cd mobile/android && ./gradlew test`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mobile/android/app/src/main/java/io/wolftown/kaiku/ui/voice/VoiceChannelScreen.kt
+git commit -m "fix(voice): remove findVideoTrackForStream fallback that mismatches multi-share tracks (#23)"
+```
+
+---
+
+## Task 8: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+cd mobile/android && ./gradlew test
+```
+Expected: ALL PASS
+
+- [ ] **Step 2: Self-review the branch diff**
+
+```bash
+git diff main...HEAD --stat
+git log --oneline main..HEAD
+```
+
+Verify: 9 issues addressed, no regressions, no leftover static callback references.

--- a/docs/superpowers/plans/2026-04-13-web-responsive.md
+++ b/docs/superpowers/plans/2026-04-13-web-responsive.md
@@ -1,0 +1,714 @@
+# Web Responsive Fixes & Overhaul — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix 5 concrete web responsive bugs and implement a full responsive overhaul with drawer-based mobile navigation at the `md` (768px) breakpoint.
+
+**Architecture:** Build responsive infrastructure first (`useBreakpoint`, `createLongPress`, `touch:` variant), then fix the bugs, then implement the drawer-based mobile layout. The overhaul reuses existing `ServerRail` and `Sidebar` components inside a new `MobileDrawer`, toggled by `useIsMobile()`.
+
+**Tech Stack:** Solid.js, UnoCSS, TypeScript, PointerEvents API
+
+**Spec:** `docs/superpowers/specs/2026-04-13-mobile-implementation-fixes-design.md` — Sub-Project 4
+
+**Branch:** `feature/web-responsive`
+
+---
+
+## File Map
+
+| File | Responsibility |
+|------|---------------|
+| `client/src/lib/useBreakpoint.ts` | NEW — Reactive breakpoint hook |
+| `client/src/lib/createLongPress.ts` | NEW — Long-press directive for touch |
+| `client/src/components/layout/MobileDrawer.tsx` | NEW — Slide-out drawer |
+| `client/src/components/layout/MobileHeader.tsx` | NEW — Mobile top bar |
+| `client/src/components/layout/AppShell.tsx` | Toggle desktop/mobile layout |
+| `client/src/components/layout/ServerRail.tsx` | Add `compact` prop |
+| `client/src/components/layout/Sidebar.tsx` | Fix opacity, pass onNavigate |
+| `client/src/components/ui/ContextMenu.tsx` | Add showContextMenuAt, touch targets |
+| `client/src/components/guilds/GuildSettingsModal.tsx` | Fix modal overflow |
+| `client/src/components/guilds/EmojisTab.tsx` | Fix hover-only delete |
+| `client/src/views/Register.tsx` | Add overflow-y-auto |
+| `client/src/views/Login.tsx` | Add overflow-y-auto |
+| `client/src/views/ForgotPassword.tsx` | Add overflow-y-auto |
+| `client/src/views/ResetPassword.tsx` | Add overflow-y-auto |
+| `client/uno.config.ts` | Add touch: variant |
+| `client/src/components/home/HomeSidebar.tsx` | Fix opacity |
+| `client/src/components/voice/VoicePanel.tsx` | Fix opacity |
+| `client/src/components/search/SearchPanel.tsx` | Fix opacity |
+| `client/src/components/admin/ReportsPanel.tsx` | Fix opacity |
+| `client/src/components/admin/CommandCenterPanel.tsx` | Fix opacity |
+| `client/src/components/admin/AuditLogPanel.tsx` | Fix opacity |
+| `client/src/components/modals/ReportModal.tsx` | Fix opacity |
+
+---
+
+## Task 1: Responsive infrastructure — useBreakpoint and createLongPress
+
+**Files:**
+- Create: `client/src/lib/useBreakpoint.ts`
+- Create: `client/src/lib/createLongPress.ts`
+
+- [ ] **Step 1: Create useBreakpoint hook**
+
+Create `client/src/lib/useBreakpoint.ts`:
+
+```typescript
+import { createSignal, onCleanup } from "solid-js";
+
+/**
+ * Reactive breakpoint hook using window.matchMedia.
+ * Returns a signal that updates when the viewport crosses the threshold.
+ */
+export function useBreakpoint(query: string): () => boolean {
+  const mql = window.matchMedia(query);
+  const [matches, setMatches] = createSignal(mql.matches);
+
+  const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+  mql.addEventListener("change", handler);
+  onCleanup(() => mql.removeEventListener("change", handler));
+
+  return matches;
+}
+
+/** Convenience: true when viewport is below md (768px). */
+export function useIsMobile(): () => boolean {
+  return useBreakpoint("(max-width: 767px)");
+}
+```
+
+- [ ] **Step 2: Create createLongPress directive**
+
+Create `client/src/lib/createLongPress.ts`:
+
+```typescript
+/**
+ * Long-press handler for touch support.
+ * Uses PointerEvents for unified mouse/touch/pen input.
+ * Returns event handlers to spread onto elements.
+ */
+export function createLongPress(
+  onLongPress: (x: number, y: number) => void,
+  duration = 500
+) {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let startX = 0;
+  let startY = 0;
+
+  const onPointerDown = (e: PointerEvent) => {
+    startX = e.clientX;
+    startY = e.clientY;
+    timer = setTimeout(() => {
+      onLongPress(e.clientX, e.clientY);
+      timer = null;
+    }, duration);
+  };
+
+  const cancel = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  const onPointerMove = (e: PointerEvent) => {
+    if (timer && (Math.abs(e.clientX - startX) > 10 || Math.abs(e.clientY - startY) > 10)) {
+      cancel();
+    }
+  };
+
+  const onContextMenu = (e: Event) => {
+    // Suppress native context menu on long-press (Android Chrome)
+    if (timer) {
+      e.preventDefault();
+    }
+  };
+
+  return {
+    onPointerDown,
+    onPointerUp: cancel,
+    onPointerCancel: cancel,
+    onPointerMove,
+    onContextMenu,
+  };
+}
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cd client && bun run build`
+Expected: PASS — no consumers yet, just verifying the files compile
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/lib/useBreakpoint.ts client/src/lib/createLongPress.ts
+git commit -m "feat(client): add useBreakpoint hook and createLongPress directive"
+```
+
+---
+
+## Task 2: UnoCSS touch variant and opacity fixes (#29, #31)
+
+**Files:**
+- Modify: `client/uno.config.ts`
+- Modify: `client/src/components/layout/Sidebar.tsx:121,130`
+- Modify: `client/src/components/home/HomeSidebar.tsx:55`
+- Modify: `client/src/components/voice/VoicePanel.tsx:101`
+- Modify: `client/src/components/search/SearchPanel.tsx:364`
+- Modify: `client/src/components/admin/ReportsPanel.tsx:315`
+- Modify: `client/src/components/admin/CommandCenterPanel.tsx:780,791,878`
+- Modify: `client/src/components/admin/AuditLogPanel.tsx:379,382`
+- Modify: `client/src/components/modals/ReportModal.tsx:159,173`
+- Modify: `client/src/components/guilds/EmojisTab.tsx:161`
+
+- [ ] **Step 1: Add touch: variant to UnoCSS config**
+
+At `uno.config.ts`, add a `variants` array to the config. The UnoCSS variant API uses objects with `name`, `match`, and `parent`:
+
+```typescript
+import { defineConfig } from "unocss";
+
+export default defineConfig({
+  // ... existing presets, theme, shortcuts ...
+  variants: [
+    {
+      name: "touch",
+      match(matcher) {
+        if (!matcher.startsWith("touch:")) return;
+        return {
+          matcher: matcher.slice(6),
+          parent: "@media (hover: none)",
+        };
+      },
+    },
+  ],
+  // ... rest of config
+});
+```
+
+This creates a `touch:` prefix that wraps the utility in `@media (hover: none) { ... }`. Usage: `touch:opacity-60` renders as `@media (hover: none) { .touch\:opacity-60 { opacity: 0.6; } }`.
+
+- [ ] **Step 2: Fix all text-text-secondary/50 occurrences**
+
+Replace `text-text-secondary/50` with `text-text-muted` in all 13 locations. For `placeholder:text-text-secondary/50`, replace with `placeholder:text-text-muted`.
+
+Files and lines (from grep results):
+1. `Sidebar.tsx:121` — `text-text-secondary/50` → `text-text-muted`
+2. `Sidebar.tsx:130` — `text-text-secondary/50` → `text-text-muted`
+3. `HomeSidebar.tsx:55` — `text-text-secondary/50` → `text-text-muted`
+4. `VoicePanel.tsx:101` — `text-text-secondary/50` → `text-text-muted`
+5. `SearchPanel.tsx:364` — `placeholder:text-text-secondary/50` → `placeholder:text-text-muted`
+6. `ReportsPanel.tsx:315` — `text-text-secondary/50` → `text-text-muted`
+7. `CommandCenterPanel.tsx:780` — `placeholder:text-text-secondary/50` → `placeholder:text-text-muted`
+8. `CommandCenterPanel.tsx:791` — `placeholder:text-text-secondary/50` → `placeholder:text-text-muted`
+9. `CommandCenterPanel.tsx:878` — `placeholder:text-text-secondary/50` → `placeholder:text-text-muted`
+10. `AuditLogPanel.tsx:379` — `text-text-secondary/50` → `text-text-muted`
+11. `AuditLogPanel.tsx:382` — `text-text-secondary/50` → `text-text-muted`
+12. `ReportModal.tsx:159` — `text-text-secondary/50` → `text-text-muted`
+13. `ReportModal.tsx:173` — `text-text-secondary/50` → `text-text-muted`
+
+- [ ] **Step 3: Make emoji delete button visible on touch**
+
+At `EmojisTab.tsx:161`, change:
+
+```
+opacity-0 group-hover:opacity-100
+```
+
+To:
+
+```
+opacity-0 group-hover:opacity-100 touch:opacity-60
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `cd client && bun run build`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/uno.config.ts \
+  client/src/components/layout/Sidebar.tsx \
+  client/src/components/home/HomeSidebar.tsx \
+  client/src/components/voice/VoicePanel.tsx \
+  client/src/components/search/SearchPanel.tsx \
+  client/src/components/admin/ReportsPanel.tsx \
+  client/src/components/admin/CommandCenterPanel.tsx \
+  client/src/components/admin/AuditLogPanel.tsx \
+  client/src/components/modals/ReportModal.tsx \
+  client/src/components/guilds/EmojisTab.tsx
+git commit -m "fix(client): replace text-text-secondary/50 with text-text-muted, add touch: variant (#29, #31)"
+```
+
+---
+
+## Task 3: Modal overflow and form scroll fixes (#11, #30)
+
+**Files:**
+- Modify: `client/src/components/guilds/GuildSettingsModal.tsx:149`
+- Modify: `client/src/views/Register.tsx:192`
+- Modify: `client/src/views/Login.tsx:191`
+- Modify: `client/src/views/ForgotPassword.tsx:55`
+- Modify: `client/src/views/ResetPassword.tsx:66`
+
+- [ ] **Step 1: Fix GuildSettingsModal sizing**
+
+At `GuildSettingsModal.tsx:149`, change:
+
+```
+w-[90vw] md:w-[900px] max-w-5xl
+```
+
+To:
+
+```
+w-[90vw] max-w-[900px] overflow-x-hidden
+```
+
+Also increase the close button padding from `p-1.5` to `p-2.5` for better touch targets.
+
+- [ ] **Step 2: Fix auth view scroll**
+
+In all four auth views, change `min-h-screen` to `min-h-screen overflow-y-auto`:
+
+- `Register.tsx:192`: `min-h-screen` → `min-h-screen overflow-y-auto`
+- `Login.tsx:191`: `min-h-screen` → `min-h-screen overflow-y-auto`
+- `ForgotPassword.tsx:55`: `min-h-screen` → `min-h-screen overflow-y-auto`
+- `ResetPassword.tsx:66`: `min-h-screen` → `min-h-screen overflow-y-auto`
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cd client && bun run build`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/components/guilds/GuildSettingsModal.tsx \
+  client/src/views/Register.tsx \
+  client/src/views/Login.tsx \
+  client/src/views/ForgotPassword.tsx \
+  client/src/views/ResetPassword.tsx
+git commit -m "fix(client): fix modal overflow at 800px and add scroll to auth views (#11, #30)"
+```
+
+---
+
+## Task 4: ContextMenu touch support (#28)
+
+**Files:**
+- Modify: `client/src/components/ui/ContextMenu.tsx:65,143`
+
+- [ ] **Step 1: Add showContextMenuAt overload**
+
+At `ContextMenu.tsx`, after the existing `showContextMenu` function (line 65), add:
+
+```typescript
+/** Position-based context menu trigger for touch/long-press. */
+export function showContextMenuAt(
+  x: number,
+  y: number,
+  items: ContextMenuEntry[],
+  submenuParent?: string
+) {
+  // Reuse existing positioning logic from showContextMenu
+  // but with raw x,y instead of extracting from MouseEvent
+  const menuW = 200;
+  const menuH = items.length * 36;
+  const viewportW = window.innerWidth;
+  const viewportH = window.innerHeight;
+
+  const finalX = x + menuW > viewportW ? x - menuW : x;
+  const finalY = y + menuH > viewportH ? y - menuH : y;
+
+  setContextMenu({
+    x: Math.max(0, finalX),
+    y: Math.max(0, finalY),
+    items,
+    submenuParent: submenuParent ?? null,
+  });
+}
+```
+
+- [ ] **Step 2: Increase context menu item touch targets**
+
+At `ContextMenuItemButton` (line 143), change `py-1.5` to `py-2.5` to bring item height from ~28px to ~40px.
+
+- [ ] **Step 3: Integrate createLongPress at key call sites**
+
+The main call sites for `showContextMenu` are `ChannelItem.tsx`, `MessageItem.tsx`, and `contextMenuBuilders.ts`. Update the two most important call sites to also support long-press:
+
+In message list items (e.g., `MessageItem.tsx:576`), where the current pattern is:
+
+```tsx
+onContextMenu={(e) => showContextMenu(e, items)}
+```
+
+Add long-press support alongside:
+
+```tsx
+import { createLongPress } from "../../lib/createLongPress";
+import { showContextMenuAt } from "../ui/ContextMenu";
+
+// Inside the component:
+const longPress = createLongPress((x, y) => {
+  showContextMenuAt(x, y, buildMessageMenuItems());
+});
+
+// On the element:
+<div
+  onContextMenu={(e) => showContextMenu(e, buildMessageMenuItems())}
+  onPointerDown={longPress.onPointerDown}
+  onPointerUp={longPress.onPointerUp}
+  onPointerCancel={longPress.onPointerCancel}
+  onPointerMove={longPress.onPointerMove}
+>
+```
+
+Apply the same pattern to channel items. This is additive — desktop right-click continues to work unchanged.
+
+- [ ] **Step 4: Build and verify**
+
+Run: `cd client && bun run build`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/components/ui/ContextMenu.tsx \
+  client/src/components/channel/MessageItem.tsx \
+  client/src/components/channel/ChannelItem.tsx
+git commit -m "feat(client): add showContextMenuAt for touch support, integrate long-press at call sites (#28)"
+```
+
+---
+
+## Task 5: ServerRail compact prop
+
+**Files:**
+- Modify: `client/src/components/layout/ServerRail.tsx:35`
+
+- [ ] **Step 1: Add compact prop to ServerRail**
+
+At `ServerRail.tsx:35`, the current signature is `const ServerRail: Component = () => {`. Change to accept props:
+
+```typescript
+interface ServerRailProps {
+  compact?: boolean;
+}
+
+const ServerRail: Component<ServerRailProps> = (props) => {
+```
+
+Add size helpers:
+
+```typescript
+const railWidth = () => props.compact ? "w-[56px]" : "w-[72px]";
+const iconSize = () => props.compact ? "w-9 h-9" : "w-12 h-12";
+const iconPadding = () => props.compact ? "p-1" : "p-2";
+```
+
+Apply `railWidth()` to the outermost `<nav>` element's class (currently hardcoded `w-[72px]`). Apply `iconSize()` and `iconPadding()` to each guild icon element (the `Box` or `div` wrappers inside the guild list at lines 102-159). Use template literals or `classList` to apply conditionally. Existing call sites pass no props and get `compact={false}` (default).
+
+- [ ] **Step 2: Build and verify**
+
+Run: `cd client && bun run build`
+Expected: PASS — existing call sites pass no props, so they get the default
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/components/layout/ServerRail.tsx
+git commit -m "feat(client): add compact prop to ServerRail for mobile drawer"
+```
+
+---
+
+## Task 6: MobileDrawer and MobileHeader components
+
+**Files:**
+- Create: `client/src/components/layout/MobileDrawer.tsx`
+- Create: `client/src/components/layout/MobileHeader.tsx`
+
+- [ ] **Step 1: Create MobileDrawer**
+
+Create `client/src/components/layout/MobileDrawer.tsx`:
+
+```typescript
+import { Component, JSX, Show, createEffect, onCleanup } from "solid-js";
+
+interface MobileDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  children: JSX.Element;
+}
+
+const MobileDrawer: Component<MobileDrawerProps> = (props) => {
+  let drawerRef: HTMLDivElement | undefined;
+  let startX = 0;
+
+  const onBackdropClick = () => props.onClose();
+
+  // Swipe-left to close
+  const onPointerDown = (e: PointerEvent) => { startX = e.clientX; };
+  const onPointerUp = (e: PointerEvent) => {
+    if (startX - e.clientX > 50) props.onClose();
+  };
+
+  // Prevent body scroll when drawer is open
+  createEffect(() => {
+    if (props.open) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+  });
+
+  onCleanup(() => { document.body.style.overflow = ""; });
+
+  return (
+    <div
+      class="fixed inset-0 z-50"
+      classList={{ "pointer-events-none": !props.open }}
+    >
+      {/* Backdrop */}
+      <div
+        class="absolute inset-0 bg-black/50 transition-opacity duration-200"
+        classList={{
+          "opacity-100": props.open,
+          "opacity-0 pointer-events-none": !props.open,
+        }}
+        onClick={onBackdropClick}
+      />
+
+      {/* Drawer panel */}
+      <div
+        ref={drawerRef}
+        class="absolute top-0 left-0 h-full w-[300px] flex transition-transform duration-200 bg-surface-base"
+        classList={{
+          "translate-x-0": props.open,
+          "-translate-x-full": !props.open,
+        }}
+        onPointerDown={onPointerDown}
+        onPointerUp={onPointerUp}
+      >
+        {props.children}
+      </div>
+    </div>
+  );
+};
+
+export default MobileDrawer;
+```
+
+- [ ] **Step 2: Create MobileHeader**
+
+Create `client/src/components/layout/MobileHeader.tsx`:
+
+```typescript
+import { Component } from "solid-js";
+import { Menu } from "lucide-solid";
+
+interface MobileHeaderProps {
+  onMenuClick: () => void;
+}
+// Guild/channel names are read from stores directly inside the component.
+// Import the guild store and derive current guild name and channel name
+// from the active selection signals.
+
+const MobileHeader: Component<MobileHeaderProps> = (props) => {
+  return (
+    <header class="h-[44px] flex items-center px-3 gap-3 bg-surface-layer1 border-b border-border-default shrink-0">
+      <button
+        class="p-1.5 rounded-lg hover:bg-white/10 transition-colors"
+        onClick={props.onMenuClick}
+        aria-label="Open navigation"
+      >
+        <Menu class="w-5 h-5 text-text-primary" />
+      </button>
+      <div class="flex-1 min-w-0 flex items-center gap-2 text-sm">
+        {/* Read from guild store — check client/src/stores/guilds.ts for
+            the current guild/channel selection signals and import them here */}
+        <Show when={guildName()}>
+          <span class="text-text-secondary truncate">{guildName()}</span>
+        </Show>
+        <Show when={channelName()}>
+          <span class="text-text-primary font-medium truncate">
+            #{channelName()}
+          </span>
+        </Show>
+      </div>
+    </header>
+  );
+};
+
+export default MobileHeader;
+```
+
+- [ ] **Step 3: Build and verify**
+
+Run: `cd client && bun run build`
+Expected: PASS — components compile but aren't rendered yet
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/components/layout/MobileDrawer.tsx \
+  client/src/components/layout/MobileHeader.tsx
+git commit -m "feat(client): add MobileDrawer and MobileHeader components"
+```
+
+---
+
+## Task 7: AppShell responsive integration
+
+**Files:**
+- Modify: `client/src/components/layout/AppShell.tsx`
+- Modify: `client/src/components/layout/Sidebar.tsx`
+
+- [ ] **Step 1: Update AppShell to toggle desktop/mobile layout**
+
+At `AppShell.tsx`, the current file imports `ServerRail`, `Sidebar`, and `LazyErrorBoundary` but no store signals. Add imports:
+
+```typescript
+import { useIsMobile } from "../../lib/useBreakpoint";
+import MobileDrawer from "./MobileDrawer";
+import MobileHeader from "./MobileHeader";
+import { createSignal, Show } from "solid-js";
+```
+
+For guild/channel names in the header, import from the existing guild store. Check `client/src/stores/guilds.ts` for signals like `currentGuild()` and `currentChannel()` — these are the reactive accessors. If they don't exist as direct exports, derive them from the route params and the guild store's data.
+
+Add state and mobile detection:
+
+```typescript
+const isMobile = useIsMobile();
+const [drawerOpen, setDrawerOpen] = createSignal(false);
+```
+
+Restructure the template. Note: the current Sidebar rendering uses `<Show when={props.sidebar} fallback={<Sidebar />}>{props.sidebar}</Show>` which supports custom sidebars (e.g., HomeSidebar). Preserve this pattern on both desktop and mobile:
+
+```tsx
+<div class="flex h-screen w-full overflow-hidden">
+  <Show when={!isMobile()}>
+    {/* Desktop: existing fixed layout */}
+    <Show when={props.showServerRail}><ServerRail /></Show>
+    <Show when={props.sidebar} fallback={<Sidebar />}>
+      {props.sidebar}
+    </Show>
+  </Show>
+
+  <Show when={isMobile()}>
+    <MobileDrawer open={drawerOpen()} onClose={() => setDrawerOpen(false)}>
+      <Show when={props.showServerRail}><ServerRail compact /></Show>
+      <Show when={props.sidebar} fallback={
+        <Sidebar onNavigate={() => setDrawerOpen(false)} />
+      }>
+        {/* Custom sidebars don't get onNavigate — they manage their own navigation.
+            Wrap in a click listener that closes the drawer on any anchor/button click: */}
+        <div onClick={(e) => {
+          if ((e.target as HTMLElement).closest("a, button[data-channel]")) {
+            setDrawerOpen(false);
+          }
+        }}>
+          {props.sidebar}
+        </div>
+      </Show>
+    </MobileDrawer>
+  </Show>
+
+  <div class="flex flex-col flex-1 min-w-0">
+    <Show when={isMobile()}>
+      <MobileHeader onMenuClick={() => setDrawerOpen(true)} />
+    </Show>
+    <main class="flex-1 min-h-0">
+      {props.children}
+    </main>
+  </div>
+</div>
+```
+
+For MobileHeader guild/channel names: read from the guild store inside MobileHeader itself (not passed from AppShell). This avoids coupling AppShell to store internals. MobileHeader imports the guild store directly and reads the current selection.
+
+- [ ] **Step 2: Add onNavigate callback to Sidebar**
+
+In `Sidebar.tsx`, add an optional `onNavigate` prop to the component's props interface:
+
+```typescript
+interface SidebarProps {
+  onNavigate?: () => void;
+}
+```
+
+Find the channel click handler (where the router navigates to a channel). After the navigation call, add `props.onNavigate?.()` to auto-close the drawer on mobile. This only fires for the default `Sidebar` — custom sidebars (HomeSidebar etc.) are handled by the click delegate wrapper in AppShell.
+
+- [ ] **Step 3: Add swipe-right-to-open on main content area**
+
+In `AppShell.tsx`, add a pointer event listener on the left 20px edge of the content area. If the pointer moves >50px rightward, open the drawer:
+
+```typescript
+const onEdgePointerDown = (e: PointerEvent) => {
+  if (isMobile() && e.clientX < 20) {
+    edgeStartX = e.clientX;
+  }
+};
+const onEdgePointerUp = (e: PointerEvent) => {
+  if (edgeStartX !== null && e.clientX - edgeStartX > 50) {
+    setDrawerOpen(true);
+  }
+  edgeStartX = null;
+};
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `cd client && bun run build && bun run test:run`
+Expected: PASS
+
+- [ ] **Step 5: Manual testing**
+
+Start dev server: `cd client && bun run dev`
+Test at viewport widths: 800px (desktop), 768px (threshold), 375px (mobile)
+Verify:
+- Desktop: existing layout unchanged
+- Mobile: header visible, sidebars hidden, hamburger opens drawer
+- Drawer: shows server rail + channel list, tap channel closes drawer
+- Swipe right from edge opens drawer, swipe left on drawer closes it
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/components/layout/AppShell.tsx \
+  client/src/components/layout/Sidebar.tsx
+git commit -m "feat(client): integrate responsive layout with MobileDrawer at md breakpoint"
+```
+
+---
+
+## Task 8: Final verification
+
+- [ ] **Step 1: Run full test and build suite**
+
+```bash
+cd client && bun run test:run && bun run build
+```
+Expected: ALL PASS
+
+- [ ] **Step 2: Verify no text-text-secondary/50 remaining**
+
+```bash
+grep -r "text-text-secondary/50" client/src/
+```
+Expected: No matches
+
+- [ ] **Step 3: Self-review the branch diff**
+
+```bash
+git diff main...HEAD --stat
+git log --oneline main..HEAD
+```
+
+Verify: 5 bugs fixed + responsive overhaul complete, new files are minimal and focused.

--- a/docs/superpowers/specs/2026-04-13-mobile-implementation-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-13-mobile-implementation-fixes-design.md
@@ -1,0 +1,384 @@
+# Mobile Implementation Fixes & Web Responsive Overhaul
+
+**Date:** 2026-04-13
+**Status:** Draft
+**Goal:** Address 30 issues from the mobile implementation review across Android auth/network, voice/WebRTC, UI/architecture, and web client responsive patterns. Includes a full responsive overhaul of the web client with drawer-based mobile navigation.
+
+## Context
+
+A comprehensive review of the mobile implementation (Android native app + web client responsive patterns) identified 30 actionable issues spanning security vulnerabilities, WebRTC lifecycle bugs, UI/architecture defects, and web responsive gaps. The issues range from critical security concerns (bearer token exposure, spoofable OIDC deep links) to important quality items (missing `remember`, touch target sizing). Two issues from the original review (#19 TokenStorage singleton, #22 ScreenShareView state) were verified as non-issues during spec review and dropped.
+
+The Android app (`mobile/android/`) was introduced in PR #363 as Milestone 1 — Kotlin + Jetpack Compose with Hilt DI, Ktor HTTP, OkHttp WebSocket, and stream-webrtc-android. The web client (`client/`) is Solid.js + UnoCSS, desktop-first with minimal responsive design.
+
+## Approach
+
+Four independent sub-projects, each with its own branch and PR. No cross-branch dependencies — all four can be implemented and merged in parallel.
+
+| Branch | Scope | Issues |
+|--------|-------|--------|
+| `fix/android-auth-network` | Security hardening + network robustness | 9 issues |
+| `fix/android-voice-webrtc` | WebRTC lifecycle + voice service | 9 issues |
+| `fix/android-ui-architecture` | Navigation, state management, accessibility | 7 issues |
+| `feature/web-responsive` | Bug fixes + responsive overhaul with drawer nav | 5 issues + feature |
+
+**Testing gate per branch:**
+- Android branches: `./gradlew test` (unit tests) must pass + new tests for each fix using existing test patterns (mockk, Turbine, kotlinx.coroutines.test)
+- Server changes in Sub-Project 1: `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings` + `cargo test -p vc-server`
+- Web branch: `bun run test:run` + `bun run build` + manual viewport testing at 800px, 768px, 600px, and 375px widths
+
+---
+
+## Sub-Project 1: `fix/android-auth-network`
+
+### Issue #1 — Bearer token in WebSocket upgrade header
+
+**Problem:** `KaikuWebSocket.kt:145` sends the access token as `Sec-WebSocket-Protocol: access_token.$token`. This header is visible in proxy logs, server access logs, and network capture tools.
+
+**Fix:** Remove the token from the handshake header. After `onOpen`, send an `Authenticate` client event as the first WebSocket frame. The server holds or rejects other events until authentication completes.
+
+**Server-side change required:** Add an `Authenticate` variant to `ClientEvent` in `server/src/ws/mod.rs`. Add a pre-auth state to the WebSocket handler that buffers events until the token is validated. Add an auth timeout (5s) that closes the connection if no `Authenticate` frame arrives. This is ~100-150 lines including the state machine, timeout, and tests.
+
+**Migration strategy:** The `Sec-WebSocket-Protocol` auth pattern is also used by the Tauri desktop client (`client/src-tauri/src/network/websocket.rs:503`) and the web client (`client/src/lib/tauri/websocket.ts:44`). To avoid a breaking change:
+1. The server accepts both old (`Sec-WebSocket-Protocol` header) and new (post-connect `Authenticate` frame) auth for one release cycle.
+2. This PR updates the Android client to the new auth pattern.
+3. A follow-up PR updates the Tauri/web client and removes legacy header auth from the server.
+
+**Files:** `KaikuWebSocket.kt`, `server/src/ws/mod.rs`, `server/src/ws/handlers.rs`
+
+### Issue #2 — No TLS 1.3 enforcement
+
+**Problem:** Neither the WebSocket `OkHttpClient` (`WebSocketModule.kt:28`) nor the Ktor HTTP engine (`KaikuHttpClient.kt:68`) specifies a `ConnectionSpec`. OkHttp defaults to TLS 1.2 on older API levels, violating the CLAUDE.md requirement of TLS 1.3 for all connections.
+
+**Fix:** Create a shared `ConnectionSpec` in `NetworkModule`:
+
+```kotlin
+val tls13Spec = ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+    .tlsVersions(TlsVersion.TLS_1_3)
+    .build()
+```
+
+Apply to both the WebSocket `OkHttpClient` and the Ktor `OkHttp` engine. Add `ProviderInstaller.installIfNeeded(context)` in `Application.onCreate()` to ensure the security provider is current on API 26-28 devices (TLS 1.3 is native on API 29+).
+
+**Files:** `NetworkModule.kt`, `WebSocketModule.kt`, `KaikuApplication.kt`
+
+### Issue #3 — OIDC deep link spoofable + no PKCE
+
+**Problem:** `kaiku://auth/callback` is a custom URI scheme that any app can intercept or spoof. The primary token path in `OidcHandler.kt:79` accepts tokens directly from the redirect URI without verifying that the redirect originated from a login the app actually initiated (no `state` nonce). The authorization code path does validate `state`, but no PKCE (`code_verifier`/`code_challenge`) is used in either path, leaving the code exchange vulnerable to interception.
+
+**Fix (two parts):**
+
+*Part A — PKCE + state nonce:*
+- In `launchOidcLogin()`: generate 32-byte `code_verifier` (compute SHA-256 `code_challenge`) and 32-byte `state` nonce. Persist both to `EncryptedSharedPreferences`.
+- Add `code_challenge`, `code_challenge_method=S256`, and `state` to the authorization URL.
+- In `handleCallback()`: validate `state` matches stored nonce before processing. Include `code_verifier` in the token exchange. Clear stored values after success.
+
+*Part B — Android App Links:*
+- Add intent filter for `https://kaiku.pmind.de/auth/callback` with `autoVerify="true"` in `AndroidManifest.xml`.
+- Keep existing `kaiku://` scheme as fallback.
+- Server-side: deploy `/.well-known/assetlinks.json` via Caddy with the app's signing certificate fingerprint (separate deployment task).
+
+**Files:** `OidcHandler.kt`, `AndroidManifest.xml`, server-side `assetlinks.json`
+
+### Issue #4 — Tokens persisted before `getMe` succeeds
+
+**Problem:** `AuthRepository.kt:30` calls `tokenStorage.saveTokens()` with `userId = ""` before calling `getMe()`. If the process is killed between these calls, an orphaned valid token is persisted without a user ID.
+
+**Fix:** Hold tokens in local variables during the login/register/OIDC sequence. Only call `tokenStorage.saveTokens(accessToken, refreshToken, userId)` after `getMe()` succeeds and returns the real `userId`.
+
+**Files:** `AuthRepository.kt`
+
+### Issue #15 — ConnectivityMonitor false positives on captive portals
+
+**Problem:** `ConnectivityMonitor.kt:44` checks `NET_CAPABILITY_INTERNET` without `NET_CAPABILITY_VALIDATED`. Captive-portal networks report connected, triggering WebSocket reconnect storms against an unreachable server.
+
+**Fix:** Require `NET_CAPABILITY_VALIDATED` in addition to `NET_CAPABILITY_INTERNET` in both `checkCurrentConnectivity()` and `onCapabilitiesChanged`.
+
+**Files:** `ConnectivityMonitor.kt`
+
+### Issue #16 — Stale token on WebSocket reconnect
+
+**Problem:** `KaikuWebSocket.kt:129` reads the access token at reconnect time without checking expiry. After backoff delay, the token may have expired, causing a 401 reject loop.
+
+**Fix:** In `doConnect()`, check `tokenStorage.isAccessTokenExpired()` before building the request. If expired, emit a new `ConnectionState.TokenExpired` event that repositories can observe to trigger a token refresh before retrying.
+
+**Files:** `KaikuWebSocket.kt`
+
+### Issue #17 — WebSocket connectivity collector leaks
+
+**Problem:** `KaikuWebSocket.kt:57` launches a connectivity collector via `scope.launch` without tracking the returned `Job`. Calling `setConnectivityMonitor` again launches a duplicate collector.
+
+**Fix:** Store the `Job` as a field. Cancel it in `disconnect()` and before launching a new one in `setConnectivityMonitor`.
+
+**Files:** `KaikuWebSocket.kt`
+
+### Issue #18 — ConnectivityMonitor callback never unregistered
+
+**Problem:** `ConnectivityMonitor.kt:53` registers a `NetworkCallback` in `init` with no `unregisterNetworkCallback` call. Prevents clean test teardown.
+
+**Fix:** Implement `Closeable`. Add `fun close()` that calls `connectivityManager.unregisterNetworkCallback(networkCallback)`.
+
+**Files:** `ConnectivityMonitor.kt`
+
+### Issue #27 — Legacy BLUETOOTH permission not scoped
+
+**Problem:** `AndroidManifest.xml:7` declares `android.permission.BLUETOOTH` without `maxSdkVersion="30"`. The legacy permission is unnecessary on API 31+ where `BLUETOOTH_CONNECT` (already declared) applies.
+
+**Fix:** Add `android:maxSdkVersion="30"` to the `BLUETOOTH` permission.
+
+**Files:** `AndroidManifest.xml`
+
+---
+
+## Sub-Project 2: `fix/android-voice-webrtc`
+
+### Issue #5 — SDP answer sent before `setLocalDescription` completes
+
+**Problem:** `WebRtcManager.kt:222` invokes `onLocalDescription` immediately after enqueuing `setLocalDescription`, which is asynchronous. The SDP answer is sent over WebSocket before the local description is committed.
+
+**Fix:** The current code passes a no-op `SdpObserverAdapter` to `setLocalDescription`. Replace it with an inline `object` that overrides `onSetSuccess` and invokes `onLocalDescription` from there:
+
+```kotlin
+pc.setLocalDescription(object : SdpObserverAdapter("setLocalDescription", onError) {
+    override fun onSetSuccess() {
+        super.onSetSuccess()
+        onLocalDescription?.invoke(desc.description)
+    }
+}, desc)
+```
+
+Remove the `onLocalDescription` call that currently follows the `setLocalDescription` enqueue.
+
+**Files:** `WebRtcManager.kt`
+
+### Issue #6 — Static callbacks on VoiceCallService
+
+**Problem:** `VoiceCallService.kt:44` uses `companion object` `var` fields for mute/disconnect callbacks. `VoiceRepository.kt:133` writes lambdas capturing `this` into these fields. Race condition between notification action intents and `cleanUp()`.
+
+**Fix:** Replace static callbacks with a `SharedFlow`-based event pattern.
+
+Introduce `VoiceServiceEvents` as a `@Singleton`:
+
+```kotlin
+@Singleton
+class VoiceServiceEvents @Inject constructor() {
+    private val _events = MutableSharedFlow<VoiceServiceEvent>(extraBufferCapacity = 5)
+    val events: SharedFlow<VoiceServiceEvent> = _events.asSharedFlow()
+    fun emit(event: VoiceServiceEvent) { _events.tryEmit(event) }
+}
+
+sealed class VoiceServiceEvent {
+    data object MuteToggle : VoiceServiceEvent()
+    data object Disconnect : VoiceServiceEvent()
+}
+```
+
+`VoiceCallService` is annotated `@AndroidEntryPoint` (prerequisite: `KaikuApplication` has `@HiltAndroidApp`, which is confirmed). The service must call `super.onCreate()` before accessing injected fields. It injects `VoiceServiceEvents` and emits events in `onStartCommand`. `VoiceRepository` injects `VoiceServiceEvents` and collects events, launching a collector in `joinChannel()` and cancelling it in `cleanUp()`.
+
+**Files:** `VoiceCallService.kt`, `VoiceRepository.kt`, new `VoiceServiceEvents.kt`
+
+### Issue #10 — ICE candidates added before remote description set
+
+**Problem:** `VoiceRepository.kt:285` calls `addIceCandidate` as soon as events arrive. If the server sends candidates before `setRemoteDescription` completes, they are silently dropped.
+
+**Fix:** Add `remoteDescriptionSet: Boolean` flag and `pendingCandidates: MutableList<IceCandidate>` to `WebRtcManager`. Buffer candidates when the flag is false. Drain in `setRemoteDescription`'s `onSetSuccess`. Reset both in `closePeerConnection()`.
+
+**Files:** `WebRtcManager.kt`
+
+### Issue #12 — JavaAudioDeviceModule never released
+
+**Problem:** `WebRtcManager.kt:115` creates a `JavaAudioDeviceModule` as a local variable. The module is handed to the factory but never stored, so `release()` is never called.
+
+**Fix:** Store as `private var audioDeviceModule: AudioDeviceModule? = null`. Release in `dispose()` after `factory?.dispose()`.
+
+**Files:** `WebRtcManager.kt`
+
+### Issue #13 — PeerConnection.dispose() missing
+
+**Problem:** `WebRtcManager.kt:172` calls `peerConnection?.close()` but not `dispose()`. Native C++ resources are not freed, leaking across reconnects.
+
+**Fix:** Add `peerConnection?.dispose()` between `close()` and nulling the reference.
+
+**Files:** `WebRtcManager.kt`
+
+### Issue #14 — leaveChannel called twice without guard
+
+**Problem:** `VoiceViewModel.kt:80` calls `leaveChannel()` from `onLeave()`, and `onCleared()` calls it again via `NonCancellable`. Both can run concurrently with no synchronization.
+
+**Fix:** Add a `Mutex` to `VoiceRepository.leaveChannel()`. Early-return inside `withLock` if `_currentChannelId.value` is null.
+
+```kotlin
+private val leaveMutex = Mutex()
+
+suspend fun leaveChannel() {
+    leaveMutex.withLock {
+        val channelId = _currentChannelId.value ?: return@withLock
+        // ... existing cleanup
+    }
+}
+```
+
+**Note:** `VoiceViewModel.onCleared()` currently uses `viewModelScope.launch(NonCancellable)`, but `viewModelScope` is already cancelled at that point. The coroutine runs but is untracked. The Mutex fix makes the double-call safe regardless of which scope runs it. No change to `onCleared` needed — the Mutex handles the concurrency.
+
+**Files:** `VoiceRepository.kt`
+
+### Issue #21 — Bluetooth SCO set synchronously
+
+**Problem:** `AudioRouteManager.kt:208` sets `isBluetoothScoOn = true` immediately after `startBluetoothSco()`, which is asynchronous. The UI shows "Bluetooth" while audio is still on the earpiece.
+
+**Fix:** Register a `BroadcastReceiver` for `ACTION_SCO_AUDIO_STATE_UPDATED`. Only update `_currentRoute` to `AudioRoute.Bluetooth` when `SCO_AUDIO_STATE_CONNECTED` is received. Fall back to speaker on `SCO_AUDIO_STATE_ERROR` or 3-second timeout. Unregister receiver in `release()`. Also update `switchRoute()` to defer `_currentRoute.value = route` for the Bluetooth case — the route should not be updated synchronously when switching to Bluetooth, only after the BroadcastReceiver confirms SCO is connected.
+
+**Files:** `AudioRouteManager.kt`
+
+### Issue #23 — findVideoTrackForStream fallback mismatches
+
+**Problem:** `VoiceChannelScreen.kt:345` has a `if (remoteVideoTracks.size == 1) return firstOrNull()` fallback that returns the wrong track in multi-peer screen share scenarios.
+
+**Fix:** Remove the size-1 fallback. Return only tracks matching the requested `streamId`. The caller already handles null.
+
+**Files:** `VoiceChannelScreen.kt`
+
+### Issue #32 — VoiceRepository scope cancellation
+
+**Problem:** `VoiceRepository.kt:50` creates `CoroutineScope(SupervisorJob() + Dispatchers.IO)` with no cancellation mechanism. Test teardown leaks.
+
+**Fix:** Implement `Closeable` with `scope.cancel()`. Ensure `cleanUp()` cancels `eventCollectionJob`.
+
+**Files:** `VoiceRepository.kt`
+
+---
+
+## Sub-Project 3: `fix/android-ui-architecture`
+
+### Issue #7 — channelName displays raw UUID
+
+**Problem:** `KaikuNavGraph.kt:116` passes `channelId` as `channelName` to `TextChannelScreen` and `VoiceChannelScreen`. The TopAppBar displays a UUID.
+
+**Fix:** Resolve the channel name in the ViewModel. Inject `GuildRepository` into `TextChannelViewModel`. Derive a `channelName: StateFlow<String>` from `guildRepository.channels`:
+
+```kotlin
+val channelName: StateFlow<String> = guildRepository.channels
+    .map { channels -> channels.find { it.id == channelId }?.name ?: channelId }
+    .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), channelId)
+```
+
+Remove `channelName` parameter from `TextChannelScreen` — the screen reads from its ViewModel. Same approach for `VoiceChannelScreen` via `VoiceViewModel`. Fallback to `channelId` while channels load.
+
+**Files:** `KaikuNavGraph.kt`, `TextChannelViewModel.kt`, `TextChannelScreen.kt`, `VoiceViewModel.kt`, `VoiceChannelScreen.kt`
+
+### Issue #8 — Navigation SharedFlow drops events
+
+**Problem:** `HomeViewModel.kt:50` uses `MutableSharedFlow(extraBufferCapacity = 1)`. `tryEmit` on a full buffer silently drops the event.
+
+**Fix:** Replace with `Channel<ChannelNavEvent>(Channel.BUFFERED)` consumed via `receiveAsFlow()`. Producer uses `trySend`. Apply same pattern to `_oidcCallbackUri` in `LoginViewModel.kt`.
+
+**Files:** `HomeViewModel.kt`, `LoginViewModel.kt`
+
+### Issue #9 — Auto-scroll fires on pagination prepend
+
+**Problem:** `TextChannelScreen.kt:41` scrolls to the bottom on every `messages.size` change, including when older messages are prepended via pagination.
+
+**Fix:** Key `LaunchedEffect` on `messages.lastOrNull()?.id` instead of `messages.size`. Only auto-scroll when the last message ID changes (new message at the bottom) and the user is within 3 items of the bottom:
+
+```kotlin
+var lastMessageId by remember { mutableStateOf<String?>(null) }
+
+LaunchedEffect(messages.lastOrNull()?.id) {
+    val newLastId = messages.lastOrNull()?.id
+    if (newLastId != null && newLastId != lastMessageId) {
+        lastMessageId = newLastId
+        val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+        if (lastVisible >= messages.size - 4) {
+            listState.animateScrollToItem(messages.size - 1)
+        }
+    }
+}
+```
+
+**Files:** `TextChannelScreen.kt`
+
+### Issue #20 — AuthState anonymous CoroutineScopes
+
+**Problem:** `AuthState.kt:25` creates two inline `CoroutineScope(Dispatchers.Default)` instances for `stateIn` calls. Neither is stored or cancellable.
+
+**Fix:** Declare a single `private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)`. Reuse for both `stateIn` calls. Implement `Closeable` with `scope.cancel()` for test teardown.
+
+**Files:** `AuthState.kt`
+
+### Issue #24 — GuildIcon missing button semantics
+
+**Problem:** `GuildSidebar.kt:68` uses `.clickable(onClick)` without `Role.Button` semantics. TalkBack does not announce the element as interactive.
+
+**Fix:** Add `.semantics { role = Role.Button }` and `onClickLabel = "Select ${guild.name}"` to the clickable modifier.
+
+**Files:** `GuildSidebar.kt`
+
+### Issue #25 — formatTimestamp not remembered
+
+**Problem:** `MessageItem.kt:91` calls `formatTimestamp(message.createdAt)` inline. Recomputed on every recomposition for every visible message.
+
+**Fix:** Wrap in `remember(message.createdAt) { formatTimestamp(message.createdAt) }`.
+
+**Files:** `MessageItem.kt`
+
+### Issue #26 — SettingsViewModel.logout passes UI callback
+
+**Problem:** `SettingsViewModel.kt:65` accepts `onLogoutComplete: () -> Unit` from the composable. The lambda captures stale navigation state during configuration changes.
+
+**Fix:** Replace with a `Channel<Unit>(Channel.CONFLATED)` exposed as `logoutComplete: Flow<Unit>`. The composable collects via `LaunchedEffect`.
+
+**Files:** `SettingsViewModel.kt`, `SettingsScreen.kt`
+
+---
+
+## Sub-Project 4: `feature/web-responsive`
+
+### New utilities
+
+**`client/src/lib/useBreakpoint.ts`** — Reactive breakpoint hook using `window.matchMedia`. Returns a Solid.js signal that updates when the viewport crosses the threshold. Exports `useIsMobile()` convenience (`max-width: 767px`).
+
+**`client/src/lib/createLongPress.ts`** — Long-press directive for touch support. Uses `PointerEvent` for unified mouse/touch/pen input. Returns event handlers that call sites spread onto elements. ~30 lines.
+
+### Bug fixes
+
+**#11 — GuildSettingsModal overflow at 800px.** Change `w-[90vw] md:w-[900px] max-w-5xl` to `w-[90vw] max-w-[900px]`. Remove the `md:` breakpoint override. Add `overflow-x-hidden` safety net. File: `GuildSettingsModal.tsx`
+
+**#28 — ContextMenu touch support.** Add `showContextMenuAt(x, y, items)` overload. Call sites spread `createLongPress` handlers alongside `onContextMenu`. Increase item padding from `py-1.5` to `py-2.5` for touch targets. Increase GuildSettingsModal close button from `p-1.5` to `p-2.5`. File: `ContextMenu.tsx`
+
+**#29 — `text-text-secondary/50` opacity violations.** This pattern appears in 13 locations across the codebase, all violating the CLAUDE.md rule against `opacity-*` below 50% on readable text. Replace all occurrences of `text-text-secondary/50` with `text-text-muted` (the semantic token for minimum-readable text). For `placeholder:text-text-secondary/50` occurrences, replace with `placeholder:text-text-muted`. Affected files: `Sidebar.tsx` (2), `HomeSidebar.tsx` (1), `VoicePanel.tsx` (1), `SearchPanel.tsx` (1), `ReportsPanel.tsx` (1), `CommandCenterPanel.tsx` (3), `AuditLogPanel.tsx` (2), `ReportModal.tsx` (2).
+
+**#30 — Register form scroll.** Change `min-h-screen` to `min-h-screen overflow-y-auto`. Apply to `Login.tsx`, `Register.tsx`, `ForgotPassword.tsx`, `ResetPassword.tsx`. Files: 4 view files.
+
+**#31 — Emoji delete hover-only.** Add a `touch:` custom variant to `uno.config.ts` mapping to `@media (hover: none)`. Apply `touch:opacity-60` to the delete button so it is visible on touch devices. File: `EmojisTab.tsx`, `uno.config.ts`
+
+### Responsive overhaul
+
+**Breakpoint:** `md` (768px). Below: mobile layout with drawer. Above: current desktop layout.
+
+**New component: `MobileDrawer.tsx`**
+- Slide-out drawer from the left edge, `w-[300px]`, `z-50`
+- Contains `ServerRail` (56px compact mode) + `Sidebar` (flex-1) side by side
+- Backdrop: `bg-black/50`, tap to close
+- CSS transform transition: `translateX(-100%) -> translateX(0)`
+- Swipe-right to open: `PointerEvent` listener on left 20px edge, >50px rightward movement
+- Swipe-left to close: >50px leftward movement on the drawer panel
+- Auto-close on channel selection via `onNavigate` callback
+
+**New component: `MobileHeader.tsx`**
+- Top bar, `h-[44px]`, visible only on mobile
+- Hamburger icon (left) opens drawer
+- Guild name + `#channel` name (center) from existing stores
+- `bg-surface-layer1`, `border-b border-border-default`
+
+**Modified: `AppShell.tsx`**
+- Use `useIsMobile()` to toggle between desktop layout (existing) and mobile layout (header + drawer)
+- Desktop: existing `ServerRail` + `Sidebar` + main stage
+- Mobile: `MobileDrawer` (contains `ServerRail compact` + `Sidebar`) + `MobileHeader` + main stage
+
+**Modified: `ServerRail.tsx`**
+- Add `compact` boolean prop (default: `false`)
+- When `compact={true}`: `w-[56px]`, smaller guild icons, tighter padding (used in MobileDrawer)
+- When `compact={false}` or omitted: existing `w-[72px]` behavior (existing call sites unchanged)
+
+**Sidebar.tsx** — No structural changes. Inside the drawer it receives `flex-1` from the drawer layout, filling `244px` (close to its designed `240px`).
+
+**HomeRightPanel** — Already `hidden xl:flex`. Always hidden on mobile. No changes needed.

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -119,6 +119,7 @@ dependencies {
 
     // Security
     implementation("androidx.security:security-crypto:1.1.0-alpha06")
+    implementation("com.google.android.gms:play-services-base:18.5.0")
 
     // WebRTC
     implementation("io.getstream:stream-webrtc-android:1.3.0")

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -40,7 +40,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="https"
                       android:host="kaiku.pmind.de"
-                      android:pathPrefix="/auth/callback" />
+                      android:path="/auth/callback" />
             </intent-filter>
         </activity>
 

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -4,7 +4,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
@@ -32,6 +33,14 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="kaiku" android:host="auth" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https"
+                      android:host="kaiku.pmind.de"
+                      android:pathPrefix="/auth/callback" />
             </intent-filter>
         </activity>
 

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/KaikuApplication.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/KaikuApplication.kt
@@ -1,7 +1,20 @@
 package io.wolftown.kaiku
 
 import android.app.Application
+import com.google.android.gms.security.ProviderInstaller
 import dagger.hilt.android.HiltAndroidApp
+import java.util.logging.Logger
 
 @HiltAndroidApp
-class KaikuApplication : Application()
+class KaikuApplication : Application() {
+    private val logger = Logger.getLogger("KaikuApplication")
+
+    override fun onCreate() {
+        super.onCreate()
+        try {
+            ProviderInstaller.installIfNeeded(this)
+        } catch (e: Exception) {
+            logger.warning("Failed to install security provider: ${e.message}")
+        }
+    }
+}

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/KaikuApplication.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/KaikuApplication.kt
@@ -22,6 +22,10 @@ class KaikuApplication : Application() {
                 .showErrorNotification(this, e.connectionStatusCode)
         } catch (e: GooglePlayServicesNotAvailableException) {
             logger.severe("Play Services not available — TLS 1.3 unsupported, network will fail: ${e.message}")
+        } catch (e: Throwable) {
+            // Defensive fallback — don't crash app startup on unexpected provider errors.
+            // Network calls will fail later if TLS 1.3 was the issue.
+            logger.severe("Unexpected error installing security provider: ${e.javaClass.simpleName}: ${e.message}")
         }
     }
 }

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/KaikuApplication.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/KaikuApplication.kt
@@ -1,6 +1,9 @@
 package io.wolftown.kaiku
 
 import android.app.Application
+import com.google.android.gms.common.GoogleApiAvailability
+import com.google.android.gms.common.GooglePlayServicesNotAvailableException
+import com.google.android.gms.common.GooglePlayServicesRepairableException
 import com.google.android.gms.security.ProviderInstaller
 import dagger.hilt.android.HiltAndroidApp
 import java.util.logging.Logger
@@ -13,8 +16,12 @@ class KaikuApplication : Application() {
         super.onCreate()
         try {
             ProviderInstaller.installIfNeeded(this)
-        } catch (e: Exception) {
-            logger.warning("Failed to install security provider: ${e.message}")
+        } catch (e: GooglePlayServicesRepairableException) {
+            logger.severe("Play Services needs update for TLS 1.3: ${e.message}")
+            GoogleApiAvailability.getInstance()
+                .showErrorNotification(this, e.connectionStatusCode)
+        } catch (e: GooglePlayServicesNotAvailableException) {
+            logger.severe("Play Services not available — TLS 1.3 unsupported, network will fail: ${e.message}")
         }
     }
 }

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/data/api/AuthApi.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/data/api/AuthApi.kt
@@ -30,7 +30,7 @@ interface AuthApi {
     suspend fun logout()
     suspend fun getMe(): User
     suspend fun getOidcProviders(): List<OidcProvider>
-    suspend fun exchangeOidcCode(code: String, state: String, redirectUri: String): AuthResponse
+    suspend fun exchangeOidcCode(code: String, state: String, redirectUri: String, codeVerifier: String? = null): AuthResponse
     suspend fun redeemQrToken(serverUrl: String, token: String): AuthResponse
 }
 
@@ -58,7 +58,8 @@ private data class RefreshTokenRequest(
 private data class OidcCallbackRequest(
     val code: String,
     val state: String,
-    val redirectUri: String
+    val redirectUri: String,
+    val codeVerifier: String? = null
 )
 
 @Serializable
@@ -160,7 +161,8 @@ class AuthApiImpl @Inject constructor(
     override suspend fun exchangeOidcCode(
         code: String,
         state: String,
-        redirectUri: String
+        redirectUri: String,
+        codeVerifier: String?
     ): AuthResponse {
         // Fallback: call the server's OIDC callback directly via GET.
         // The server exchanges the authorization code internally and returns tokens.
@@ -168,6 +170,9 @@ class AuthApiImpl @Inject constructor(
             url {
                 parameters.append("code", code)
                 parameters.append("state", state)
+                if (codeVerifier != null) {
+                    parameters.append("code_verifier", codeVerifier)
+                }
             }
         }
 

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/data/api/AuthApi.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/data/api/AuthApi.kt
@@ -29,6 +29,8 @@ interface AuthApi {
     suspend fun refresh(refreshToken: String): AuthResponse
     suspend fun logout()
     suspend fun getMe(): User
+    /** Calls /auth/me with an explicit bearer token, bypassing the interceptor chain. */
+    suspend fun authenticatedGetMe(accessToken: String): User
     suspend fun getOidcProviders(): List<OidcProvider>
     suspend fun exchangeOidcCode(code: String, state: String, redirectUri: String, codeVerifier: String? = null): AuthResponse
     suspend fun redeemQrToken(serverUrl: String, token: String): AuthResponse
@@ -138,6 +140,21 @@ class AuthApiImpl @Inject constructor(
 
     override suspend fun getMe(): User {
         val response = httpClient.get("/auth/me")
+
+        if (!response.status.isSuccess()) {
+            val errorBody = runCatching { response.body<ApiErrorResponse>() }.getOrNull()
+            throw ApiException(response.status, errorBody?.message ?: "Failed to get user")
+        }
+
+        return response.body()
+    }
+
+    override suspend fun authenticatedGetMe(accessToken: String): User {
+        val response = httpClient.get("/auth/me") {
+            headers {
+                set(HttpHeaders.Authorization, "Bearer $accessToken")
+            }
+        }
 
         if (!response.status.isSuccess()) {
             val errorBody = runCatching { response.body<ApiErrorResponse>() }.getOrNull()

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/data/api/KaikuHttpClient.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/data/api/KaikuHttpClient.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
+import okhttp3.ConnectionSpec
 import java.util.logging.Level
 import java.util.logging.Logger
 import javax.inject.Inject
@@ -39,7 +40,8 @@ internal data class RefreshRequest(val refreshToken: String)
  */
 class KaikuHttpClient @Inject constructor(
     private val tokenStorage: TokenStorage,
-    private val authState: AuthState
+    private val authState: AuthState,
+    private val tls13Spec: ConnectionSpec
 ) {
     private enum class RefreshResult { SUCCESS, AUTH_REJECTED, NETWORK_ERROR }
 
@@ -57,7 +59,8 @@ class KaikuHttpClient @Inject constructor(
             authState: AuthState,
             engine: HttpClientEngine
         ): KaikuHttpClient {
-            return KaikuHttpClient(tokenStorage, authState).apply {
+            // ConnectionSpec is unused for MockEngine; provide MODERN_TLS as placeholder.
+            return KaikuHttpClient(tokenStorage, authState, ConnectionSpec.MODERN_TLS).apply {
                 testClient = createConfiguredClient(engine)
             }
         }
@@ -65,7 +68,11 @@ class KaikuHttpClient @Inject constructor(
 
     private val refreshMutex = Mutex()
 
-    val httpClient: HttpClient = createConfiguredClient(OkHttp.create())
+    val httpClient: HttpClient = createConfiguredClient(OkHttp.create {
+        config {
+            connectionSpecs(listOf(tls13Spec))
+        }
+    })
 
     @Volatile
     private var testClient: HttpClient? = null

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/data/local/TokenStorage.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/data/local/TokenStorage.kt
@@ -14,6 +14,8 @@ class TokenStorage @Inject constructor(
         private const val KEY_EXPIRES_AT = "expires_at"
         private const val KEY_USER_ID = "user_id"
         private const val KEY_SERVER_URL = "server_url"
+        private const val KEY_OIDC_CODE_VERIFIER = "oidc_code_verifier"
+        private const val KEY_OIDC_STATE = "oidc_state"
         private val logger = Logger.getLogger("TokenStorage")
     }
 
@@ -61,6 +63,24 @@ class TokenStorage @Inject constructor(
     fun isAccessTokenExpired(): Boolean {
         val expiresAt = prefs.getLong(KEY_EXPIRES_AT, 0L)
         return System.currentTimeMillis() >= expiresAt
+    }
+
+    fun saveOidcPkceState(codeVerifier: String, state: String) {
+        prefs.edit()
+            .putString(KEY_OIDC_CODE_VERIFIER, codeVerifier)
+            .putString(KEY_OIDC_STATE, state)
+            .apply()
+    }
+
+    fun getOidcCodeVerifier(): String? = prefs.getString(KEY_OIDC_CODE_VERIFIER, null)
+
+    fun getOidcState(): String? = prefs.getString(KEY_OIDC_STATE, null)
+
+    fun clearOidcPkceState() {
+        prefs.edit()
+            .remove(KEY_OIDC_CODE_VERIFIER)
+            .remove(KEY_OIDC_STATE)
+            .apply()
     }
 
     fun clear() {

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/data/local/TokenStorage.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/data/local/TokenStorage.kt
@@ -80,10 +80,13 @@ class TokenStorage @Inject constructor(
     fun getOidcState(): String? = prefs.getString(KEY_OIDC_STATE, null)
 
     fun clearOidcPkceState() {
-        prefs.edit()
+        val success = prefs.edit()
             .remove(KEY_OIDC_CODE_VERIFIER)
             .remove(KEY_OIDC_STATE)
-            .apply()
+            .commit()
+        if (!success) {
+            logger.warning("Failed to clear OIDC PKCE state from storage")
+        }
     }
 
     fun clear() {

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/data/local/TokenStorage.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/data/local/TokenStorage.kt
@@ -66,10 +66,13 @@ class TokenStorage @Inject constructor(
     }
 
     fun saveOidcPkceState(codeVerifier: String, state: String) {
-        prefs.edit()
+        val success = prefs.edit()
             .putString(KEY_OIDC_CODE_VERIFIER, codeVerifier)
             .putString(KEY_OIDC_STATE, state)
-            .apply()
+            .commit()
+        if (!success) {
+            logger.warning("Failed to persist OIDC PKCE state to storage")
+        }
     }
 
     fun getOidcCodeVerifier(): String? = prefs.getString(KEY_OIDC_CODE_VERIFIER, null)

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/data/repository/AuthRepository.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/data/repository/AuthRepository.kt
@@ -28,16 +28,8 @@ class AuthRepository @Inject constructor(
         return try {
             val authResponse = authApi.login(username, password, mfaCode)
 
-            tokenStorage.saveTokens(
-                accessToken = authResponse.accessToken,
-                refreshToken = authResponse.refreshToken,
-                expiresIn = authResponse.expiresIn,
-                userId = "" // Will be populated after getMe
-            )
+            val user = authApi.authenticatedGetMe(authResponse.accessToken)
 
-            val user = authApi.getMe()
-
-            // Re-save tokens with correct userId
             tokenStorage.saveTokens(
                 accessToken = authResponse.accessToken,
                 refreshToken = authResponse.refreshToken,
@@ -66,14 +58,7 @@ class AuthRepository @Inject constructor(
         return try {
             val authResponse = authApi.register(username, password, email, displayName)
 
-            tokenStorage.saveTokens(
-                accessToken = authResponse.accessToken,
-                refreshToken = authResponse.refreshToken,
-                expiresIn = authResponse.expiresIn,
-                userId = "" // Will be populated after getMe
-            )
-
-            val user = authApi.getMe()
+            val user = authApi.authenticatedGetMe(authResponse.accessToken)
 
             tokenStorage.saveTokens(
                 accessToken = authResponse.accessToken,
@@ -128,14 +113,7 @@ class AuthRepository @Inject constructor(
         expiresIn: Int
     ): Result<User> {
         return try {
-            tokenStorage.saveTokens(
-                accessToken = accessToken,
-                refreshToken = refreshToken,
-                expiresIn = expiresIn,
-                userId = "" // Will be populated after getMe
-            )
-
-            val user = authApi.getMe()
+            val user = authApi.authenticatedGetMe(accessToken)
 
             tokenStorage.saveTokens(
                 accessToken = accessToken,
@@ -164,14 +142,7 @@ class AuthRepository @Inject constructor(
             val redirectUri = "kaiku://auth/callback"
             val authResponse = authApi.exchangeOidcCode(code, state, redirectUri, codeVerifier)
 
-            tokenStorage.saveTokens(
-                accessToken = authResponse.accessToken,
-                refreshToken = authResponse.refreshToken,
-                expiresIn = authResponse.expiresIn,
-                userId = ""
-            )
-
-            val user = authApi.getMe()
+            val user = authApi.authenticatedGetMe(authResponse.accessToken)
 
             tokenStorage.saveTokens(
                 accessToken = authResponse.accessToken,
@@ -194,9 +165,8 @@ class AuthRepository @Inject constructor(
      * Redeems a QR login token scanned from the desktop client.
      *
      * Exchanges the token for auth credentials via an absolute URL, then
-     * saves the server URL after the redeem succeeds (before getMe, which
-     * needs it to construct the request URL). A failed getMe leaves the
-     * server URL set, which is acceptable since the redeem already succeeded.
+     * saves the server URL (needed by KaikuHttpClient for base URL) before
+     * calling getMe. Tokens are only persisted after getMe succeeds.
      */
     suspend fun redeemQrToken(serverUrl: String, token: String): Result<User> {
         return try {
@@ -204,16 +174,9 @@ class AuthRepository @Inject constructor(
 
             // Save server URL before getMe — KaikuHttpClient needs it for the base URL
             tokenStorage.saveServerUrl(serverUrl)
-            tokenStorage.saveTokens(
-                accessToken = authResponse.accessToken,
-                refreshToken = authResponse.refreshToken,
-                expiresIn = authResponse.expiresIn,
-                userId = "" // Will be populated after getMe
-            )
 
-            val user = authApi.getMe()
+            val user = authApi.authenticatedGetMe(authResponse.accessToken)
 
-            // Re-save tokens with correct userId
             tokenStorage.saveTokens(
                 accessToken = authResponse.accessToken,
                 refreshToken = authResponse.refreshToken,

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/data/repository/AuthRepository.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/data/repository/AuthRepository.kt
@@ -159,10 +159,10 @@ class AuthRepository @Inject constructor(
      *
      * This is a fallback path if the server does not redirect with tokens directly.
      */
-    suspend fun exchangeOidcCode(code: String, state: String): Result<User> {
+    suspend fun exchangeOidcCode(code: String, state: String, codeVerifier: String? = null): Result<User> {
         return try {
             val redirectUri = "kaiku://auth/callback"
-            val authResponse = authApi.exchangeOidcCode(code, state, redirectUri)
+            val authResponse = authApi.exchangeOidcCode(code, state, redirectUri, codeVerifier)
 
             tokenStorage.saveTokens(
                 accessToken = authResponse.accessToken,

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/data/ws/ClientEvent.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/data/ws/ClientEvent.kt
@@ -12,6 +12,10 @@ import kotlinx.serialization.Serializable
 sealed class ClientEvent {
 
     @Serializable
+    @SerialName("authenticate")
+    data class Authenticate(val token: String) : ClientEvent()
+
+    @Serializable
     @SerialName("ping")
     data object Ping : ClientEvent()
 

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/data/ws/ConnectivityMonitor.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/data/ws/ConnectivityMonitor.kt
@@ -9,6 +9,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import java.io.Closeable
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -21,7 +22,7 @@ import javax.inject.Singleton
 @Singleton
 class ConnectivityMonitor @Inject constructor(
     @ApplicationContext private val context: Context
-) {
+) : Closeable {
     private val connectivityManager =
         context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
 
@@ -44,15 +45,15 @@ class ConnectivityMonitor @Inject constructor(
         ) {
             val hasInternet = networkCapabilities
                 .hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
-            if (hasInternet) {
-                _isConnected.value = true
-            }
+                && networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+            _isConnected.value = hasInternet
         }
     }
 
     init {
         val request = NetworkRequest.Builder()
             .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
             .build()
         connectivityManager.registerNetworkCallback(request, networkCallback)
     }
@@ -61,5 +62,15 @@ class ConnectivityMonitor @Inject constructor(
         val network = connectivityManager.activeNetwork ?: return false
         val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
         return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            && capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+    }
+
+    override fun close() {
+        try {
+            connectivityManager.unregisterNetworkCallback(networkCallback)
+        } catch (_: IllegalArgumentException) {
+            // Already unregistered
+        }
+        _isConnected.value = false
     }
 }

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/data/ws/KaikuWebSocket.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/data/ws/KaikuWebSocket.kt
@@ -53,6 +53,8 @@ class KaikuWebSocket @Inject constructor(
         internal const val PING_INTERVAL_MS = 30_000L
         internal const val INITIAL_RECONNECT_DELAY_MS = 1_000L
         internal const val MAX_RECONNECT_DELAY_MS = 30_000L
+        /** WebSocket close code 1008 (Policy Violation) — server uses this for auth failures. */
+        internal const val AUTH_REJECTED_CLOSE_CODE = 1008
     }
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -196,19 +198,31 @@ class KaikuWebSocket @Inject constructor(
 
         override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
             logger.info("WebSocket closed: code=$code reason=$reason")
-            handleDisconnect()
+            handleDisconnect(closeCode = code)
         }
 
         override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
             logger.log(Level.WARNING, "WebSocket failure: ${t.message}", t)
-            handleDisconnect()
+            handleDisconnect(closeCode = null)
         }
     }
 
-    private fun handleDisconnect() {
+    private fun handleDisconnect(closeCode: Int? = null) {
         pingJob?.cancel()
         pingJob = null
         webSocket = null
+
+        // If the server closed with a policy violation (1008) while we were still
+        // authenticating, treat this as an auth failure — don't loop on a bad token.
+        // The user must obtain a new token (typically via re-login or refresh).
+        val wasAuthenticating = _connectionState.value == ConnectionState.Connecting
+        if (wasAuthenticating && closeCode == AUTH_REJECTED_CLOSE_CODE) {
+            logger.warning("WebSocket auth rejected by server (code 1008), suppressing reconnect")
+            _connectionState.value = ConnectionState.TokenExpired
+            shouldReconnect = false
+            return
+        }
+
         _connectionState.value = ConnectionState.Disconnected
 
         if (shouldReconnect) {

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/data/ws/KaikuWebSocket.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/data/ws/KaikuWebSocket.kt
@@ -28,7 +28,8 @@ import javax.inject.Singleton
 enum class ConnectionState {
     Connected,
     Connecting,
-    Disconnected
+    Disconnected,
+    TokenExpired
 }
 
 /**
@@ -55,6 +56,7 @@ class KaikuWebSocket @Inject constructor(
     }
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var connectivityJob: Job? = null
 
     private val _events = MutableSharedFlow<ServerEvent>(extraBufferCapacity = 64)
     val events: SharedFlow<ServerEvent> = _events.asSharedFlow()
@@ -73,8 +75,9 @@ class KaikuWebSocket @Inject constructor(
     private var connectivityMonitor: ConnectivityMonitor? = null
 
     fun setConnectivityMonitor(monitor: ConnectivityMonitor) {
+        connectivityJob?.cancel()
         connectivityMonitor = monitor
-        scope.launch {
+        connectivityJob = scope.launch {
             monitor.isConnected.collect { connected ->
                 if (connected && shouldReconnect && _connectionState.value == ConnectionState.Disconnected) {
                     reconnectDelay = INITIAL_RECONNECT_DELAY_MS
@@ -104,6 +107,8 @@ class KaikuWebSocket @Inject constructor(
         reconnectJob = null
         pingJob?.cancel()
         pingJob = null
+        connectivityJob?.cancel()
+        connectivityJob = null
         webSocket?.close(1000, "Client disconnect")
         webSocket = null
         _connectionState.value = ConnectionState.Disconnected
@@ -130,6 +135,13 @@ class KaikuWebSocket @Inject constructor(
             logger.warning("No access token available, stopping reconnect")
             shouldReconnect = false
             _connectionState.value = ConnectionState.Disconnected
+            return
+        }
+
+        if (tokenStorage.isAccessTokenExpired()) {
+            logger.info("Access token expired, emitting TokenExpired state")
+            _connectionState.value = ConnectionState.TokenExpired
+            shouldReconnect = false
             return
         }
 

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/data/ws/KaikuWebSocket.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/data/ws/KaikuWebSocket.kt
@@ -154,14 +154,16 @@ class KaikuWebSocket @Inject constructor(
 
         val request = Request.Builder()
             .url(wsUrl)
-            .addHeader("Sec-WebSocket-Protocol", "access_token.$token")
             .build()
 
-        webSocket = okHttpClient.newWebSocket(request, createListener())
+        webSocket = okHttpClient.newWebSocket(request, createListener(token))
     }
 
-    private fun createListener() = object : WebSocketListener() {
+    private fun createListener(token: String) = object : WebSocketListener() {
         override fun onOpen(webSocket: WebSocket, response: Response) {
+            // Authenticate via first frame (post-connect auth)
+            send(ClientEvent.Authenticate(token))
+
             logger.info("WebSocket connected")
             _connectionState.value = ConnectionState.Connected
             reconnectDelay = INITIAL_RECONNECT_DELAY_MS

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/data/ws/KaikuWebSocket.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/data/ws/KaikuWebSocket.kt
@@ -164,15 +164,22 @@ class KaikuWebSocket @Inject constructor(
             // Authenticate via first frame (post-connect auth)
             send(ClientEvent.Authenticate(token))
 
-            logger.info("WebSocket connected")
-            _connectionState.value = ConnectionState.Connected
-            reconnectDelay = INITIAL_RECONNECT_DELAY_MS
-            startPingLoop()
+            logger.info("WebSocket open, awaiting Ready for authentication confirmation")
+            // Stay in Connecting state until server sends Ready event (auth confirmed).
+            // Server's 5s auth timeout closes the WS if auth fails — handled by onClosed/onFailure.
         }
 
         override fun onMessage(webSocket: WebSocket, text: String) {
             try {
                 val event = json.decodeFromString<ServerEvent>(text)
+                // Transition to Connected on Ready event (works for both header-based
+                // and post-connect Authenticate auth modes — server sends Ready in both).
+                if (event is ServerEvent.Ready && _connectionState.value == ConnectionState.Connecting) {
+                    logger.info("WebSocket authenticated, transitioning to Connected")
+                    _connectionState.value = ConnectionState.Connected
+                    reconnectDelay = INITIAL_RECONNECT_DELAY_MS
+                    startPingLoop()
+                }
                 val emitted = _events.tryEmit(event)
                 if (!emitted) {
                     logger.warning("Event buffer full, dropped: ${event::class.simpleName}")

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/di/NetworkModule.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/di/NetworkModule.kt
@@ -10,6 +10,8 @@ import io.wolftown.kaiku.data.api.KaikuHttpClient
 import io.wolftown.kaiku.data.local.AuthState
 import io.wolftown.kaiku.data.local.TokenStorage
 import kotlinx.serialization.json.Json
+import okhttp3.ConnectionSpec
+import okhttp3.TlsVersion
 import javax.inject.Singleton
 
 @Module
@@ -18,11 +20,20 @@ object NetworkModule {
 
     @Provides
     @Singleton
+    fun provideTls13Spec(): ConnectionSpec {
+        return ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+            .tlsVersions(TlsVersion.TLS_1_3)
+            .build()
+    }
+
+    @Provides
+    @Singleton
     fun provideKaikuHttpClient(
         tokenStorage: TokenStorage,
-        authState: AuthState
+        authState: AuthState,
+        tls13Spec: ConnectionSpec
     ): KaikuHttpClient {
-        return KaikuHttpClient(tokenStorage, authState)
+        return KaikuHttpClient(tokenStorage, authState, tls13Spec)
     }
 
     @Provides

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/di/WebSocketModule.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/di/WebSocketModule.kt
@@ -9,6 +9,7 @@ import io.wolftown.kaiku.data.ws.ConnectivityMonitor
 import io.wolftown.kaiku.data.ws.KaikuWebSocket
 import io.wolftown.kaiku.data.ws.WsJson
 import kotlinx.serialization.json.Json
+import okhttp3.ConnectionSpec
 import okhttp3.OkHttpClient
 import java.util.concurrent.TimeUnit
 import javax.inject.Qualifier
@@ -25,8 +26,9 @@ object WebSocketModule {
 
     @Provides
     @Singleton
-    fun provideOkHttpClient(): OkHttpClient {
+    fun provideOkHttpClient(tls13Spec: ConnectionSpec): OkHttpClient {
         return OkHttpClient.Builder()
+            .connectionSpecs(listOf(tls13Spec))
             .pingInterval(0, TimeUnit.SECONDS) // We handle ping/pong at the application level
             .readTimeout(0, TimeUnit.SECONDS)   // No timeout for WebSocket reads
             .build()

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/auth/OidcHandler.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/auth/OidcHandler.kt
@@ -2,10 +2,13 @@ package io.wolftown.kaiku.ui.auth
 
 import android.content.Context
 import android.net.Uri
+import android.util.Base64
 import androidx.browser.customtabs.CustomTabsIntent
 import io.wolftown.kaiku.data.local.TokenStorage
 import io.wolftown.kaiku.data.repository.AuthRepository
 import io.wolftown.kaiku.domain.model.User
+import java.security.MessageDigest
+import java.security.SecureRandom
 import java.util.logging.Level
 import java.util.logging.Logger
 import javax.inject.Inject
@@ -42,8 +45,28 @@ class OidcHandler @Inject constructor(
     fun launchOidcLogin(context: Context, providerSlug: String) {
         val serverUrl = tokenStorage.getServerUrl()
             ?: throw IllegalStateException("Server URL not configured")
+
+        // Generate PKCE code_verifier (43-128 chars, URL-safe base64)
+        val codeVerifier = ByteArray(32).also { SecureRandom().nextBytes(it) }
+            .let { Base64.encodeToString(it, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING) }
+
+        // Compute code_challenge = BASE64URL(SHA256(code_verifier))
+        val codeChallenge = MessageDigest.getInstance("SHA-256")
+            .digest(codeVerifier.toByteArray(Charsets.US_ASCII))
+            .let { Base64.encodeToString(it, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING) }
+
+        // Generate state nonce for CSRF protection
+        val state = ByteArray(32).also { SecureRandom().nextBytes(it) }
+            .let { Base64.encodeToString(it, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING) }
+
+        // Persist to EncryptedSharedPreferences for validation in callback
+        tokenStorage.saveOidcPkceState(codeVerifier, state)
+
         val authUrl = "$serverUrl/auth/oidc/authorize/$providerSlug" +
-            "?redirect_uri=${Uri.encode(REDIRECT_URI)}"
+            "?redirect_uri=${Uri.encode(REDIRECT_URI)}" +
+            "&code_challenge=$codeChallenge" +
+            "&code_challenge_method=S256" +
+            "&state=$state"
         try {
             val customTabIntent = CustomTabsIntent.Builder().build()
             customTabIntent.launchUrl(context, Uri.parse(authUrl))
@@ -77,12 +100,21 @@ class OidcHandler @Inject constructor(
      * @return [Result] containing the authenticated [User] or a failure
      */
     suspend fun handleCallback(uri: Uri, authRepository: AuthRepository): Result<User> {
+        // Validate state nonce against saved value (CSRF protection)
+        val savedState = tokenStorage.getOidcState()
+        val uriState = uri.getQueryParameter("state")
+        if (savedState == null || uriState != savedState) {
+            tokenStorage.clearOidcPkceState()
+            return Result.failure(IllegalStateException("OIDC state mismatch — possible CSRF"))
+        }
+
         // Primary path: server already exchanged the code and redirected with tokens
         val accessToken = uri.getQueryParameter("access_token")
         val refreshToken = uri.getQueryParameter("refresh_token")
         val expiresInStr = uri.getQueryParameter("expires_in")
 
         if (accessToken != null && expiresInStr != null) {
+            tokenStorage.clearOidcPkceState()
             val expiresIn = expiresInStr.toIntOrNull()
                 ?: return Result.failure(IllegalArgumentException("Invalid expires_in value"))
             return authRepository.completeOidcLogin(
@@ -97,11 +129,9 @@ class OidcHandler @Inject constructor(
             ?: return Result.failure(
                 IllegalArgumentException("OIDC callback missing both tokens and authorization code")
             )
-        val state = uri.getQueryParameter("state")
-            ?: return Result.failure(
-                IllegalArgumentException("OIDC callback missing state parameter")
-            )
 
-        return authRepository.exchangeOidcCode(code, state)
+        val codeVerifier = tokenStorage.getOidcCodeVerifier()
+        tokenStorage.clearOidcPkceState()
+        return authRepository.exchangeOidcCode(code, uriState, codeVerifier)
     }
 }

--- a/mobile/android/app/src/test/java/io/wolftown/kaiku/data/ws/KaikuWebSocketTest.kt
+++ b/mobile/android/app/src/test/java/io/wolftown/kaiku/data/ws/KaikuWebSocketTest.kt
@@ -109,6 +109,12 @@ class KaikuWebSocketTest {
                 authLatch.await(5, TimeUnit.SECONDS)
             )
 
+            // Give the WebSocket message loop time to process anything the server
+            // would have sent. Without this real delay, expectNoEvents() returns
+            // immediately and would pass even if the production code transitioned
+            // to Connected directly from onOpen.
+            kotlinx.coroutines.delay(200)
+
             // No transition to Connected — server hasn't sent Ready
             expectNoEvents()
 

--- a/mobile/android/app/src/test/java/io/wolftown/kaiku/data/ws/KaikuWebSocketTest.kt
+++ b/mobile/android/app/src/test/java/io/wolftown/kaiku/data/ws/KaikuWebSocketTest.kt
@@ -115,17 +115,22 @@ class KaikuWebSocketTest {
     @Test
     fun `send serializes ClientEvent and sends over WebSocket`() = runTest {
         val receivedMessages = mutableListOf<String>()
-        val messageLatch = CountDownLatch(1)
+        // Count 2: one for the automatic Authenticate frame, one for Subscribe
+        val messageLatch = CountDownLatch(2)
 
         mockServer.enqueue(
             MockResponse().withWebSocketUpgrade(object : WebSocketListener() {
                 override fun onOpen(webSocket: WebSocket, response: Response) {
-                    webSocket.send("""{"type":"ready","user_id":"usr-001"}""")
+                    // Server sends ready after receiving the authenticate frame
                 }
 
                 override fun onMessage(webSocket: WebSocket, text: String) {
                     receivedMessages.add(text)
                     messageLatch.countDown()
+                    // Send ready after authenticate so the client can proceed
+                    if (text.contains("authenticate")) {
+                        webSocket.send("""{"type":"ready","user_id":"usr-001"}""")
+                    }
                 }
             })
         )
@@ -136,8 +141,8 @@ class KaikuWebSocketTest {
 
             ws.send(ClientEvent.Subscribe("chan-001"))
 
-            // Wait for the message to arrive at the mock server (max 5s)
-            assertTrue("Server did not receive message in time", messageLatch.await(5, TimeUnit.SECONDS))
+            // Wait for both messages to arrive at the mock server (max 5s)
+            assertTrue("Server did not receive messages in time", messageLatch.await(5, TimeUnit.SECONDS))
 
             val sent = receivedMessages.firstOrNull { it.contains("subscribe") }
             assertTrue("Expected subscribe message to be sent", sent != null)
@@ -173,10 +178,20 @@ class KaikuWebSocketTest {
     }
 
     @Test
-    fun `connect uses Sec-WebSocket-Protocol header with token`() = runTest {
+    fun `connect sends Authenticate frame instead of header`() = runTest {
+        val receivedMessages = mutableListOf<String>()
+        val authLatch = CountDownLatch(1)
+
         mockServer.enqueue(
             MockResponse().withWebSocketUpgrade(object : WebSocketListener() {
                 override fun onOpen(webSocket: WebSocket, response: Response) {
+                    // Don't send ready until we receive the auth frame
+                }
+
+                override fun onMessage(webSocket: WebSocket, text: String) {
+                    receivedMessages.add(text)
+                    authLatch.countDown()
+                    // After receiving auth, send ready
                     webSocket.send("""{"type":"ready","user_id":"usr-001"}""")
                 }
             })
@@ -184,11 +199,19 @@ class KaikuWebSocketTest {
 
         ws.events.test(timeout = 10.seconds) {
             ws.connect(mockServer.url("/").toString())
-            awaitItem() // Ready
 
+            // Wait for the authenticate message to arrive at the mock server
+            assertTrue("Server did not receive auth message in time", authLatch.await(5, TimeUnit.SECONDS))
+
+            // Verify no Sec-WebSocket-Protocol header was sent
             val request = mockServer.takeRequest()
             val protocol = request.getHeader("Sec-WebSocket-Protocol")
-            assertEquals("access_token.test-jwt-token", protocol)
+            assertEquals(null, protocol)
+
+            // Verify the first message is the authenticate frame
+            val authMsg = receivedMessages.first()
+            assertTrue("Expected type field", authMsg.contains(""""type":"authenticate""""))
+            assertTrue("Expected token field", authMsg.contains(""""token":"test-jwt-token""""))
 
             cancelAndIgnoreRemainingEvents()
         }

--- a/mobile/android/app/src/test/java/io/wolftown/kaiku/data/ws/KaikuWebSocketTest.kt
+++ b/mobile/android/app/src/test/java/io/wolftown/kaiku/data/ws/KaikuWebSocketTest.kt
@@ -81,6 +81,42 @@ class KaikuWebSocketTest {
     }
 
     @Test
+    fun `connect stays in Connecting state until Ready event arrives`() = runTest {
+        val authLatch = CountDownLatch(1)
+
+        mockServer.enqueue(
+            MockResponse().withWebSocketUpgrade(object : WebSocketListener() {
+                override fun onOpen(webSocket: WebSocket, response: Response) {
+                    // Don't send anything — wait for Authenticate frame
+                }
+
+                override fun onMessage(webSocket: WebSocket, text: String) {
+                    // Receive Authenticate but don't respond with Ready
+                    authLatch.countDown()
+                }
+            })
+        )
+
+        ws.connectionState.test(timeout = 10.seconds) {
+            assertEquals(ConnectionState.Disconnected, awaitItem())
+
+            ws.connect(mockServer.url("/").toString())
+            assertEquals(ConnectionState.Connecting, awaitItem())
+
+            // Wait for the auth frame to be received by mock server
+            assertTrue(
+                "Server did not receive auth message in time",
+                authLatch.await(5, TimeUnit.SECONDS)
+            )
+
+            // No transition to Connected — server hasn't sent Ready
+            expectNoEvents()
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `events flow emits parsed server events`() = runTest {
         mockServer.enqueue(
             MockResponse().withWebSocketUpgrade(object : WebSocketListener() {

--- a/server/src/ws/events.rs
+++ b/server/src/ws/events.rs
@@ -63,6 +63,11 @@ pub(super) const fn default_pc_type() -> PcType {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ClientEvent {
+    /// Post-connect authentication (replaces header-based auth for new clients).
+    Authenticate {
+        /// JWT access token.
+        token: String,
+    },
     /// Ping for keepalive
     Ping,
     /// Subscribe to channel events
@@ -217,6 +222,7 @@ impl ClientEvent {
     /// Return a low-cardinality static name for this event variant (for metrics).
     pub const fn variant_name(&self) -> &'static str {
         match self {
+            Self::Authenticate { .. } => "authenticate",
             Self::Ping => "ping",
             Self::Subscribe { .. } => "subscribe",
             Self::Unsubscribe { .. } => "unsubscribe",

--- a/server/src/ws/handlers.rs
+++ b/server/src/ws/handlers.rs
@@ -71,66 +71,146 @@ fn error_response(status: u16, body: &'static str) -> Response {
 
 /// WebSocket upgrade handler.
 ///
-/// Authentication is performed via the `Sec-WebSocket-Protocol` header to avoid
-/// token exposure in server logs and browser history (OWASP recommendation).
+/// Supports two authentication methods (dual-auth for transition period):
 ///
-/// # Protocol
+/// 1. **Header-based** (legacy): Client sends
+///    `Sec-WebSocket-Protocol: access_token.<jwt_token>`.
+///    Token is validated before upgrade; server responds with
+///    `Sec-WebSocket-Protocol: access_token`.
 ///
-/// Client sends: `Sec-WebSocket-Protocol: access_token.<jwt_token>`
-/// Server responds: `Sec-WebSocket-Protocol: access_token`
+/// 2. **Post-connect** (new): Client connects without a token header.
+///    After upgrade the server waits up to 5 seconds for an `Authenticate`
+///    frame carrying the JWT.  On success the normal socket loop starts.
 #[tracing::instrument(skip(ws, state, headers))]
 pub async fn handler(
     ws: WebSocketUpgrade,
     State(state): State<AppState>,
     headers: HeaderMap,
 ) -> Response {
-    // Extract token from Sec-WebSocket-Protocol header
-    let token = match extract_token_from_protocol(&headers) {
-        Some(t) => t,
-        None => {
-            return error_response(
-                401,
-                "Missing or invalid Sec-WebSocket-Protocol header. Expected: access_token.<jwt>",
-            );
-        }
-    };
+    // Try header-based auth first (backwards compatible)
+    if let Some(token) = extract_token_from_protocol(&headers) {
+        let claims = match jwt::validate_access_token(&token, &state.config.jwt_public_key) {
+            Ok(claims) => claims,
+            Err(_) => {
+                return error_response(401, "Invalid token");
+            }
+        };
 
-    // Validate token before upgrade
-    let claims = match jwt::validate_access_token(&token, &state.config.jwt_public_key) {
-        Ok(claims) => claims,
-        Err(_) => {
-            return error_response(401, "Invalid token");
-        }
-    };
+        let user_id = match Uuid::parse_str(&claims.sub) {
+            Ok(id) => id,
+            Err(_) => {
+                return error_response(401, "Invalid user ID in token");
+            }
+        };
 
-    let user_id = match Uuid::parse_str(&claims.sub) {
-        Ok(id) => id,
-        Err(_) => {
-            return error_response(401, "Invalid user ID in token");
+        // Verify user still exists (lightweight existence check, not full row fetch)
+        match sqlx::query_scalar::<_, bool>("SELECT EXISTS(SELECT 1 FROM users WHERE id = $1)")
+            .bind(user_id)
+            .fetch_one(&state.db)
+            .await
+        {
+            Ok(true) => {}
+            Ok(false) => {
+                return error_response(401, "User not found");
+            }
+            Err(e) => {
+                warn!("Database error during WS auth: {}", e);
+                return error_response(503, "Service temporarily unavailable");
+            }
         }
-    };
 
-    // Verify user still exists (lightweight existence check, not full row fetch)
-    match sqlx::query_scalar::<_, bool>("SELECT EXISTS(SELECT 1 FROM users WHERE id = $1)")
-        .bind(user_id)
-        .fetch_one(&state.db)
-        .await
-    {
-        Ok(true) => {}
-        Ok(false) => {
-            return error_response(401, "User not found");
-        }
-        Err(e) => {
-            warn!("Database error during WS auth: {}", e);
-            return error_response(503, "Service temporarily unavailable");
-        }
+        // Respond with the protocol to confirm (required for WebSocket handshake)
+        return ws
+            .protocols(["access_token"])
+            .max_message_size(256 * 1024)
+            .max_frame_size(64 * 1024)
+            .on_upgrade(move |socket| handle_socket(socket, state, user_id));
     }
 
-    // Respond with the protocol to confirm (required for WebSocket handshake)
-    ws.protocols(["access_token"])
-        .max_message_size(256 * 1024)
+    // No header token — accept upgrade, authenticate via first frame
+    ws.max_message_size(256 * 1024)
         .max_frame_size(64 * 1024)
-        .on_upgrade(move |socket| handle_socket(socket, state, user_id))
+        .on_upgrade(move |socket| handle_post_connect_auth(socket, state))
+}
+
+/// Handle post-connect authentication: wait for an `Authenticate` frame,
+/// then hand off to the normal socket loop on success.
+async fn handle_post_connect_auth(socket: WebSocket, state: AppState) {
+    let (ws_sender, mut ws_receiver) = socket.split();
+
+    // Wait up to 5 seconds for the Authenticate frame
+    let user_id = match tokio::time::timeout(
+        Duration::from_secs(5),
+        wait_for_auth_frame(&mut ws_receiver, &state),
+    )
+    .await
+    {
+        Ok(Ok(uid)) => uid,
+        Ok(Err(reason)) => {
+            warn!("Post-connect auth failed: {}", reason);
+            let mut ws_sender = ws_sender;
+            let _ = ws_sender.close().await;
+            return;
+        }
+        Err(_) => {
+            warn!("Post-connect auth timeout");
+            let mut ws_sender = ws_sender;
+            let _ = ws_sender.close().await;
+            return;
+        }
+    };
+
+    // Reassemble the socket and continue with normal handler
+    let socket = ws_sender
+        .reunite(ws_receiver)
+        .expect("reunite should never fail for same socket");
+    handle_socket(socket, state, user_id).await;
+}
+
+/// Read frames until an `Authenticate` event arrives and validate its token.
+async fn wait_for_auth_frame(
+    receiver: &mut futures::stream::SplitStream<WebSocket>,
+    state: &AppState,
+) -> Result<Uuid, String> {
+    while let Some(msg) = receiver.next().await {
+        match msg {
+            Ok(Message::Text(text)) => match serde_json::from_str::<ClientEvent>(&text) {
+                Ok(ClientEvent::Authenticate { token }) => {
+                    let claims = jwt::validate_access_token(&token, &state.config.jwt_public_key)
+                        .map_err(|e| format!("Invalid token: {e}"))?;
+                    let user_id = Uuid::parse_str(&claims.sub)
+                        .map_err(|_| "Invalid user ID in token".to_string())?;
+
+                    // Verify user exists
+                    match sqlx::query_scalar::<_, bool>(
+                        "SELECT EXISTS(SELECT 1 FROM users WHERE id = $1)",
+                    )
+                    .bind(user_id)
+                    .fetch_one(&state.db)
+                    .await
+                    {
+                        Ok(true) => return Ok(user_id),
+                        Ok(false) => return Err("User not found".to_string()),
+                        Err(e) => return Err(format!("Database error: {e}")),
+                    }
+                }
+                Ok(_) => {
+                    // Ignore non-Authenticate events during pre-auth
+                }
+                Err(e) => {
+                    return Err(format!("Invalid event: {e}"));
+                }
+            },
+            Ok(Message::Close(_)) => {
+                return Err("Connection closed before authentication".to_string());
+            }
+            Ok(_) => {} // Ignore binary, ping, pong
+            Err(e) => {
+                return Err(format!("WebSocket error: {e}"));
+            }
+        }
+    }
+    Err("Connection closed before authentication".to_string())
 }
 
 /// Handle WebSocket connection.
@@ -696,6 +776,10 @@ pub async fn handle_client_message(
         ClientEvent::AdminUnsubscribe => {
             *admin_subscribed.write().await = false;
             debug!("Admin {} unsubscribed from admin events", user_id);
+        }
+
+        ClientEvent::Authenticate { .. } => {
+            // Already authenticated — ignore duplicate
         }
     }
 

--- a/server/src/ws/handlers.rs
+++ b/server/src/ws/handlers.rs
@@ -91,7 +91,8 @@ pub async fn handler(
     if let Some(token) = extract_token_from_protocol(&headers) {
         let claims = match jwt::validate_access_token(&token, &state.config.jwt_public_key) {
             Ok(claims) => claims,
-            Err(_) => {
+            Err(e) => {
+                warn!("Header-based WS auth failed: {}", e);
                 return error_response(401, "Invalid token");
             }
         };


### PR DESCRIPTION
## Summary
- **WebSocket auth migration**: Move token from `Sec-WebSocket-Protocol` header to post-connect `Authenticate` frame, preventing exposure in proxy logs. Server supports both methods for backwards compatibility.
- **TLS 1.3 enforcement**: Add `ConnectionSpec` restricting all OkHttp connections to TLS 1.3, with `ProviderInstaller` for API 26-28 devices.
- **OIDC PKCE + state nonce**: Add RFC 8252 PKCE (`code_verifier`/`code_challenge`) and CSRF-preventing `state` nonce to the OIDC flow. Add Android App Links (`https://kaiku.pmind.de/auth/callback`) alongside the existing `kaiku://` scheme.
- **Token persistence fix**: Defer `saveTokens` until `getMe` succeeds across all 5 auth flows, preventing orphaned credentials on process death.
- **Network robustness**: Add `NET_CAPABILITY_VALIDATED` to prevent captive portal false positives, check token expiry before WebSocket reconnect, track and cancel connectivity collector jobs.
- **Manifest cleanup**: Scope legacy `BLUETOOTH` permission to API ≤30.

Addresses issues #1, #2, #3, #4, #15, #16, #17, #18, #27 from the mobile implementation review.

## Test plan
- [ ] Server: `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings` passes
- [ ] Android: `./gradlew test` passes (unit tests)
- [ ] WebSocket connects and authenticates via post-connect frame
- [ ] OIDC login flow works with PKCE parameters
- [ ] App Links verification with `assetlinks.json` (deployment task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)