### PR TITLE
fix(client): Android UI & architecture quality fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Android: screen share video track lookup no longer falls back to wrong track in multi-peer scenarios (#23)
 - Android: ICE candidate buffer is bounded to prevent unbounded memory growth on buggy SDP flows
 - Android: concurrent voice connection cleanup is now race-free, preventing rare crashes on rapid reconnect
+- Android: channel names now display correctly instead of raw UUIDs in text and voice channel headers (#7)
+- Android: rapid channel taps no longer silently drop navigation events (#8)
+- Android: scrolling up to read history no longer snaps back to the bottom when new messages arrive (#9)
+- Android: guild icons are properly announced as interactive buttons by screen readers (#24)
 - Admin dashboard status badges, elevation buttons, and warning banners now have readable text instead of invisible same-hue text on colored backgrounds (#524)
 - Clicking another user's reaction emoji now correctly toggles your own reaction instead of removing theirs (#454)
 - Sent friend requests now show "Cancel" button instead of Accept/Decline buttons in the pending view (#453)

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/data/local/AuthState.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/data/local/AuthState.kt
@@ -2,12 +2,15 @@ package io.wolftown.kaiku.data.local
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import java.io.Closeable
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -17,16 +20,18 @@ sealed class AuthSession {
 }
 
 @Singleton
-class AuthState @Inject constructor() {
+class AuthState @Inject constructor() : Closeable {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     private val _session = MutableStateFlow<AuthSession>(AuthSession.LoggedOut)
     val session: StateFlow<AuthSession> = _session.asStateFlow()
 
     val isLoggedIn: StateFlow<Boolean> = _session.map { it is AuthSession.LoggedIn }
-        .stateIn(CoroutineScope(Dispatchers.Default), SharingStarted.Eagerly, false)
+        .stateIn(scope, SharingStarted.Eagerly, false)
 
     val currentUserId: StateFlow<String?> = _session.map { (it as? AuthSession.LoggedIn)?.userId }
-        .stateIn(CoroutineScope(Dispatchers.Default), SharingStarted.Eagerly, null)
+        .stateIn(scope, SharingStarted.Eagerly, null)
 
     fun setLoggedIn(userId: String) {
         require(userId.isNotBlank()) { "userId must not be blank" }
@@ -58,5 +63,9 @@ class AuthState @Inject constructor() {
         }
 
         setLoggedOut()
+    }
+
+    override fun close() {
+        scope.cancel()
     }
 }

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/KaikuNavGraph.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/KaikuNavGraph.kt
@@ -113,19 +113,15 @@ fun KaikuNavGraph(
                     )
                 }
 
-                composable("channel/{channelId}") { backStackEntry ->
-                    val channelId = backStackEntry.arguments?.getString("channelId") ?: ""
+                composable("channel/{channelId}") {
                     TextChannelScreen(
-                        channelName = channelId,
                         currentUserId = currentUserId ?: "",
                         onNavigateBack = { navController.popBackStack() }
                     )
                 }
 
-                composable("voice/{channelId}") { backStackEntry ->
-                    val channelId = backStackEntry.arguments?.getString("channelId") ?: ""
+                composable("voice/{channelId}") {
                     VoiceChannelScreen(
-                        channelName = channelId,
                         onNavigateBack = { navController.popBackStack() }
                     )
                 }

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/auth/LoginViewModel.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/auth/LoginViewModel.kt
@@ -34,8 +34,11 @@ class LoginViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(LoginUiState())
     val uiState: StateFlow<LoginUiState> = _uiState.asStateFlow()
 
-    /** One-shot event flow for OIDC callback URIs received from deep links. */
-    private val _oidcCallbackUri = Channel<Uri>(Channel.BUFFERED)
+    /**
+     * One-shot event flow for OIDC callback URIs received from deep links.
+     * CONFLATED keeps only the latest — redelivery is harmless and trySend never blocks.
+     */
+    private val _oidcCallbackUri = Channel<Uri>(Channel.CONFLATED)
     val oidcCallbackUri = _oidcCallbackUri.receiveAsFlow()
 
     init {

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/auth/LoginViewModel.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/auth/LoginViewModel.kt
@@ -6,12 +6,11 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.wolftown.kaiku.data.repository.AuthRepository
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -36,8 +35,8 @@ class LoginViewModel @Inject constructor(
     val uiState: StateFlow<LoginUiState> = _uiState.asStateFlow()
 
     /** One-shot event flow for OIDC callback URIs received from deep links. */
-    private val _oidcCallbackUri = MutableSharedFlow<Uri>(extraBufferCapacity = 1)
-    val oidcCallbackUri: SharedFlow<Uri> = _oidcCallbackUri.asSharedFlow()
+    private val _oidcCallbackUri = Channel<Uri>(Channel.BUFFERED)
+    val oidcCallbackUri = _oidcCallbackUri.receiveAsFlow()
 
     init {
         // Collect OIDC callbacks and process them
@@ -52,7 +51,7 @@ class LoginViewModel @Inject constructor(
      * Called by MainActivity when an OIDC deep link is received.
      */
     fun onOidcDeepLink(uri: Uri) {
-        _oidcCallbackUri.tryEmit(uri)
+        _oidcCallbackUri.trySend(uri)
     }
 
     /**

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/channel/MessageItem.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/channel/MessageItem.kt
@@ -86,8 +86,11 @@ fun MessageItem(
 
                     Spacer(modifier = Modifier.width(8.dp))
 
+                    val formattedTime = remember(message.createdAt) {
+                        formatTimestamp(message.createdAt)
+                    }
                     Text(
-                        text = formatTimestamp(message.createdAt),
+                        text = formattedTime,
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         maxLines = 1,

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/channel/TextChannelScreen.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/channel/TextChannelScreen.kt
@@ -37,10 +37,18 @@ fun TextChannelScreen(
 
     val listState = rememberLazyListState()
 
-    // Auto-scroll to bottom when new messages arrive
-    LaunchedEffect(messages.size) {
-        if (messages.isNotEmpty()) {
-            listState.animateScrollToItem(messages.size - 1)
+    // Auto-scroll to bottom only when a genuinely new message arrives
+    // and the user is already near the bottom of the list.
+    var lastMessageId by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(messages.lastOrNull()?.id) {
+        val newLastId = messages.lastOrNull()?.id
+        if (newLastId != null && newLastId != lastMessageId) {
+            lastMessageId = newLastId
+            val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+            if (lastVisible >= messages.size - 4) {
+                listState.animateScrollToItem(messages.size - 1)
+            }
         }
     }
 

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/channel/TextChannelScreen.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/channel/TextChannelScreen.kt
@@ -25,11 +25,11 @@ import androidx.hilt.navigation.compose.hiltViewModel
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TextChannelScreen(
-    channelName: String,
     currentUserId: String,
     onNavigateBack: () -> Unit,
     viewModel: TextChannelViewModel = hiltViewModel()
 ) {
+    val channelName by viewModel.channelName.collectAsState()
     val messages by viewModel.messages.collectAsState()
     val typingUsers by viewModel.typingUsers.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/channel/TextChannelViewModel.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/channel/TextChannelViewModel.kt
@@ -5,10 +5,14 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.wolftown.kaiku.data.repository.ChatRepository
+import io.wolftown.kaiku.data.repository.GuildRepository
 import io.wolftown.kaiku.domain.model.Message
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -18,6 +22,7 @@ import javax.inject.Inject
 @HiltViewModel
 class TextChannelViewModel @Inject constructor(
     private val chatRepository: ChatRepository,
+    private val guildRepository: GuildRepository,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -26,6 +31,10 @@ class TextChannelViewModel @Inject constructor(
     }
 
     private val channelId: String = savedStateHandle["channelId"]!!
+
+    val channelName: StateFlow<String> = guildRepository.channels
+        .map { channels -> channels.find { it.id == channelId }?.name ?: channelId }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), channelId)
 
     val messages: StateFlow<List<Message>> = chatRepository.getMessages(channelId)
     val typingUsers: StateFlow<Set<String>> = chatRepository.getTypingUsers(channelId)

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/home/GuildSidebar.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/home/GuildSidebar.kt
@@ -13,6 +13,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -70,7 +73,11 @@ private fun GuildIcon(
             .size(48.dp)
             .clip(CircleShape)
             .background(backgroundColor)
-            .clickable(onClick = onClick),
+            .semantics { role = Role.Button }
+            .clickable(
+                onClick = onClick,
+                onClickLabel = "Select ${guild.name}"
+            ),
         contentAlignment = Alignment.Center
     ) {
         if (guild.iconUrl != null) {

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/home/HomeViewModel.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/home/HomeViewModel.kt
@@ -47,8 +47,11 @@ class HomeViewModel @Inject constructor(
     private val _error = MutableStateFlow<String?>(null)
     val error: StateFlow<String?> = _error.asStateFlow()
 
-    /** One-shot navigation event for channel selection. */
-    private val _navigateToChannel = Channel<ChannelNavEvent>(Channel.BUFFERED)
+    /**
+     * One-shot navigation event for channel selection.
+     * Bounded capacity (4) prevents buildup if a navigation collector is suspended.
+     */
+    private val _navigateToChannel = Channel<ChannelNavEvent>(capacity = 4)
     val navigateToChannel = _navigateToChannel.receiveAsFlow()
 
     init {

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/home/HomeViewModel.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/home/HomeViewModel.kt
@@ -73,7 +73,10 @@ class HomeViewModel @Inject constructor(
     }
 
     fun onChannelSelected(channelId: String, channelType: ChannelType) {
-        _navigateToChannel.trySend(ChannelNavEvent(channelId, channelType))
+        val result = _navigateToChannel.trySend(ChannelNavEvent(channelId, channelType))
+        if (result.isFailure) {
+            logger.warning("navigateToChannel dropped (collector suspended or buffer full): $channelId")
+        }
     }
 
     fun refresh() {

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/home/HomeViewModel.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/home/HomeViewModel.kt
@@ -10,6 +10,7 @@ import io.wolftown.kaiku.domain.model.Channel
 import io.wolftown.kaiku.domain.model.ChannelType
 import io.wolftown.kaiku.domain.model.Guild
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import java.util.logging.Logger
@@ -47,8 +48,8 @@ class HomeViewModel @Inject constructor(
     val error: StateFlow<String?> = _error.asStateFlow()
 
     /** One-shot navigation event for channel selection. */
-    private val _navigateToChannel = MutableSharedFlow<ChannelNavEvent>(extraBufferCapacity = 1)
-    val navigateToChannel: SharedFlow<ChannelNavEvent> = _navigateToChannel.asSharedFlow()
+    private val _navigateToChannel = Channel<ChannelNavEvent>(Channel.BUFFERED)
+    val navigateToChannel = _navigateToChannel.receiveAsFlow()
 
     init {
         connectWebSocket()
@@ -69,7 +70,7 @@ class HomeViewModel @Inject constructor(
     }
 
     fun onChannelSelected(channelId: String, channelType: ChannelType) {
-        _navigateToChannel.tryEmit(ChannelNavEvent(channelId, channelType))
+        _navigateToChannel.trySend(ChannelNavEvent(channelId, channelType))
     }
 
     fun refresh() {

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/settings/SettingsScreen.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/settings/SettingsScreen.kt
@@ -25,6 +25,10 @@ fun SettingsScreen(
 
     var showLogoutDialog by remember { mutableStateOf(false) }
 
+    LaunchedEffect(Unit) {
+        viewModel.logoutComplete.collect { onLogout() }
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -126,7 +130,7 @@ fun SettingsScreen(
                 TextButton(
                     onClick = {
                         showLogoutDialog = false
-                        viewModel.logout { onLogout() }
+                        viewModel.logout()
                     }
                 ) {
                     Text("Log out", color = MaterialTheme.colorScheme.error)

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/settings/SettingsViewModel.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/settings/SettingsViewModel.kt
@@ -6,9 +6,11 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import io.wolftown.kaiku.data.local.TokenStorage
 import io.wolftown.kaiku.data.repository.AuthRepository
 import io.wolftown.kaiku.domain.model.User
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import java.util.logging.Level
 import java.util.logging.Logger
@@ -62,7 +64,10 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
-    fun logout(onLogoutComplete: () -> Unit) {
+    private val _logoutComplete = Channel<Unit>(Channel.CONFLATED)
+    val logoutComplete = _logoutComplete.receiveAsFlow()
+
+    fun logout() {
         viewModelScope.launch {
             try {
                 authRepository.logout()
@@ -71,7 +76,7 @@ class SettingsViewModel @Inject constructor(
             } catch (e: Exception) {
                 logger.log(Level.WARNING, "Logout failed", e)
             }
-            onLogoutComplete()
+            _logoutComplete.send(Unit)
         }
     }
 }

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/voice/VoiceChannelScreen.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/voice/VoiceChannelScreen.kt
@@ -40,10 +40,10 @@ import org.webrtc.VideoTrack
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun VoiceChannelScreen(
-    channelName: String,
     onNavigateBack: () -> Unit,
     viewModel: VoiceViewModel = hiltViewModel()
 ) {
+    val channelName by viewModel.channelName.collectAsState()
     val participants by viewModel.participants.collectAsState()
     val isMuted by viewModel.isMuted.collectAsState()
     val isConnected by viewModel.isConnected.collectAsState()

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/voice/VoiceViewModel.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/voice/VoiceViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.wolftown.kaiku.data.repository.GuildRepository
 import io.wolftown.kaiku.data.repository.VoiceRepository
 import io.wolftown.kaiku.data.voice.AudioRoute
 import io.wolftown.kaiku.data.voice.AudioRouteManager
@@ -12,8 +13,11 @@ import io.wolftown.kaiku.data.ws.ScreenShareInfo
 import io.wolftown.kaiku.data.ws.VoiceParticipant
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import org.webrtc.EglBase
 import org.webrtc.VideoTrack
 import kotlinx.coroutines.launch
@@ -32,6 +36,7 @@ import javax.inject.Inject
 @HiltViewModel
 class VoiceViewModel @Inject constructor(
     private val voiceRepository: VoiceRepository,
+    private val guildRepository: GuildRepository,
     private val audioRouteManager: AudioRouteManager,
     private val webRtcManager: WebRtcManager,
     savedStateHandle: SavedStateHandle
@@ -42,6 +47,10 @@ class VoiceViewModel @Inject constructor(
     }
 
     private val channelId: String = savedStateHandle["channelId"]!!
+
+    val channelName: StateFlow<String> = guildRepository.channels
+        .map { channels -> channels.find { it.id == channelId }?.name ?: channelId }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), channelId)
 
     val participants: StateFlow<List<VoiceParticipant>> = voiceRepository.participants
     val isMuted: StateFlow<Boolean> = voiceRepository.isMuted


### PR DESCRIPTION
## Summary
- **Channel names**: Resolve channel names from `GuildRepository` instead of displaying raw UUIDs in text and voice channel headers.
- **Navigation events**: Replace `SharedFlow(extraBufferCapacity=1)` with `Channel(BUFFERED)` to prevent silent event drops on rapid taps.
- **Auto-scroll guard**: Only auto-scroll to bottom when a new message arrives AND the user is within 3 items of the bottom. Pagination prepend no longer snaps back.
- **AuthState scope**: Replace anonymous `CoroutineScope` instances with a named, cancellable scope for clean test teardown.
- **GuildIcon accessibility**: Add `Role.Button` semantics and `onClickLabel` for TalkBack.
- **formatTimestamp**: Wrap in `remember(message.createdAt)` to avoid recomputation on every recomposition.
- **Logout lifecycle**: Replace UI callback parameter with `Channel` event to prevent stale closure on configuration change.

Addresses issues #7, #8, #9, #20, #24, #25, #26 from the mobile implementation review.

## Test plan
- [ ] Android: `./gradlew test` passes
- [ ] Channel names display correctly (not UUIDs)
- [ ] Scrolling up to read history is not interrupted by new messages
- [ ] Rapid channel switching navigates correctly
- [ ] Logout works from settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)