### PR TITLE
feat(client): web responsive overhaul with mobile drawer navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All `text-text-secondary/50` instances replaced with `text-text-muted` for WCAG-compliant contrast (#29)
 - Auth pages (login, register, forgot/reset password) now scroll when content exceeds viewport height (#30)
 - Context menu items have larger touch targets for reliable mobile interaction (#28)
+- Long-press on touch devices no longer shows duplicate context menus (custom menu plus browser native)
+- Mobile drawer no longer traps keyboard focus or screen reader navigation when closed
+- Body scroll lock no longer interferes with overlapping modals
 - Admin dashboard status badges, elevation buttons, and warning banners now have readable text instead of invisible same-hue text on colored backgrounds (#524)
 - Clicking another user's reaction emoji now correctly toggles your own reaction instead of removing theirs (#454)
 - Sent friend requests now show "Cancel" button instead of Accept/Decline buttons in the pending view (#453)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Milestone: Phase 6 - Competitive Differentiators & Mastery
 - Release note structure source: `docs/project/RELEASE_NOTES_TEMPLATE.md`
 
+### Added
+- Responsive mobile layout: sidebar and server rail collapse into a slide-out drawer below 768px viewport width
+- Mobile header bar with hamburger menu, guild name, and channel name
+- Swipe gestures: right from edge to open drawer, left to close
+- Long-press context menu support for touch devices on messages, channels, and member lists
+- `touch:` UnoCSS variant for touch-specific styling via `@media (hover: none)`
+
 ### Changed
 - Voice connections use dual PeerConnection architecture (publisher + subscriber) for reliable screen sharing and multi-user scalability
 - Screen sharing uses standard WebRTC `addTrack` negotiation instead of `replaceTrack` workarounds
@@ -52,6 +59,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Android: rapid channel taps no longer silently drop navigation events (#8)
 - Android: scrolling up to read history no longer snaps back to the bottom when new messages arrive (#9)
 - Android: guild icons are properly announced as interactive buttons by screen readers (#24)
+- Guild settings modal no longer overflows the viewport at 800px window width (#11)
+- Emoji delete button is now visible on touch devices instead of requiring hover (#31)
+- All `text-text-secondary/50` instances replaced with `text-text-muted` for WCAG-compliant contrast (#29)
+- Auth pages (login, register, forgot/reset password) now scroll when content exceeds viewport height (#30)
+- Context menu items have larger touch targets for reliable mobile interaction (#28)
 - Admin dashboard status badges, elevation buttons, and warning banners now have readable text instead of invisible same-hue text on colored backgrounds (#524)
 - Clicking another user's reaction emoji now correctly toggles your own reaction instead of removing theirs (#454)
 - Sent friend requests now show "Cancel" button instead of Accept/Decline buttons in the pending view (#453)

--- a/client/src/components/admin/AuditLogPanel.tsx
+++ b/client/src/components/admin/AuditLogPanel.tsx
@@ -376,10 +376,10 @@ const AuditLogPanel: Component = () => {
                     <div class="flex items-center text-sm text-text-secondary truncate">
                       <Show
                         when={entry.target_type && entry.target_id}
-                        fallback={<span class="text-text-secondary/50">-</span>}
+                        fallback={<span class="text-text-muted">-</span>}
                       >
                         <span class="capitalize">{entry.target_type}</span>
-                        <span class="mx-1 text-text-secondary/50">/</span>
+                        <span class="mx-1 text-text-muted">/</span>
                         <span class="font-mono">
                           {truncateId(entry.target_id!)}
                         </span>

--- a/client/src/components/admin/CommandCenterPanel.tsx
+++ b/client/src/components/admin/CommandCenterPanel.tsx
@@ -777,7 +777,7 @@ const CommandCenterPanel: Component = () => {
                 placeholder="Domain..."
                 value={logsDomain()}
                 onInput={(e) => handleLogsDomainChange(e.currentTarget.value)}
-                class="w-24 px-2 py-1 text-xs rounded-md bg-white/5 border border-white/10 text-text-primary placeholder:text-text-secondary/50"
+                class="w-24 px-2 py-1 text-xs rounded-md bg-white/5 border border-white/10 text-text-primary placeholder:text-text-muted"
               />
               <div class="relative">
                 <Search class="absolute left-2 top-1/2 -translate-y-1/2 w-3 h-3 text-text-secondary" />
@@ -788,7 +788,7 @@ const CommandCenterPanel: Component = () => {
                   onInput={(e) =>
                     handleLogsSearchChange(e.currentTarget.value)
                   }
-                  class="w-40 pl-6 pr-2 py-1 text-xs rounded-md bg-white/5 border border-white/10 text-text-primary placeholder:text-text-secondary/50"
+                  class="w-40 pl-6 pr-2 py-1 text-xs rounded-md bg-white/5 border border-white/10 text-text-primary placeholder:text-text-muted"
                 />
               </div>
             </div>
@@ -875,7 +875,7 @@ const CommandCenterPanel: Component = () => {
                 onInput={(e) =>
                   handleTracesDomainChange(e.currentTarget.value)
                 }
-                class="w-24 px-2 py-1 text-xs rounded-md bg-white/5 border border-white/10 text-text-primary placeholder:text-text-secondary/50"
+                class="w-24 px-2 py-1 text-xs rounded-md bg-white/5 border border-white/10 text-text-primary placeholder:text-text-muted"
               />
             </div>
           </div>

--- a/client/src/components/admin/ReportsPanel.tsx
+++ b/client/src/components/admin/ReportsPanel.tsx
@@ -312,7 +312,7 @@ const ReportsPanel: Component = () => {
                           {report.target_type}
                         </span>
                         <br />
-                        <span class="text-xs text-text-secondary/50 font-mono">
+                        <span class="text-xs text-text-muted font-mono">
                           {report.target_user_id.slice(0, 8)}...
                         </span>
                       </td>

--- a/client/src/components/channels/ChannelItem.tsx
+++ b/client/src/components/channels/ChannelItem.tsx
@@ -29,8 +29,10 @@ import { markChannelAsRead, isChannelUnread } from "@/stores/channels";
 import { isFavorited, toggleFavorite } from "@/stores/favorites";
 import {
   showContextMenu,
+  showContextMenuAt,
   type ContextMenuEntry,
 } from "@/components/ui/ContextMenu";
+import { createLongPress } from "@/lib/createLongPress";
 
 interface ChannelItemProps {
   channel: ChannelWithUnread;
@@ -82,7 +84,7 @@ const ChannelItem: Component<ChannelItemProps> = (props) => {
     return localSpeaking || remoteSpeaking;
   });
 
-  const handleContextMenu = (e: MouseEvent) => {
+  const buildContextMenuItems = (): ContextMenuEntry[] => {
     const ch = props.channel;
     const muted = isChannelMuted(ch.id);
     const favorited = props.guildId ? isFavorited(ch.id) : false;
@@ -147,11 +149,26 @@ const ChannelItem: Component<ChannelItemProps> = (props) => {
       action: () => navigator.clipboard.writeText(ch.id),
     });
 
-    showContextMenu(e, items);
+    return items;
   };
 
+  const handleContextMenu = (e: MouseEvent) => {
+    showContextMenu(e, buildContextMenuItems());
+  };
+
+  const longPress = createLongPress((x, y) => {
+    showContextMenuAt(x, y, buildContextMenuItems());
+  });
+
   return (
-    <div class="relative group" onContextMenu={handleContextMenu}>
+    <div
+      class="relative group"
+      onContextMenu={handleContextMenu}
+      onPointerDown={longPress.onPointerDown}
+      onPointerUp={longPress.onPointerUp}
+      onPointerCancel={longPress.onPointerCancel}
+      onPointerMove={longPress.onPointerMove}
+    >
       <button
         type="button"
         data-testid="channel-item"

--- a/client/src/components/channels/ChannelItem.tsx
+++ b/client/src/components/channels/ChannelItem.tsx
@@ -152,13 +152,16 @@ const ChannelItem: Component<ChannelItemProps> = (props) => {
     return items;
   };
 
-  const handleContextMenu = (e: MouseEvent) => {
-    showContextMenu(e, buildContextMenuItems());
-  };
-
   const longPress = createLongPress((x, y) => {
     showContextMenuAt(x, y, buildContextMenuItems());
   });
+
+  const handleContextMenu = (e: MouseEvent) => {
+    longPress.onContextMenu(e);
+    if (!e.defaultPrevented) {
+      showContextMenu(e, buildContextMenuItems());
+    }
+  };
 
   return (
     <div

--- a/client/src/components/channels/ChannelList.tsx
+++ b/client/src/components/channels/ChannelList.tsx
@@ -63,7 +63,12 @@ import {
   type DraggableType,
 } from "./ChannelDragContext";
 
-const ChannelList: Component = () => {
+interface ChannelListProps {
+  /** Called after a navigation action (e.g. channel selected). Used to close the mobile drawer. */
+  onNavigate?: () => void;
+}
+
+const ChannelList: Component<ChannelListProps> = (props) => {
   const [showMicTest, setShowMicTest] = createSignal(false);
   const [showCreateModal, setShowCreateModal] = createSignal(false);
   const [createModalType, setCreateModalType] = createSignal<"text" | "voice">(
@@ -419,7 +424,7 @@ const ChannelList: Component = () => {
                 onClick={
                   isVoice
                     ? () => handleVoiceChannelClick(channel.id)
-                    : () => selectChannel(channel.id)
+                    : () => { selectChannel(channel.id); props.onNavigate?.(); }
                 }
                 onSettings={
                   canManageChannels()

--- a/client/src/components/guilds/EmojisTab.tsx
+++ b/client/src/components/guilds/EmojisTab.tsx
@@ -158,7 +158,7 @@ const EmojisTab: Component<EmojisTabProps> = (props) => {
               <Show when={canManageEmojis()}>
                 <button
                   onClick={() => handleDelete(emoji.id)}
-                  class="absolute top-2 right-2 p-1.5 rounded-lg opacity-0 group-hover:opacity-100 transition-opacity"
+                  class="absolute top-2 right-2 p-1.5 rounded-lg opacity-0 group-hover:opacity-100 touch:opacity-60 transition-opacity"
                   classList={{
                     "bg-accent-danger text-white opacity-100":
                       deleteConfirm() === emoji.id,

--- a/client/src/components/guilds/GuildSettingsModal.tsx
+++ b/client/src/components/guilds/GuildSettingsModal.tsx
@@ -146,7 +146,7 @@ const GuildSettingsModal: Component<GuildSettingsModalProps> = (props) => {
         tabIndex={-1}
       >
         <div
-          class="border border-white/10 rounded-2xl w-[90vw] md:w-[900px] max-w-5xl max-h-[85vh] flex flex-col shadow-2xl"
+          class="border border-white/10 rounded-2xl w-[90vw] max-w-[900px] overflow-x-hidden max-h-[85vh] flex flex-col shadow-2xl"
           style="background-color: var(--color-surface-base)"
         >
           {/* Header */}
@@ -177,7 +177,7 @@ const GuildSettingsModal: Component<GuildSettingsModalProps> = (props) => {
             </div>
             <button
               onClick={props.onClose}
-              class="p-1.5 text-text-secondary hover:text-text-primary hover:bg-white/10 rounded-lg transition-colors"
+              class="p-2.5 text-text-secondary hover:text-text-primary hover:bg-white/10 rounded-lg transition-colors"
             >
               <X class="w-5 h-5" />
             </button>

--- a/client/src/components/guilds/MembersTab.tsx
+++ b/client/src/components/guilds/MembersTab.tsx
@@ -210,13 +210,16 @@ const MembersTab: Component<MembersTabProps> = (props) => {
                           <div
                             data-testid={`members-tab-row-${m().username}`}
                             class="flex items-center gap-3 p-3 rounded-lg hover:bg-white/5 transition-colors group"
-                            onContextMenu={(e) =>
-                              showUserContextMenu(e, {
-                                id: m().user_id,
-                                username: m().username,
-                                display_name: m().display_name,
-                              })
-                            }
+                            onContextMenu={(e) => {
+                              memberLongPress.onContextMenu(e);
+                              if (!e.defaultPrevented) {
+                                showUserContextMenu(e, {
+                                  id: m().user_id,
+                                  username: m().username,
+                                  display_name: m().display_name,
+                                });
+                              }
+                            }}
                             onPointerDown={memberLongPress.onPointerDown}
                             onPointerUp={memberLongPress.onPointerUp}
                             onPointerCancel={memberLongPress.onPointerCancel}

--- a/client/src/components/guilds/MembersTab.tsx
+++ b/client/src/components/guilds/MembersTab.tsx
@@ -30,7 +30,11 @@ import { authState } from "@/stores/auth";
 import MemberRoleDropdown from "./MemberRoleDropdown";
 import { ActivityIndicator } from "../ui";
 import type { GuildMember } from "@/lib/types";
-import { showUserContextMenu } from "@/lib/contextMenuBuilders";
+import {
+  showUserContextMenu,
+  showUserContextMenuAt,
+} from "@/lib/contextMenuBuilders";
+import { createLongPress } from "@/lib/createLongPress";
 
 interface MembersTabProps {
   guildId: string;
@@ -194,6 +198,14 @@ const MembersTab: Component<MembersTabProps> = (props) => {
                         const memberRoles = () =>
                           getMemberRoles(props.guildId, m().user_id);
 
+                        const memberLongPress = createLongPress((x, y) => {
+                          showUserContextMenuAt(x, y, {
+                            id: m().user_id,
+                            username: m().username,
+                            display_name: m().display_name,
+                          });
+                        });
+
                         return (
                           <div
                             data-testid={`members-tab-row-${m().username}`}
@@ -205,6 +217,10 @@ const MembersTab: Component<MembersTabProps> = (props) => {
                                 display_name: m().display_name,
                               })
                             }
+                            onPointerDown={memberLongPress.onPointerDown}
+                            onPointerUp={memberLongPress.onPointerUp}
+                            onPointerCancel={memberLongPress.onPointerCancel}
+                            onPointerMove={memberLongPress.onPointerMove}
                           >
                             {/* Avatar with status indicator */}
                             <div class="relative flex-shrink-0">

--- a/client/src/components/home/HomeSidebar.tsx
+++ b/client/src/components/home/HomeSidebar.tsx
@@ -52,7 +52,7 @@ const HomeSidebar: Component = () => {
       <div class="px-3 py-2 mt-2">
         <button
           onClick={() => setShowDMSearch(true)}
-          class="w-full px-3 py-2 rounded-xl text-sm text-text-secondary/50 text-left outline-none border border-white/5"
+          class="w-full px-3 py-2 rounded-xl text-sm text-text-muted text-left outline-none border border-white/5"
           style="background-color: var(--color-surface-base)"
         >
           Find conversation...

--- a/client/src/components/layout/AppShell.tsx
+++ b/client/src/components/layout/AppShell.tsx
@@ -62,6 +62,9 @@ const AppShell: Component<AppShellProps> = (props) => {
       setDrawerOpen(true);
     edgeStartX = null;
   };
+  const onEdgeReset = () => {
+    edgeStartX = null;
+  };
 
   /** Sidebar content — shared between desktop inline and mobile drawer */
   const sidebarContent = (onNavigate?: () => void) => (
@@ -76,6 +79,7 @@ const AppShell: Component<AppShellProps> = (props) => {
       classList={{ "flex-col": isMobile() }}
       onPointerDown={onEdgePointerDown}
       onPointerUp={onEdgePointerUp}
+      onPointerCancel={onEdgeReset}
     >
       <Show
         when={!isMobile()}

--- a/client/src/components/layout/AppShell.tsx
+++ b/client/src/components/layout/AppShell.tsx
@@ -5,15 +5,31 @@
  * Implements "The Focused Hybrid" design philosophy:
  * Discord structure + Linear/Arc efficiency.
  *
- * Layout Structure:
+ * Layout Structure (Desktop):
  * 1. Server Rail (72px) - Leftmost vertical bar for server/guild navigation
  * 2. Context Sidebar (240px) - Channel list and user panel
  * 3. Main Stage (flex-1) - Chat messages and content
+ *
+ * Layout Structure (Mobile):
+ * 1. MobileHeader (44px) - Top bar with hamburger menu + guild/channel name
+ * 2. Main Stage (flex-1) - Chat messages and content
+ * 3. MobileDrawer (overlay) - Server Rail (compact) + Sidebar, slides from left
  */
 
-import { Component, JSX, ParentProps, Show, lazy, Suspense } from "solid-js";
+import {
+  Component,
+  JSX,
+  ParentProps,
+  Show,
+  lazy,
+  Suspense,
+  createSignal,
+} from "solid-js";
+import { useIsMobile } from "@/lib/useBreakpoint";
 import ServerRail from "./ServerRail";
 import Sidebar from "./Sidebar";
+import MobileDrawer from "./MobileDrawer";
+import MobileHeader from "./MobileHeader";
 import { LazyErrorBoundary } from "@/components/ui/LazyFallback";
 
 const ScreenShareViewer = lazy(
@@ -31,22 +47,61 @@ interface AppShellProps extends ParentProps {
 
 const AppShell: Component<AppShellProps> = (props) => {
   const showServerRail = () => props.showServerRail ?? false;
+  const isMobile = useIsMobile();
+  const [drawerOpen, setDrawerOpen] = createSignal(false);
+
+  const closeDrawer = () => setDrawerOpen(false);
+
+  // Swipe-right-to-open on the content area's left edge
+  let edgeStartX: number | null = null;
+  const onEdgePointerDown = (e: PointerEvent) => {
+    if (isMobile() && e.clientX < 20) edgeStartX = e.clientX;
+  };
+  const onEdgePointerUp = (e: PointerEvent) => {
+    if (edgeStartX !== null && e.clientX - edgeStartX > 50)
+      setDrawerOpen(true);
+    edgeStartX = null;
+  };
+
+  /** Sidebar content — shared between desktop inline and mobile drawer */
+  const sidebarContent = (onNavigate?: () => void) => (
+    <Show when={props.sidebar} fallback={<Sidebar onNavigate={onNavigate} />}>
+      {props.sidebar}
+    </Show>
+  );
 
   return (
-    <div class="flex h-screen w-full bg-surface-base overflow-hidden selection:bg-accent-primary/30">
-      {/* 1. Server Rail (Leftmost) */}
-      <Show when={showServerRail()}>
-        <ServerRail />
+    <div
+      class="flex h-screen w-full bg-surface-base overflow-hidden selection:bg-accent-primary/30"
+      classList={{ "flex-col": isMobile() }}
+      onPointerDown={onEdgePointerDown}
+      onPointerUp={onEdgePointerUp}
+    >
+      <Show
+        when={!isMobile()}
+        fallback={
+          <>
+            {/* Mobile: Drawer + Header */}
+            <MobileDrawer open={drawerOpen()} onClose={closeDrawer}>
+              <Show when={showServerRail()}>
+                <ServerRail compact />
+              </Show>
+              {sidebarContent(closeDrawer)}
+            </MobileDrawer>
+
+            <MobileHeader onMenuClick={() => setDrawerOpen(true)} />
+          </>
+        }
+      >
+        {/* Desktop: Inline Server Rail + Sidebar */}
+        <Show when={showServerRail()}>
+          <ServerRail />
+        </Show>
+        {sidebarContent()}
       </Show>
 
-      {/* 2. Context Sidebar (Middle-Left) */}
-      <Show when={props.sidebar} fallback={<Sidebar />}>
-        {props.sidebar}
-      </Show>
-
-      {/* 3. Main Stage (Right) */}
+      {/* Main Stage */}
       <main class="flex-1 flex flex-col min-w-0 bg-surface-layer1 relative border-l border-border-solid">
-        {/* Main content passed as children */}
         {props.children}
       </main>
 

--- a/client/src/components/layout/AppShell.tsx
+++ b/client/src/components/layout/AppShell.tsx
@@ -80,6 +80,7 @@ const AppShell: Component<AppShellProps> = (props) => {
       onPointerDown={onEdgePointerDown}
       onPointerUp={onEdgePointerUp}
       onPointerCancel={onEdgeReset}
+      onPointerLeave={onEdgeReset}
     >
       <Show
         when={!isMobile()}

--- a/client/src/components/layout/MobileDrawer.tsx
+++ b/client/src/components/layout/MobileDrawer.tsx
@@ -16,6 +16,7 @@ interface MobileDrawerProps {
 
 const MobileDrawer: Component<MobileDrawerProps> = (props) => {
   let startX = 0;
+  let savedOverflow: string | null = null;
 
   // Swipe-left to close
   const onPointerDown = (e: PointerEvent) => {
@@ -25,18 +26,32 @@ const MobileDrawer: Component<MobileDrawerProps> = (props) => {
     if (startX - e.clientX > 50) props.onClose();
   };
 
-  // Prevent body scroll when drawer is open
+  // Prevent body scroll when drawer is open; save/restore prior overflow
   createEffect(() => {
-    document.body.style.overflow = props.open ? "hidden" : "";
+    if (props.open && savedOverflow === null) {
+      // Closed → open: snapshot the prior value once
+      savedOverflow = document.body.style.overflow;
+      document.body.style.overflow = "hidden";
+    } else if (!props.open && savedOverflow !== null) {
+      // Open → closed: restore and clear the snapshot
+      document.body.style.overflow = savedOverflow;
+      savedOverflow = null;
+    }
   });
+
   onCleanup(() => {
-    document.body.style.overflow = "";
+    // Component disposed mid-lock: restore so we don't leave the page locked
+    if (savedOverflow !== null) {
+      document.body.style.overflow = savedOverflow;
+      savedOverflow = null;
+    }
   });
 
   return (
     <div
       class="fixed inset-0 z-50"
       classList={{ "pointer-events-none": !props.open }}
+      inert={!props.open ? true : undefined}
     >
       {/* Backdrop */}
       <div

--- a/client/src/components/layout/MobileDrawer.tsx
+++ b/client/src/components/layout/MobileDrawer.tsx
@@ -1,0 +1,67 @@
+/**
+ * MobileDrawer - Slide-out Navigation Drawer
+ *
+ * A left-edge drawer containing the server rail and sidebar for mobile viewports.
+ * Supports swipe-left-to-close and backdrop click dismissal.
+ * Prevents body scroll while open.
+ */
+
+import { Component, JSX, createEffect, onCleanup } from "solid-js";
+
+interface MobileDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  children: JSX.Element;
+}
+
+const MobileDrawer: Component<MobileDrawerProps> = (props) => {
+  let startX = 0;
+
+  // Swipe-left to close
+  const onPointerDown = (e: PointerEvent) => {
+    startX = e.clientX;
+  };
+  const onPointerUp = (e: PointerEvent) => {
+    if (startX - e.clientX > 50) props.onClose();
+  };
+
+  // Prevent body scroll when drawer is open
+  createEffect(() => {
+    document.body.style.overflow = props.open ? "hidden" : "";
+  });
+  onCleanup(() => {
+    document.body.style.overflow = "";
+  });
+
+  return (
+    <div
+      class="fixed inset-0 z-50"
+      classList={{ "pointer-events-none": !props.open }}
+    >
+      {/* Backdrop */}
+      <div
+        class="absolute inset-0 bg-black/50 transition-opacity duration-200"
+        classList={{
+          "opacity-100": props.open,
+          "opacity-0 pointer-events-none": !props.open,
+        }}
+        onClick={() => props.onClose()}
+      />
+
+      {/* Drawer panel */}
+      <div
+        class="absolute top-0 left-0 h-full w-[300px] flex transition-transform duration-200 bg-surface-base"
+        classList={{
+          "translate-x-0": props.open,
+          "-translate-x-full": !props.open,
+        }}
+        onPointerDown={onPointerDown}
+        onPointerUp={onPointerUp}
+      >
+        {props.children}
+      </div>
+    </div>
+  );
+};
+
+export default MobileDrawer;

--- a/client/src/components/layout/MobileHeader.tsx
+++ b/client/src/components/layout/MobileHeader.tsx
@@ -1,0 +1,53 @@
+/**
+ * MobileHeader - Top Navigation Bar for Mobile
+ *
+ * Displays a hamburger menu button to open the navigation drawer,
+ * plus the current guild and channel names for orientation.
+ * Only rendered on mobile viewports.
+ */
+
+import { Component, Show } from "solid-js";
+import { Menu } from "lucide-solid";
+import { getActiveGuild } from "@/stores/guilds";
+import { selectedChannel } from "@/stores/channels";
+
+interface MobileHeaderProps {
+  onMenuClick: () => void;
+}
+
+const MobileHeader: Component<MobileHeaderProps> = (props) => {
+  const activeGuild = () => getActiveGuild();
+  const channel = () => selectedChannel();
+
+  return (
+    <header class="h-[44px] flex items-center px-3 gap-3 bg-surface-layer1 border-b border-border-default shrink-0">
+      <button
+        class="p-2 rounded-lg hover:bg-white/10 transition-colors"
+        onClick={props.onMenuClick}
+        aria-label="Open navigation"
+      >
+        <Menu class="w-5 h-5 text-text-primary" />
+      </button>
+      <div class="flex-1 min-w-0 flex items-center gap-2 text-sm">
+        <Show when={activeGuild()}>
+          <span class="text-text-secondary truncate">
+            {activeGuild()!.name}
+          </span>
+        </Show>
+        <Show when={activeGuild() && channel()}>
+          <span class="text-text-muted">/</span>
+        </Show>
+        <Show when={channel()}>
+          <span class="text-text-primary font-medium truncate">
+            {channel()!.name}
+          </span>
+        </Show>
+        <Show when={!activeGuild() && !channel()}>
+          <span class="text-text-primary font-medium">Kaiku</span>
+        </Show>
+      </div>
+    </header>
+  );
+};
+
+export default MobileHeader;

--- a/client/src/components/layout/ServerRail.tsx
+++ b/client/src/components/layout/ServerRail.tsx
@@ -32,7 +32,11 @@ const CreateGuildModal = lazy(
 );
 const JoinGuildModal = lazy(() => import("@/components/guilds/JoinGuildModal"));
 
-const ServerRail: Component = () => {
+interface ServerRailProps {
+  compact?: boolean;
+}
+
+const ServerRail: Component<ServerRailProps> = (props) => {
   // Hover state (still local to component)
   const [hoveredServerId, setHoveredServerId] = createSignal<string | null>(
     null,
@@ -62,10 +66,19 @@ const ServerRail: Component = () => {
     return isActive(id) ? "40px" : "8px";
   };
 
+  /** Icon button size classes based on compact prop */
+  const iconSize = () => (props.compact ? "w-9 h-9" : "w-12 h-12");
+
+  /** Separator width based on compact prop */
+  const separatorClass = () =>
+    props.compact
+      ? "w-6 h-0.5 bg-white/10 rounded-full my-1"
+      : "w-8 h-0.5 bg-white/10 rounded-full my-1";
+
   return (
     <nav
       aria-label="Servers"
-      class="w-[72px] flex flex-col items-center py-3 gap-2 bg-surface-base border-r border-border-solid z-20"
+      class={`${props.compact ? 'w-[56px]' : 'w-[72px]'} flex flex-col items-center py-3 gap-2 bg-surface-base border-r border-border-solid z-20`}
       data-testid="server-rail"
     >
       {/* Home Icon - Kaiku Logo */}
@@ -78,7 +91,7 @@ const ServerRail: Component = () => {
 
         {/* Icon Container */}
         <button
-          class="w-12 h-12 flex items-center justify-center bg-surface-layer2 transition-all duration-200 cursor-pointer"
+          class={`${iconSize()} flex items-center justify-center bg-surface-layer2 transition-all duration-200 cursor-pointer`}
           data-testid="home-button"
           style={{
             "border-radius": getBorderRadius("home"),
@@ -95,7 +108,7 @@ const ServerRail: Component = () => {
       </div>
 
       {/* Separator */}
-      <div class="w-8 h-0.5 bg-white/10 rounded-full my-1" />
+      <div class={separatorClass()} />
 
       {/* Server Icons - Scrollable List */}
       <div class="flex-1 flex flex-col items-center gap-2 overflow-y-auto scrollbar-none">
@@ -119,7 +132,7 @@ const ServerRail: Component = () => {
 
                 {/* Server Icon */}
                 <button
-                  class="w-12 h-12 flex items-center justify-center bg-surface-layer2 transition-all duration-200 cursor-pointer overflow-hidden"
+                  class={`${iconSize()} flex items-center justify-center bg-surface-layer2 transition-all duration-200 cursor-pointer overflow-hidden`}
                   data-testid="guild-button"
                   style={{
                     "border-radius": getBorderRadius(guild.id),
@@ -161,7 +174,7 @@ const ServerRail: Component = () => {
         {/* Guild load error */}
         <Show when={guildsState.error}>
           <button
-            class="w-12 h-12 flex items-center justify-center bg-error-bg/20 rounded-full cursor-pointer text-error-text hover:bg-error-bg/30 transition-colors"
+            class={`${iconSize()} flex items-center justify-center bg-error-bg/20 rounded-full cursor-pointer text-error-text hover:bg-error-bg/30 transition-colors`}
             title={`Failed to load servers: ${guildsState.error}. Click to retry.`}
             onClick={() => loadGuilds()}
           >
@@ -171,7 +184,7 @@ const ServerRail: Component = () => {
       </div>
 
       {/* Separator before action buttons */}
-      <div class="w-8 h-0.5 bg-white/10 rounded-full my-1" />
+      <div class={separatorClass()} />
 
       {/* Explore / Discover Servers Button */}
       <div class="relative">
@@ -183,7 +196,7 @@ const ServerRail: Component = () => {
           />
         </Show>
         <button
-          class="w-12 h-12 flex items-center justify-center bg-surface-layer2 hover:bg-accent-primary/20 transition-all duration-200 cursor-pointer group"
+          class={`${iconSize()} flex items-center justify-center bg-surface-layer2 hover:bg-accent-primary/20 transition-all duration-200 cursor-pointer group`}
           style={{
             "border-radius":
               isDiscoveryActive() || isHovered("discover") ? "16px" : "50%",
@@ -202,7 +215,7 @@ const ServerRail: Component = () => {
       {/* Add Server Button */}
       <div class="relative">
         <button
-          class="w-12 h-12 flex items-center justify-center bg-surface-layer2 hover:bg-accent-primary/20 transition-all duration-200 cursor-pointer group"
+          class={`${iconSize()} flex items-center justify-center bg-surface-layer2 hover:bg-accent-primary/20 transition-all duration-200 cursor-pointer group`}
           data-testid="create-server-button"
           style={{
             "border-radius": isHovered("add") ? "16px" : "50%",
@@ -220,7 +233,7 @@ const ServerRail: Component = () => {
       {/* Join Server Button */}
       <div class="relative">
         <button
-          class="w-12 h-12 flex items-center justify-center bg-surface-layer2 hover:bg-accent-primary/20 transition-all duration-200 cursor-pointer group"
+          class={`${iconSize()} flex items-center justify-center bg-surface-layer2 hover:bg-accent-primary/20 transition-all duration-200 cursor-pointer group`}
           style={{
             "border-radius": isHovered("join") ? "16px" : "50%",
             opacity: isHovered("join") ? 1 : 0.8,

--- a/client/src/components/layout/Sidebar.tsx
+++ b/client/src/components/layout/Sidebar.tsx
@@ -41,7 +41,12 @@ const GuildSettingsModal = lazy(
   () => import("@/components/guilds/GuildSettingsModal"),
 );
 
-const Sidebar: Component = () => {
+interface SidebarProps {
+  /** Called after a navigation action (e.g. channel selected). Used by AppShell to close the mobile drawer. */
+  onNavigate?: () => void;
+}
+
+const Sidebar: Component<SidebarProps> = (props) => {
   const navigate = useNavigate();
   const [showGuildSettings, setShowGuildSettings] = createSignal(false);
   const [selectedPageId, setSelectedPageId] = createSignal<string | null>(null);
@@ -87,6 +92,7 @@ const Sidebar: Component = () => {
     const guild = activeGuild();
     if (guild) {
       navigate(`/guilds/${guild.id}/pages/${page.slug}`);
+      props.onNavigate?.();
     }
   };
 
@@ -167,7 +173,7 @@ const Sidebar: Component = () => {
       </Show>
 
       {/* Channel List */}
-      <ChannelList />
+      <ChannelList onNavigate={props.onNavigate} />
 
       {/* Voice Panel (Bottom, above User Panel) */}
       <VoicePanel />

--- a/client/src/components/layout/Sidebar.tsx
+++ b/client/src/components/layout/Sidebar.tsx
@@ -118,7 +118,7 @@ const Sidebar: Component = () => {
         <Show when={activeGuild()}>
           <button
             onClick={() => setShowSearch(true)}
-            class="w-full flex items-center gap-2 px-3 py-2 rounded-xl text-sm text-text-secondary/50 border border-white/5 hover:border-white/10 transition-colors"
+            class="w-full flex items-center gap-2 px-3 py-2 rounded-xl text-sm text-text-muted border border-white/5 hover:border-white/10 transition-colors"
             style="background-color: var(--color-surface-base)"
           >
             <Search class="w-4 h-4" />
@@ -127,7 +127,7 @@ const Sidebar: Component = () => {
         </Show>
         <Show when={!activeGuild()}>
           <div
-            class="w-full px-3 py-2 rounded-xl text-sm text-text-secondary/50 border border-white/5"
+            class="w-full px-3 py-2 rounded-xl text-sm text-text-muted border border-white/5"
             style="background-color: var(--color-surface-base)"
           >
             Search...

--- a/client/src/components/messages/MessageItem.tsx
+++ b/client/src/components/messages/MessageItem.tsx
@@ -578,13 +578,16 @@ const MessageItem: Component<MessageItemProps> = (props) => {
     return items;
   };
 
-  const handleContextMenu = (e: MouseEvent) => {
-    showContextMenu(e, buildContextMenuItems());
-  };
-
   const longPress = createLongPress((x, y) => {
     showContextMenuAt(x, y, buildContextMenuItems());
   });
+
+  const handleContextMenu = (e: MouseEvent) => {
+    longPress.onContextMenu(e);
+    if (!e.defaultPrevented) {
+      showContextMenu(e, buildContextMenuItems());
+    }
+  };
 
   return (
     <Show

--- a/client/src/components/messages/MessageItem.tsx
+++ b/client/src/components/messages/MessageItem.tsx
@@ -41,8 +41,10 @@ import {
 } from "@/lib/tauri";
 import {
   showContextMenu,
+  showContextMenuAt,
   type ContextMenuEntry,
 } from "@/components/ui/ContextMenu";
+import { createLongPress } from "@/lib/createLongPress";
 import { currentUser } from "@/stores/auth";
 import { showUserContextMenu, triggerReport } from "@/lib/contextMenuBuilders";
 import { spoilerExtension } from "@/lib/markdown/spoilerExtension";
@@ -462,7 +464,7 @@ const MessageItem: Component<MessageItemProps> = (props) => {
     }
   });
 
-  const handleContextMenu = (e: MouseEvent) => {
+  const buildContextMenuItems = (): ContextMenuEntry[] => {
     const msg = props.message;
 
     const items: ContextMenuEntry[] = [
@@ -573,8 +575,16 @@ const MessageItem: Component<MessageItemProps> = (props) => {
       );
     }
 
-    showContextMenu(e, items);
+    return items;
   };
+
+  const handleContextMenu = (e: MouseEvent) => {
+    showContextMenu(e, buildContextMenuItems());
+  };
+
+  const longPress = createLongPress((x, y) => {
+    showContextMenuAt(x, y, buildContextMenuItems());
+  });
 
   return (
     <Show
@@ -592,6 +602,10 @@ const MessageItem: Component<MessageItemProps> = (props) => {
     <div
       data-testid="message-item"
       onContextMenu={handleContextMenu}
+      onPointerDown={longPress.onPointerDown}
+      onPointerUp={longPress.onPointerUp}
+      onPointerCancel={longPress.onPointerCancel}
+      onPointerMove={longPress.onPointerMove}
       onMouseEnter={() => {
         reactionShortcutHandler = handleAddReaction;
       }}

--- a/client/src/components/messages/MessageItem.tsx
+++ b/client/src/components/messages/MessageItem.tsx
@@ -624,12 +624,17 @@ const MessageItem: Component<MessageItemProps> = (props) => {
         <Show when={!props.compact}>
           <div
             onContextMenu={(e: MouseEvent) => {
+              // Suppress native context menu if a long-press just fired on the
+              // parent message row — prevents triple-stacking native + message + user menus.
+              longPress.onContextMenu(e);
               e.stopPropagation();
-              showUserContextMenu(e, {
-                id: author().id,
-                username: author().username,
-                display_name: author().display_name,
-              });
+              if (!e.defaultPrevented) {
+                showUserContextMenu(e, {
+                  id: author().id,
+                  username: author().username,
+                  display_name: author().display_name,
+                });
+              }
             }}
           >
             <Avatar
@@ -672,12 +677,16 @@ const MessageItem: Component<MessageItemProps> = (props) => {
             <span
               class="font-semibold text-text-primary hover:underline cursor-pointer transition-colors"
               onContextMenu={(e: MouseEvent) => {
+                // Suppress native context menu if long-press fired on parent row.
+                longPress.onContextMenu(e);
                 e.stopPropagation();
-                showUserContextMenu(e, {
-                  id: author().id,
-                  username: author().username,
-                  display_name: author().display_name,
-                });
+                if (!e.defaultPrevented) {
+                  showUserContextMenu(e, {
+                    id: author().id,
+                    username: author().username,
+                    display_name: author().display_name,
+                  });
+                }
               }}
             >
               {author().display_name}

--- a/client/src/components/modals/ReportModal.tsx
+++ b/client/src/components/modals/ReportModal.tsx
@@ -156,7 +156,7 @@ const ReportModal: Component<ReportModalProps> = (props) => {
                 <div class="space-y-2">
                   <label class="text-sm font-medium text-text-secondary">
                     Details{" "}
-                    <span class="text-text-secondary/50">
+                    <span class="text-text-muted">
                       (optional, max 500 chars)
                     </span>
                   </label>
@@ -170,7 +170,7 @@ const ReportModal: Component<ReportModalProps> = (props) => {
                     rows={3}
                     maxLength={500}
                   />
-                  <div class="text-xs text-text-secondary/50 text-right">
+                  <div class="text-xs text-text-muted text-right">
                     {description().length}/500
                   </div>
                 </div>

--- a/client/src/components/search/SearchPanel.tsx
+++ b/client/src/components/search/SearchPanel.tsx
@@ -361,7 +361,7 @@ const SearchPanel: Component<SearchPanelProps> = (props) => {
                 setAuthorFilter(e.currentTarget.value);
                 triggerSearch();
               }}
-              class="w-full px-2 py-1 rounded text-xs text-text-primary placeholder:text-text-secondary/50 bg-surface-layer1 border border-white/10 outline-none"
+              class="w-full px-2 py-1 rounded text-xs text-text-primary placeholder:text-text-muted bg-surface-layer1 border border-white/10 outline-none"
             />
           </div>
           <div class="flex gap-2">

--- a/client/src/components/ui/ContextMenu.tsx
+++ b/client/src/components/ui/ContextMenu.tsx
@@ -16,6 +16,9 @@ import {
 } from "solid-js";
 import { Dynamic, Portal } from "solid-js/web";
 
+// Each context menu item: py-2.5 (10px top + 10px bottom) + text-sm leading + border ≈ 40px
+const ITEM_HEIGHT_PX = 40;
+
 // --- Types ---
 
 export interface ContextMenuItem {
@@ -71,7 +74,7 @@ export function showContextMenu(
 
   // Estimate menu dimensions for viewport edge flipping
   const menuWidth = 200;
-  const menuHeight = items.length * 36;
+  const menuHeight = items.length * ITEM_HEIGHT_PX;
 
   const viewportW = window.innerWidth;
   const viewportH = window.innerHeight;
@@ -105,7 +108,7 @@ export function showContextMenuAt(
 ): void {
   // Estimate menu dimensions for viewport edge flipping
   const menuWidth = 200;
-  const menuHeight = items.length * 36;
+  const menuHeight = items.length * ITEM_HEIGHT_PX;
 
   const viewportW = window.innerWidth;
   const viewportH = window.innerHeight;

--- a/client/src/components/ui/ContextMenu.tsx
+++ b/client/src/components/ui/ContextMenu.tsx
@@ -95,6 +95,37 @@ export function showContextMenu(
 }
 
 /**
+ * Show a context menu at specific coordinates (for touch/long-press).
+ * Automatically flips position if near the viewport edge.
+ */
+export function showContextMenuAt(
+  x: number,
+  y: number,
+  items: ContextMenuEntry[],
+): void {
+  // Estimate menu dimensions for viewport edge flipping
+  const menuWidth = 200;
+  const menuHeight = items.length * 36;
+
+  const viewportW = window.innerWidth;
+  const viewportH = window.innerHeight;
+
+  if (x + menuWidth > viewportW) {
+    x = viewportW - menuWidth - 8;
+  }
+  if (y + menuHeight > viewportH) {
+    y = viewportH - menuHeight - 8;
+  }
+
+  // Ensure we don't go negative
+  x = Math.max(4, x);
+  y = Math.max(4, y);
+
+  setFocusedIndex(-1);
+  setMenuState({ visible: true, x, y, items });
+}
+
+/**
  * Hide the context menu.
  */
 export function hideContextMenu(): void {
@@ -154,7 +185,7 @@ const ContextMenuItemButton: Component<{
     <button
       type="button"
       class={`
-        w-full flex items-center gap-2.5 px-3 py-1.5 text-sm text-left rounded
+        w-full flex items-center gap-2.5 px-3 py-2.5 text-sm text-left rounded
         transition-colors cursor-default
         ${
           props.item.disabled

--- a/client/src/components/voice/VoicePanel.tsx
+++ b/client/src/components/voice/VoicePanel.tsx
@@ -98,7 +98,7 @@ const VoicePanel: Component = () => {
               <div class="text-xs text-text-secondary truncate flex items-center gap-1.5">
                 <span class="hover:text-text-primary transition-colors">{channel()?.name || "Voice Channel"}</span>
                 <Show when={isConnected()}>
-                  <span class="text-text-secondary/50">&middot;</span>
+                  <span class="text-text-muted">&middot;</span>
                   <span class="font-mono">{elapsedTime()}</span>
                   <div
                     class="relative"

--- a/client/src/lib/contextMenuBuilders.ts
+++ b/client/src/lib/contextMenuBuilders.ts
@@ -7,6 +7,7 @@
 import { User, MessageSquare, UserPlus, Ban, Copy, Flag } from "lucide-solid";
 import {
   showContextMenu,
+  showContextMenuAt,
   type ContextMenuEntry,
 } from "@/components/ui/ContextMenu";
 import { currentUser } from "@/stores/auth";
@@ -70,12 +71,9 @@ export function triggerReport(target: {
 }
 
 /**
- * Show a context menu for a user (member list, message author, etc.).
+ * Build context menu items for a user (member list, message author, etc.).
  */
-export function showUserContextMenu(
-  event: MouseEvent,
-  user: UserMenuTarget,
-): void {
+function buildUserContextMenuItems(user: UserMenuTarget): ContextMenuEntry[] {
   const me = currentUser();
   const isSelf = me?.id === user.id;
 
@@ -187,5 +185,26 @@ export function showUserContextMenu(
     },
   );
 
-  showContextMenu(event, items);
+  return items;
+}
+
+/**
+ * Show a context menu for a user (member list, message author, etc.).
+ */
+export function showUserContextMenu(
+  event: MouseEvent,
+  user: UserMenuTarget,
+): void {
+  showContextMenu(event, buildUserContextMenuItems(user));
+}
+
+/**
+ * Show a context menu for a user at specific coordinates (for touch/long-press).
+ */
+export function showUserContextMenuAt(
+  x: number,
+  y: number,
+  user: UserMenuTarget,
+): void {
+  showContextMenuAt(x, y, buildUserContextMenuItems(user));
 }

--- a/client/src/lib/createLongPress.ts
+++ b/client/src/lib/createLongPress.ts
@@ -1,0 +1,44 @@
+export function createLongPress(
+  onLongPress: (x: number, y: number) => void,
+  duration = 500
+) {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let startX = 0;
+  let startY = 0;
+
+  const onPointerDown = (e: PointerEvent) => {
+    startX = e.clientX;
+    startY = e.clientY;
+    timer = setTimeout(() => {
+      onLongPress(e.clientX, e.clientY);
+      timer = null;
+    }, duration);
+  };
+
+  const cancel = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  const onPointerMove = (e: PointerEvent) => {
+    if (timer && (Math.abs(e.clientX - startX) > 10 || Math.abs(e.clientY - startY) > 10)) {
+      cancel();
+    }
+  };
+
+  const onContextMenu = (e: Event) => {
+    if (timer) {
+      e.preventDefault();
+    }
+  };
+
+  return {
+    onPointerDown,
+    onPointerUp: cancel,
+    onPointerCancel: cancel,
+    onPointerMove,
+    onContextMenu,
+  };
+}

--- a/client/src/lib/createLongPress.ts
+++ b/client/src/lib/createLongPress.ts
@@ -3,13 +3,16 @@ export function createLongPress(
   duration = 500
 ) {
   let timer: ReturnType<typeof setTimeout> | null = null;
+  let consumed = false;
   let startX = 0;
   let startY = 0;
 
   const onPointerDown = (e: PointerEvent) => {
+    consumed = false;
     startX = e.clientX;
     startY = e.clientY;
     timer = setTimeout(() => {
+      consumed = true;
       onLongPress(e.clientX, e.clientY);
       timer = null;
     }, duration);
@@ -29,9 +32,18 @@ export function createLongPress(
   };
 
   const onContextMenu = (e: Event) => {
-    if (timer) {
+    // Suppress native context menu only if a long-press was just consumed or
+    // is currently pending. Always reset `consumed` afterwards so a subsequent
+    // keyboard-triggered context menu (e.g., Shift+F10) is not incorrectly
+    // suppressed.
+    //
+    // Trade-off: on hybrid devices, if the user touch-long-presses then
+    // immediately right-clicks before the next pointerdown, the right-click
+    // is suppressed. This is acceptable.
+    if (timer || consumed) {
       e.preventDefault();
     }
+    consumed = false;
   };
 
   return {

--- a/client/src/lib/useBreakpoint.ts
+++ b/client/src/lib/useBreakpoint.ts
@@ -1,0 +1,14 @@
+import { createSignal, onCleanup } from "solid-js";
+
+export function useBreakpoint(query: string): () => boolean {
+  const mql = window.matchMedia(query);
+  const [matches, setMatches] = createSignal(mql.matches);
+  const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+  mql.addEventListener("change", handler);
+  onCleanup(() => mql.removeEventListener("change", handler));
+  return matches;
+}
+
+export function useIsMobile(): () => boolean {
+  return useBreakpoint("(max-width: 767px)");
+}

--- a/client/src/views/ForgotPassword.tsx
+++ b/client/src/views/ForgotPassword.tsx
@@ -52,7 +52,7 @@ const ForgotPassword: Component = () => {
   };
 
   return (
-    <div class="flex items-center justify-center min-h-screen bg-background-primary">
+    <div class="flex items-center justify-center min-h-screen overflow-y-auto bg-background-primary">
       <div class="flex w-full max-w-4xl mx-4 bg-background-secondary rounded-lg shadow-lg overflow-hidden">
         <div class="hidden lg:flex w-1/2 items-center justify-center p-8 bg-surface-base">
           <img src={getThemeImage("floki_auth_forgot.png")} alt="Floki turning a combination lock" class="w-full max-w-xs object-contain" loading="eager" />

--- a/client/src/views/Login.tsx
+++ b/client/src/views/Login.tsx
@@ -188,7 +188,7 @@ const Login: Component = () => {
   const error = () => localError() || authState.error;
 
   return (
-    <div class="flex items-center justify-center min-h-screen bg-background-primary">
+    <div class="flex items-center justify-center min-h-screen overflow-y-auto bg-background-primary">
       <div class="flex w-full max-w-4xl mx-4 bg-background-secondary rounded-lg shadow-lg overflow-hidden">
         {/* Left: Floki illustration */}
         <div class="hidden lg:flex w-1/2 items-center justify-center p-8 bg-surface-base">

--- a/client/src/views/Register.tsx
+++ b/client/src/views/Register.tsx
@@ -189,7 +189,7 @@ const Register: Component = () => {
   const error = () => localError() || authState.error;
 
   return (
-    <div class="flex items-center justify-center min-h-screen bg-background-primary py-8">
+    <div class="flex items-center justify-center min-h-screen overflow-y-auto bg-background-primary py-8">
       <div class="flex w-full max-w-4xl mx-4 bg-background-secondary rounded-lg shadow-lg overflow-hidden">
         <div class="hidden lg:flex w-1/2 items-start justify-center pt-16 p-8 bg-surface-base">
           <img src={getThemeImage("floki_auth_register.png")} alt="Floki holding membership badge" class="w-full max-w-xs object-contain" loading="eager" />

--- a/client/src/views/ResetPassword.tsx
+++ b/client/src/views/ResetPassword.tsx
@@ -63,7 +63,7 @@ const ResetPassword: Component = () => {
   };
 
   return (
-    <div class="flex items-center justify-center min-h-screen bg-background-primary">
+    <div class="flex items-center justify-center min-h-screen overflow-y-auto bg-background-primary">
       <div class="flex w-full max-w-4xl mx-4 bg-background-secondary rounded-lg shadow-lg overflow-hidden">
         <div class="hidden lg:flex w-1/2 items-center justify-center p-8 bg-surface-base">
           <img src={getThemeImage("floki_auth_forgot.png")} alt="Floki turning a combination lock" class="w-full max-w-xs object-contain" loading="eager" />

--- a/client/uno.config.ts
+++ b/client/uno.config.ts
@@ -137,6 +137,18 @@ export default defineConfig({
       getCSS: () => `@keyframes slideUp { from { opacity: 0; transform: translateY(20px); } to { opacity: 1; transform: translateY(0); } }`,
     },
   ],
+  variants: [
+    {
+      name: "touch",
+      match(matcher: string) {
+        if (!matcher.startsWith("touch:")) return;
+        return {
+          matcher: matcher.slice(6),
+          parent: "@media (hover: none)",
+        };
+      },
+    },
+  ],
   rules: [
     [/^animate-\[slideUp/, () => ({
       animation: "slideUp 0.2s ease-out",


### PR DESCRIPTION
## Summary
- **Responsive layout**: Below 768px (md breakpoint), sidebar and server rail collapse into a slide-out drawer. Above 768px, existing desktop layout is unchanged.
- **MobileDrawer**: Slide-out drawer (300px) with backdrop overlay, swipe-left-to-close, and auto-close on channel selection.
- **MobileHeader**: 44px top bar with hamburger menu, current guild name, and channel name.
- **Swipe gestures**: Right from left edge to open drawer, left on drawer to close.
- **Touch support**: `createLongPress` directive + `showContextMenuAt` for context menus on touch devices. Integrated at message items, channel items, and member lists.
- **UnoCSS touch variant**: New `touch:` prefix mapping to `@media (hover: none)`.
- **Contrast fixes**: All 13 `text-text-secondary/50` instances replaced with `text-text-muted` for WCAG compliance.
- **Modal overflow**: GuildSettingsModal no longer exceeds viewport at 800px.
- **Auth scroll**: Login, register, and password reset views now scroll when content exceeds viewport height.
- **Emoji delete**: Delete button visible on touch devices via `touch:opacity-60`.
- **Touch targets**: Context menu items and modal close button enlarged for reliable touch interaction.

Addresses issues #11, #28, #29, #30, #31 plus responsive overhaul from the mobile implementation review.

## Test plan
- [ ] `bun run test:run` passes (577/577)
- [ ] `bun run build` succeeds
- [ ] Desktop (>768px): layout unchanged, all features work
- [ ] Mobile (≤767px): drawer opens via hamburger, swipe-right from edge
- [ ] Mobile: channel selection closes drawer
- [ ] Mobile: long-press on message shows context menu
- [ ] `grep -r "text-text-secondary/50" client/src/` returns 0 matches
- [ ] GuildSettingsModal fits at 800px viewport width

🤖 Generated with [Claude Code](https://claude.com/claude-code)