### PR TITLE
fix(voice): server security — self-mute, rate limiting, screen share slot leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Android: network connectivity detection uses `NET_CAPABILITY_VALIDATED` to avoid false positives on captive portals
 - Android: OIDC PKCE state is persisted synchronously, preventing intermittent CSRF-error login failures on low-memory devices
 - Android: TLS 1.3 provider failure now prompts users to update Play Services instead of failing silently on every network call
+- Self-muted users' audio is now actually dropped at the server rather than being forwarded to listeners
+- Voice signaling events are rate-limited per peer to prevent flooding
 
 ### Fixed
+- Screen share slots are no longer leaked by duplicate stream IDs
 - Android: test infrastructure now injects EglBase via a provider so unit tests can be written without native EGL14 stubs; unblocks CI coverage for voice signaling
 - Android: OIDC callback path matching is now exact instead of prefix-based, preventing potential intent collisions
 - Android: WebSocket connection state correctly waits for server authentication confirmation before reporting Connected

--- a/server/src/voice/error.rs
+++ b/server/src/voice/error.rs
@@ -53,8 +53,8 @@ pub enum VoiceError {
     NotInChannel,
 
     /// Rate limited.
-    #[error("Rate limited: too many voice join requests")]
-    RateLimited,
+    #[error("Rate limited: {0}")]
+    RateLimited(&'static str),
 
     /// Internal error.
     #[error("Internal error: {0}")]
@@ -92,7 +92,7 @@ impl IntoResponse for VoiceError {
             }
             Self::AlreadyJoined => (StatusCode::CONFLICT, "ALREADY_JOINED", self.to_string()),
             Self::NotInChannel => (StatusCode::BAD_REQUEST, "NOT_IN_CHANNEL", self.to_string()),
-            Self::RateLimited => (
+            Self::RateLimited(_) => (
                 StatusCode::TOO_MANY_REQUESTS,
                 "RATE_LIMITED",
                 self.to_string(),

--- a/server/src/voice/error.rs
+++ b/server/src/voice/error.rs
@@ -25,6 +25,10 @@ pub enum VoiceError {
     #[error("Signaling error: {0}")]
     Signaling(String),
 
+    /// Screen share `stream_id` already exists in the room.
+    #[error("Screen share stream already exists")]
+    DuplicateStreamId,
+
     /// ICE connection failed.
     #[error("ICE connection failed")]
     IceConnectionFailed,
@@ -80,6 +84,11 @@ impl IntoResponse for VoiceError {
                 "WebRTC operation failed".to_string(),
             ),
             Self::Signaling(_) => (StatusCode::BAD_REQUEST, "SIGNALING_ERROR", self.to_string()),
+            Self::DuplicateStreamId => (
+                StatusCode::CONFLICT,
+                "DUPLICATE_STREAM_ID",
+                self.to_string(),
+            ),
             Self::IceConnectionFailed => (
                 StatusCode::SERVICE_UNAVAILABLE,
                 "ICE_FAILED",

--- a/server/src/voice/mod.rs
+++ b/server/src/voice/mod.rs
@@ -18,7 +18,7 @@ mod metrics;
 mod peer;
 mod quality;
 mod queries;
-mod rate_limit;
+pub mod rate_limit;
 pub mod screen_share;
 pub mod sfu;
 mod stats;

--- a/server/src/voice/peer.rs
+++ b/server/src/voice/peer.rs
@@ -49,8 +49,11 @@ pub struct Peer {
     /// Map: `(source_user_id, source_type)` -> local track
     outgoing_tracks: RwLock<HashMap<(Uuid, TrackSource), Arc<TrackLocalStaticRTP>>>,
 
-    /// Whether the user is muted.
-    muted: RwLock<bool>,
+    /// Whether the user muted themselves.
+    self_muted: RwLock<bool>,
+    /// Whether a moderator muted the user. Set only by future moderation events.
+    #[allow(dead_code)]
+    server_muted: RwLock<bool>,
     /// Channel to send signaling messages back to the user.
     pub signal_tx: mpsc::Sender<OutboundMsg>,
     /// Unique session identifier for this connection.
@@ -86,7 +89,8 @@ impl Peer {
             subscriber_pc,
             incoming_tracks: RwLock::new(HashMap::new()),
             outgoing_tracks: RwLock::new(HashMap::new()),
-            muted: RwLock::new(false),
+            self_muted: RwLock::new(false),
+            server_muted: RwLock::new(false),
             signal_tx,
             session_id: Uuid::now_v7(),
             connected_at: Utc::now(),
@@ -189,15 +193,20 @@ impl Peer {
             || self.subscriber_pc.connection_state() == RTCPeerConnectionState::Connected
     }
 
-    /// Set mute state.
-    pub async fn set_muted(&self, muted: bool) {
-        let mut m = self.muted.write().await;
+    /// Set the user's own mute state (does not affect `server_muted`).
+    pub async fn set_self_muted(&self, muted: bool) {
+        let mut m = self.self_muted.write().await;
         *m = muted;
     }
 
-    /// Get mute state.
-    pub async fn is_muted(&self) -> bool {
-        *self.muted.read().await
+    /// Returns true if the user has muted themselves (ignores moderator mute).
+    pub async fn is_self_muted(&self) -> bool {
+        *self.self_muted.read().await
+    }
+
+    /// Returns true if either the user self-muted or a moderator muted them.
+    pub async fn is_effectively_muted(&self) -> bool {
+        *self.self_muted.read().await || *self.server_muted.read().await
     }
 
     /// Close both peer connections.

--- a/server/src/voice/rate_limit.rs
+++ b/server/src/voice/rate_limit.rs
@@ -67,7 +67,7 @@ impl VoiceStatsLimiter {
             let elapsed = last.elapsed();
             if elapsed < self.min_stats_interval {
                 // Still within rate limit window
-                return Err(VoiceError::RateLimited);
+                return Err(VoiceError::RateLimited("voice_stats"));
             }
         }
 

--- a/server/src/voice/rate_limit.rs
+++ b/server/src/voice/rate_limit.rs
@@ -1,10 +1,16 @@
 //! Rate limiting for voice operations.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use dashmap::DashMap;
 use tokio::sync::RwLock;
+// Use `tokio::time::Instant` (not `std::time::Instant`) for the token bucket
+// so integration tests with `#[tokio::test(start_paused = true)]` can use
+// virtual time deterministically.
+use tokio::time::Instant as TokioInstant;
 use tracing::debug;
 use uuid::Uuid;
 
@@ -87,6 +93,152 @@ impl VoiceStatsLimiter {
     }
 }
 
+/// Event class key for per-peer voice signaling rate limiting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EventClass {
+    /// ICE candidates for the publisher `PeerConnection`.
+    IceCandidatePublisher,
+    /// ICE candidates for the subscriber `PeerConnection`.
+    IceCandidateSubscriber,
+    /// Covers `VoicePublisherOffer` and `VoiceSubscriberAnswer`.
+    PublisherOffer,
+    /// Covers `VoiceScreenShareStart` and `VoiceScreenShareStop`.
+    ScreenShareToggle,
+    /// Covers Mute / Unmute / `WebcamStart` / `WebcamStop`.
+    MuteOrWebcamToggle,
+    /// Simulcast layer preference updates.
+    SetLayerPreference,
+}
+
+impl EventClass {
+    /// Stable label for observability logs.
+    #[must_use]
+    pub const fn as_scope(self) -> &'static str {
+        match self {
+            Self::IceCandidatePublisher => "ice_candidate_publisher",
+            Self::IceCandidateSubscriber => "ice_candidate_subscriber",
+            Self::PublisherOffer => "publisher_offer",
+            Self::ScreenShareToggle => "screen_share_toggle",
+            Self::MuteOrWebcamToggle => "mute_or_webcam_toggle",
+            Self::SetLayerPreference => "set_layer_preference",
+        }
+    }
+}
+
+/// Lazy-refilling token bucket backed by an atomic counter.
+///
+/// Refills are computed on demand from elapsed time, so no background task is
+/// required. Tokens are capped at `capacity`.
+#[derive(Debug)]
+pub struct TokenBucket {
+    capacity: u32,
+    tokens: AtomicU32,
+    refill_per_sec: u32,
+    last_refill: std::sync::Mutex<TokioInstant>,
+}
+
+impl TokenBucket {
+    /// Create a new token bucket, starting full at `capacity`.
+    #[must_use]
+    pub fn new(capacity: u32, refill_per_sec: u32) -> Self {
+        Self {
+            capacity,
+            tokens: AtomicU32::new(capacity),
+            refill_per_sec,
+            last_refill: std::sync::Mutex::new(TokioInstant::now()),
+        }
+    }
+
+    /// Attempt to acquire one token. Performs a lazy refill before trying.
+    ///
+    /// Returns `true` if a token was consumed, `false` if the bucket was empty.
+    pub fn try_acquire(&self) -> bool {
+        let now = TokioInstant::now();
+        {
+            let mut last = self.last_refill.lock().unwrap();
+            let elapsed_ms = now.duration_since(*last).as_millis() as u64;
+            if elapsed_ms > 0 {
+                let tokens_to_add = ((elapsed_ms * u64::from(self.refill_per_sec)) / 1000) as u32;
+                if tokens_to_add > 0 {
+                    let current = self.tokens.load(Ordering::Relaxed);
+                    let new_value = current.saturating_add(tokens_to_add).min(self.capacity);
+                    self.tokens.store(new_value, Ordering::Release);
+                    *last = now;
+                }
+            }
+        }
+
+        let mut current = self.tokens.load(Ordering::Acquire);
+        loop {
+            if current == 0 {
+                return false;
+            }
+            match self.tokens.compare_exchange_weak(
+                current,
+                current - 1,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return true,
+                Err(actual) => current = actual,
+            }
+        }
+    }
+}
+
+/// Per-peer, per-event-class token bucket rate limiter for voice signaling.
+///
+/// Buckets are created lazily on first access for a `(peer_id, event_class)`
+/// pair and removed when the peer disconnects via [`Self::forget_peer`].
+#[derive(Debug, Default)]
+pub struct VoiceRateLimiter {
+    buckets: DashMap<(Uuid, EventClass), TokenBucket>,
+}
+
+impl VoiceRateLimiter {
+    /// Create a new empty rate limiter.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Try to acquire a token for `(peer_id, class)`.
+    ///
+    /// Returns `true` if the event is allowed, `false` if it should be dropped.
+    /// Creates the bucket on first use with the class's default configuration.
+    pub fn try_acquire(&self, peer_id: Uuid, class: EventClass) -> bool {
+        let bucket = self
+            .buckets
+            .entry((peer_id, class))
+            .or_insert_with(|| Self::bucket_for_class(class));
+        bucket.try_acquire()
+    }
+
+    /// Remove all buckets for a peer. Call on voice disconnect to avoid leaks.
+    pub fn forget_peer(&self, peer_id: Uuid) {
+        self.buckets.retain(|(pid, _), _| *pid != peer_id);
+    }
+
+    /// Bucket configuration per event class.
+    ///
+    /// See `docs/superpowers/specs/2026-04-15-voice-screenshare-fixes-design.md`
+    /// Fix 2 for the design rationale behind these limits.
+    fn bucket_for_class(class: EventClass) -> TokenBucket {
+        match class {
+            // ICE trickle is bursty per PC; tolerate flurries but cap sustained rate.
+            EventClass::IceCandidatePublisher | EventClass::IceCandidateSubscriber => {
+                TokenBucket::new(200, 40)
+            }
+            // Renegotiation should be rare — protect against offer storms.
+            EventClass::PublisherOffer => TokenBucket::new(5, 1),
+            // Integer approximation of "1 per 5 seconds" for screen share toggles.
+            EventClass::ScreenShareToggle => TokenBucket::new(5, 1),
+            EventClass::MuteOrWebcamToggle => TokenBucket::new(10, 2),
+            EventClass::SetLayerPreference => TokenBucket::new(20, 5),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -153,5 +305,131 @@ mod tests {
         // Cleanup should remove old entries
         limiter.cleanup().await;
         assert_eq!(limiter.last_stats.read().await.len(), 0);
+    }
+
+    // ----- TokenBucket / VoiceRateLimiter tests -----
+
+    #[tokio::test(start_paused = true)]
+    async fn token_bucket_allows_initial_capacity_then_blocks() {
+        let bucket = TokenBucket::new(3, 1);
+
+        assert!(bucket.try_acquire());
+        assert!(bucket.try_acquire());
+        assert!(bucket.try_acquire());
+        // Capacity exhausted, and no time has passed under paused time.
+        assert!(!bucket.try_acquire());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn token_bucket_refills_after_one_second() {
+        let bucket = TokenBucket::new(2, 5);
+
+        assert!(bucket.try_acquire());
+        assert!(bucket.try_acquire());
+        assert!(!bucket.try_acquire());
+
+        // Advance virtual time by one second — 5 tokens should be generated,
+        // but the bucket caps at capacity (2).
+        tokio::time::advance(Duration::from_secs(1)).await;
+
+        assert!(bucket.try_acquire());
+        assert!(bucket.try_acquire());
+        assert!(!bucket.try_acquire());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn token_bucket_partial_refill_from_elapsed_time() {
+        // 10 tokens/sec → one token per 100ms.
+        let bucket = TokenBucket::new(10, 10);
+
+        // Drain the bucket.
+        for _ in 0..10 {
+            assert!(bucket.try_acquire());
+        }
+        assert!(!bucket.try_acquire());
+
+        // Advance 300ms — expect 3 tokens added.
+        tokio::time::advance(Duration::from_millis(300)).await;
+
+        assert!(bucket.try_acquire());
+        assert!(bucket.try_acquire());
+        assert!(bucket.try_acquire());
+        assert!(!bucket.try_acquire());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn token_bucket_does_not_over_deliver_under_sequential_load() {
+        let bucket = TokenBucket::new(50, 10);
+
+        // Under paused time no refill happens; we should get exactly `capacity`
+        // successful acquires across many attempts.
+        let mut allowed = 0;
+        for _ in 0..200 {
+            if bucket.try_acquire() {
+                allowed += 1;
+            }
+        }
+        assert_eq!(allowed, 50);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn voice_rate_limiter_separates_peers_and_classes() {
+        let limiter = VoiceRateLimiter::new();
+        let peer_a = Uuid::new_v4();
+        let peer_b = Uuid::new_v4();
+
+        // publisher_offer: capacity 5.
+        for _ in 0..5 {
+            assert!(limiter.try_acquire(peer_a, EventClass::PublisherOffer));
+        }
+        assert!(!limiter.try_acquire(peer_a, EventClass::PublisherOffer));
+
+        // Different peer has its own fresh bucket.
+        assert!(limiter.try_acquire(peer_b, EventClass::PublisherOffer));
+
+        // Different class on the same peer has its own fresh bucket.
+        assert!(limiter.try_acquire(peer_a, EventClass::MuteOrWebcamToggle));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn voice_rate_limiter_forget_peer_frees_buckets() {
+        let limiter = VoiceRateLimiter::new();
+        let peer = Uuid::new_v4();
+
+        // Drain publisher_offer capacity.
+        for _ in 0..5 {
+            assert!(limiter.try_acquire(peer, EventClass::PublisherOffer));
+        }
+        assert!(!limiter.try_acquire(peer, EventClass::PublisherOffer));
+
+        limiter.forget_peer(peer);
+
+        // Bucket is recreated at full capacity after forget.
+        assert!(limiter.try_acquire(peer, EventClass::PublisherOffer));
+    }
+
+    #[test]
+    fn event_class_scope_labels_are_stable() {
+        assert_eq!(
+            EventClass::IceCandidatePublisher.as_scope(),
+            "ice_candidate_publisher"
+        );
+        assert_eq!(
+            EventClass::IceCandidateSubscriber.as_scope(),
+            "ice_candidate_subscriber"
+        );
+        assert_eq!(EventClass::PublisherOffer.as_scope(), "publisher_offer");
+        assert_eq!(
+            EventClass::ScreenShareToggle.as_scope(),
+            "screen_share_toggle"
+        );
+        assert_eq!(
+            EventClass::MuteOrWebcamToggle.as_scope(),
+            "mute_or_webcam_toggle"
+        );
+        assert_eq!(
+            EventClass::SetLayerPreference.as_scope(),
+            "set_layer_preference"
+        );
     }
 }

--- a/server/src/voice/rate_limit.rs
+++ b/server/src/voice/rate_limit.rs
@@ -36,13 +36,6 @@ impl VoiceStatsLimiter {
         }
     }
 
-    /// Create a rate limiter with default settings.
-    /// - 1 stats report per second
-    /// - Cleanup every 60 seconds
-    pub fn default() -> Self {
-        Self::new(Duration::from_secs(1))
-    }
-
     /// Start a background task that periodically cleans up stale entries.
     /// Returns a handle to the spawned task.
     pub fn start_cleanup_task(self: &Arc<Self>) -> tokio::task::JoinHandle<()> {
@@ -93,6 +86,15 @@ impl VoiceStatsLimiter {
     }
 }
 
+impl Default for VoiceStatsLimiter {
+    /// Create a rate limiter with default settings.
+    /// - 1 stats report per second
+    /// - Cleanup every 60 seconds
+    fn default() -> Self {
+        Self::new(Duration::from_secs(1))
+    }
+}
+
 /// Event class key for per-peer voice signaling rate limiting.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum EventClass {
@@ -130,7 +132,7 @@ impl EventClass {
 /// Refills are computed on demand from elapsed time, so no background task is
 /// required. Tokens are capped at `capacity`.
 #[derive(Debug)]
-pub struct TokenBucket {
+pub(crate) struct TokenBucket {
     capacity: u32,
     tokens: AtomicU32,
     refill_per_sec: u32,
@@ -140,7 +142,7 @@ pub struct TokenBucket {
 impl TokenBucket {
     /// Create a new token bucket, starting full at `capacity`.
     #[must_use]
-    pub fn new(capacity: u32, refill_per_sec: u32) -> Self {
+    pub(crate) fn new(capacity: u32, refill_per_sec: u32) -> Self {
         Self {
             capacity,
             tokens: AtomicU32::new(capacity),
@@ -152,7 +154,7 @@ impl TokenBucket {
     /// Attempt to acquire one token. Performs a lazy refill before trying.
     ///
     /// Returns `true` if a token was consumed, `false` if the bucket was empty.
-    pub fn try_acquire(&self) -> bool {
+    pub(crate) fn try_acquire(&self) -> bool {
         let now = TokioInstant::now();
         {
             let mut last = self.last_refill.lock().unwrap();

--- a/server/src/voice/sfu.rs
+++ b/server/src/voice/sfu.rs
@@ -859,7 +859,7 @@ impl SfuServer {
                 .map_err(|e| VoiceError::Internal(e.to_string()))?;
 
             if !result.allowed {
-                return Err(VoiceError::RateLimited);
+                return Err(VoiceError::RateLimited("voice_join"));
             }
         }
         Ok(())

--- a/server/src/voice/sfu.rs
+++ b/server/src/voice/sfu.rs
@@ -211,7 +211,7 @@ impl Room {
                 user_id: *user_id,
                 username: Some(peer.username.clone()),
                 display_name: Some(peer.display_name.clone()),
-                muted: peer.is_muted().await,
+                muted: peer.is_self_muted().await,
                 screen_sharing: shares.values().any(|s| s.user_id == *user_id),
                 webcam_active: webcams.contains_key(user_id),
             });

--- a/server/src/voice/sfu.rs
+++ b/server/src/voice/sfu.rs
@@ -596,6 +596,7 @@ impl SfuServer {
                         layer,
                         track.clone(),
                         room.track_router.clone(),
+                        peer.clone(),
                     );
 
                     // For video tracks: send PLI every 3 seconds so subscribers

--- a/server/src/voice/sfu.rs
+++ b/server/src/voice/sfu.rs
@@ -27,7 +27,7 @@ use webrtc::rtp_transceiver::RTCPFeedback;
 
 use super::error::VoiceError;
 use super::peer::Peer;
-use super::rate_limit::VoiceStatsLimiter;
+use super::rate_limit::{VoiceRateLimiter, VoiceStatsLimiter};
 use super::screen_share::ScreenShareInfo;
 use super::track::{spawn_rtp_forwarder, spawn_subscriber_remb_reader, TrackRouter};
 use super::track_types::{Layer, TrackSource};
@@ -287,6 +287,8 @@ pub struct SfuServer {
     rate_limiter: Option<Arc<RateLimiter>>,
     /// Rate limiter for voice stats (local/memory).
     stats_limiter: Arc<VoiceStatsLimiter>,
+    /// Per-peer, per-event-class token bucket limiter for voice signaling events.
+    voice_rate_limiter: Arc<VoiceRateLimiter>,
 }
 
 impl SfuServer {
@@ -379,6 +381,7 @@ impl SfuServer {
             config,
             rate_limiter: rate_limiter.map(Arc::new),
             stats_limiter: Arc::new(VoiceStatsLimiter::default()),
+            voice_rate_limiter: Arc::new(VoiceRateLimiter::new()),
         })
     }
 
@@ -868,6 +871,12 @@ impl SfuServer {
     /// Check if a user can report voice stats (rate limit check).
     pub async fn check_stats_rate_limit(&self, user_id: Uuid) -> Result<(), VoiceError> {
         self.stats_limiter.check_stats(user_id).await
+    }
+
+    /// Access the per-peer voice signaling rate limiter.
+    #[must_use]
+    pub const fn voice_rate_limiter(&self) -> &Arc<VoiceRateLimiter> {
+        &self.voice_rate_limiter
     }
 
     /// Get active room count.

--- a/server/src/voice/track.rs
+++ b/server/src/voice/track.rs
@@ -453,6 +453,7 @@ pub fn spawn_rtp_forwarder(
     layer: Layer,
     track: Arc<TrackRemote>,
     router: Arc<TrackRouter>,
+    peer: Arc<Peer>,
 ) {
     tokio::spawn(async move {
         let mut buf = vec![0u8; 1500]; // MTU size
@@ -462,6 +463,13 @@ pub fn spawn_rtp_forwarder(
             match track.read(&mut buf).await {
                 Ok((packet, _attributes)) => {
                     packet_count += 1;
+
+                    // Drop audio packets from muted peers. Video tracks (screen share,
+                    // webcam) are not affected by mute state.
+                    if source_type == TrackSource::Microphone && peer.is_effectively_muted().await {
+                        continue;
+                    }
+
                     if packet_count == 1 || packet_count.is_multiple_of(500) {
                         let sub_count = router.subscription_count(source_user_id, source_type);
                         debug!(

--- a/server/src/voice/ws_handler.rs
+++ b/server/src/voice/ws_handler.rs
@@ -791,6 +791,15 @@ async fn handle_screen_share_start(
         .ok()
         .flatten()
         .unwrap_or(6);
+    // Use the stream_id provided by the client.
+    let stream_id = params.stream_id;
+
+    // Check for duplicate stream_id FIRST — before reserving the channel slot,
+    // otherwise a duplicate leaks the slot.
+    if room.screen_shares.read().await.contains_key(&stream_id) {
+        return Err(VoiceError::DuplicateStreamId);
+    }
+
     let max_shares: u32 = max_screen_shares.try_into().unwrap_or(6);
 
     // Try to reserve a slot via limiter
@@ -803,16 +812,6 @@ async fn handle_screen_share_start(
             ScreenShareError::InternalError => "Internal error".to_string(),
             _ => format!("{e:?}"),
         }));
-    }
-
-    // Use the stream_id provided by the client.
-    let stream_id = params.stream_id;
-
-    // Reject duplicate stream_id
-    if room.screen_shares.read().await.contains_key(&stream_id) {
-        return Err(VoiceError::Signaling(format!(
-            "Screen share stream already exists: {stream_id}"
-        )));
     }
 
     // Queue pending track sources so setup_track_handler can identify them

--- a/server/src/voice/ws_handler.rs
+++ b/server/src/voice/ws_handler.rs
@@ -611,7 +611,7 @@ async fn handle_mute(
         .await
         .ok_or(VoiceError::ParticipantNotFound(user_id))?;
 
-    peer.set_muted(muted).await;
+    peer.set_self_muted(muted).await;
 
     // Notify other participants
     let event = if muted {

--- a/server/src/voice/ws_handler.rs
+++ b/server/src/voice/ws_handler.rs
@@ -12,6 +12,7 @@ use vc_common::protocol::PcType;
 
 use super::error::VoiceError;
 use super::metrics::{finalize_session, get_guild_id, store_metrics};
+use super::rate_limit::EventClass;
 use super::screen_share::{
     validate_source_label, ScreenShareError, ScreenShareInfo, ScreenShareLimiter,
 };
@@ -43,6 +44,44 @@ pub async fn handle_voice_event(
     tx: &mpsc::Sender<OutboundMsg>,
     screen_share_limiter: Option<&ScreenShareLimiter>,
 ) -> Result<(), VoiceError> {
+    // Per-peer, per-event-class token bucket rate limiting.
+    //
+    // Events that exceed the limit are dropped silently (no error returned
+    // to the client) per the design in
+    // `docs/superpowers/specs/2026-04-15-voice-screenshare-fixes-design.md`
+    // Fix 2. VoiceJoin is handled by the separate join rate limit; VoiceStats
+    // is handled by `VoiceStatsLimiter`; VoiceLeave is never limited.
+    let rate_limit_class: Option<EventClass> = match &event {
+        ClientEvent::VoiceIceCandidate { pc_type, .. } => Some(match pc_type {
+            PcType::Publisher => EventClass::IceCandidatePublisher,
+            PcType::Subscriber => EventClass::IceCandidateSubscriber,
+        }),
+        ClientEvent::VoicePublisherOffer { .. } | ClientEvent::VoiceSubscriberAnswer { .. } => {
+            Some(EventClass::PublisherOffer)
+        }
+        ClientEvent::VoiceScreenShareStart { .. } | ClientEvent::VoiceScreenShareStop { .. } => {
+            Some(EventClass::ScreenShareToggle)
+        }
+        ClientEvent::VoiceMute { .. }
+        | ClientEvent::VoiceUnmute { .. }
+        | ClientEvent::VoiceWebcamStart { .. }
+        | ClientEvent::VoiceWebcamStop { .. } => Some(EventClass::MuteOrWebcamToggle),
+        ClientEvent::VoiceSetLayerPreference { .. } => Some(EventClass::SetLayerPreference),
+        _ => None,
+    };
+    if let Some(class) = rate_limit_class {
+        if !sfu.voice_rate_limiter().try_acquire(user_id, class) {
+            // Structured log for observability. A follow-up PR should wire
+            // this into a Prometheus `voice_rate_limit_drops_total` counter.
+            warn!(
+                user_id = %user_id,
+                event_class = class.as_scope(),
+                "voice_rate_limit_drop",
+            );
+            return Ok(());
+        }
+    }
+
     match event {
         ClientEvent::VoiceJoin { channel_id } => {
             let result = handle_join(sfu, pool, user_id, channel_id, tx).await;
@@ -365,6 +404,9 @@ async fn handle_leave(
         // Close the peer connection
         peer.close().await;
     }
+
+    // Free per-peer rate-limit buckets so they don't accumulate across reconnects.
+    sfu.voice_rate_limiter().forget_peer(user_id);
 
     room.broadcast_except(
         user_id,

--- a/server/src/voice/ws_handler_test.rs
+++ b/server/src/voice/ws_handler_test.rs
@@ -267,7 +267,7 @@ mod tests {
 
         assert!(result.is_err());
         match result.unwrap_err() {
-            error::VoiceError::RateLimited => {
+            error::VoiceError::RateLimited(_) => {
                 // Expected
             }
             other => panic!("Expected RateLimited error, got: {other:?}"),

--- a/server/src/ws/handlers.rs
+++ b/server/src/ws/handlers.rs
@@ -471,6 +471,11 @@ async fn handle_socket(socket: WebSocket, state: AppState, user_id: Uuid) {
     pubsub_handle.abort();
     sender_handle.abort();
 
+    // Free per-peer voice rate-limit buckets in case the socket dropped without
+    // an explicit VoiceLeave (ping timeout, TCP drop, app crash). The explicit
+    // VoiceLeave path also calls `forget_peer`; calling it here too is idempotent.
+    state.sfu.voice_rate_limiter().forget_peer(user_id);
+
     // Update user presence to offline
     if let Err(e) = update_presence(&state, user_id, "offline").await {
         warn!("Failed to update presence on disconnect: {}", e);

--- a/server/tests/integration/main.rs
+++ b/server/tests/integration/main.rs
@@ -39,6 +39,7 @@ mod setup_integration;
 mod threads;
 mod upload_limits;
 mod uploads_http;
+mod voice_mute_enforcement;
 mod voice_sfu;
 mod webhooks;
 mod websocket_integration;

--- a/server/tests/integration/main.rs
+++ b/server/tests/integration/main.rs
@@ -40,6 +40,7 @@ mod threads;
 mod upload_limits;
 mod uploads_http;
 mod voice_mute_enforcement;
+mod voice_rate_limit;
 mod voice_sfu;
 mod webhooks;
 mod websocket_integration;

--- a/server/tests/integration/voice_mute_enforcement.rs
+++ b/server/tests/integration/voice_mute_enforcement.rs
@@ -16,12 +16,12 @@
 //!
 //! Instead, these tests exercise the mute state machine that the
 //! forwarder consumes:
-//!   * `Peer::is_effectively_muted()` correctly combines the
-//!     self-mute flag with the server-mute flag.
-//!   * `Peer::set_self_muted()` toggles the flag observable both
-//!     on the peer and through `Room::get_participant_info()`.
-//!   * The classification (`TrackSource::is_video`) the forwarder
-//!     uses to skip mute enforcement for video stays intact.
+//!   * `Peer::is_effectively_muted()` correctly combines the self-mute flag with the server-mute
+//!     flag.
+//!   * `Peer::set_self_muted()` toggles the flag observable both on the peer and through
+//!     `Room::get_participant_info()`.
+//!   * The classification (`TrackSource::is_video`) the forwarder uses to skip mute enforcement for
+//!     video stays intact.
 //!
 //! A regression that accidentally removed the `if muted { continue }`
 //! branch inside `spawn_rtp_forwarder` would NOT be caught here —
@@ -270,12 +270,11 @@ async fn per_peer_mute_state_is_independent() {
 /// guards only the two properties the forwarder relies on that are
 /// *not* covered there:
 ///
-/// 1. `Microphone` and `ScreenAudio` are distinct variants, so the
-///    narrow `== TrackSource::Microphone` match excludes system audio
-///    from the mute-drop path.
-/// 2. `ScreenAudio` is classified as audio — a status-quo pin so that
-///    if the policy ever broadens from "drop muted microphone" to
-///    "drop all muted audio", the forwarder must be updated in lockstep.
+/// 1. `Microphone` and `ScreenAudio` are distinct variants, so the narrow `==
+///    TrackSource::Microphone` match excludes system audio from the mute-drop path.
+/// 2. `ScreenAudio` is classified as audio — a status-quo pin so that if the policy ever broadens
+///    from "drop muted microphone" to "drop all muted audio", the forwarder must be updated in
+///    lockstep.
 #[test]
 fn track_source_forwarder_mute_policy_contract() {
     let stream_id = Uuid::new_v4();

--- a/server/tests/integration/voice_mute_enforcement.rs
+++ b/server/tests/integration/voice_mute_enforcement.rs
@@ -1,0 +1,297 @@
+//! Integration tests for self-mute RTP enforcement.
+//!
+//! Verifies the mute state model consumed by `spawn_rtp_forwarder`
+//! (see `server/src/voice/track.rs`), which drops audio RTP packets
+//! from peers whose `Peer::is_effectively_muted` returns `true` while
+//! leaving video tracks (screen share / webcam) untouched.
+//!
+//! ## Scope of coverage — what is feasible from an integration test
+//!
+//! The `voice::peer` and `voice::track` modules are private, so the
+//! `Peer` constructor, the `TrackRouter`, and `spawn_rtp_forwarder`
+//! are not reachable from this crate-external test. The webrtc-rs
+//! `TrackRemote` type also cannot be constructed outside the crate
+//! (`TrackRemote::new` is `pub(crate)`), so driving the forwarder
+//! loop directly and counting packets in/out is not possible here.
+//!
+//! Instead, these tests exercise the mute state machine that the
+//! forwarder consumes:
+//!   * `Peer::is_effectively_muted()` correctly combines the
+//!     self-mute flag with the server-mute flag.
+//!   * `Peer::set_self_muted()` toggles the flag observable both
+//!     on the peer and through `Room::get_participant_info()`.
+//!   * The classification (`TrackSource::is_video`) the forwarder
+//!     uses to skip mute enforcement for video stays intact.
+//!
+//! A regression that accidentally removed the `if muted { continue }`
+//! branch inside `spawn_rtp_forwarder` would NOT be caught here —
+//! that requires either a full two-peer WebRTC harness (out of scope
+//! for the current test infrastructure) or in-crate `#[cfg(test)]`
+//! coverage alongside `spawn_rtp_forwarder` itself.
+//!
+//! Run with: `cargo test --test integration voice_mute_enforcement`
+
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+use uuid::Uuid;
+use vc_server::config::Config;
+use vc_server::voice::sfu::SfuServer;
+use vc_server::voice::TrackSource;
+use vc_server::ws::OutboundMsg;
+
+/// Build an `SfuServer` configured for tests. No `PostgreSQL`, Valkey, or
+/// network is required — `SfuServer::new` only constructs an in-process
+/// `WebRTC` API from a `Config`.
+fn build_sfu() -> Arc<SfuServer> {
+    let config = Arc::new(Config::default_for_test());
+    Arc::new(SfuServer::new(config, None).expect("SFU creation should succeed"))
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+/// Newly-joined peer is unmuted by default.
+#[tokio::test]
+async fn peer_starts_unmuted() {
+    let sfu = build_sfu();
+    let room = sfu.get_or_create_room(Uuid::new_v4()).await;
+
+    let user_id = Uuid::new_v4();
+    let (tx, _rx) = mpsc::channel::<OutboundMsg>(32);
+    let peer = sfu
+        .create_peer(
+            user_id,
+            "alice".into(),
+            "Alice Display".into(),
+            room.channel_id,
+            tx,
+        )
+        .await
+        .expect("create_peer should succeed");
+    room.add_peer(peer.clone()).await.expect("add_peer");
+
+    assert!(
+        !peer.is_self_muted().await,
+        "new peer should not be self-muted"
+    );
+    assert!(
+        !peer.is_effectively_muted().await,
+        "new peer should not be effectively muted"
+    );
+
+    // Participant info should reflect the same state.
+    let participants = room.get_participant_info().await;
+    let alice = participants
+        .iter()
+        .find(|p| p.user_id == user_id)
+        .expect("alice should be in room");
+    assert!(
+        !alice.muted,
+        "ParticipantInfo.muted should be false for unmuted peer"
+    );
+}
+
+/// `set_self_muted(true)` flips both `is_self_muted` and
+/// `is_effectively_muted`, which is the gate used by
+/// `spawn_rtp_forwarder` to drop microphone RTP packets.
+#[tokio::test]
+async fn self_mute_flips_effective_mute() {
+    let sfu = build_sfu();
+    let room = sfu.get_or_create_room(Uuid::new_v4()).await;
+
+    let user_id = Uuid::new_v4();
+    let (tx, _rx) = mpsc::channel::<OutboundMsg>(32);
+    let peer = sfu
+        .create_peer(
+            user_id,
+            "bob".into(),
+            "Bob Display".into(),
+            room.channel_id,
+            tx,
+        )
+        .await
+        .expect("create_peer");
+    room.add_peer(peer.clone()).await.expect("add_peer");
+
+    // Mute.
+    peer.set_self_muted(true).await;
+    assert!(peer.is_self_muted().await, "self_muted should be true");
+    assert!(
+        peer.is_effectively_muted().await,
+        "effective mute should follow self-mute — this is the predicate \
+         the SFU forwarder uses to drop microphone RTP packets"
+    );
+
+    let participants = room.get_participant_info().await;
+    assert!(
+        participants
+            .iter()
+            .find(|p| p.user_id == user_id)
+            .expect("peer present")
+            .muted,
+        "ParticipantInfo.muted should reflect self-mute"
+    );
+
+    // Unmute.
+    peer.set_self_muted(false).await;
+    assert!(
+        !peer.is_self_muted().await,
+        "self_muted should be cleared after unmute"
+    );
+    assert!(
+        !peer.is_effectively_muted().await,
+        "effective mute should clear after self-unmute (no server mute set)"
+    );
+
+    let participants = room.get_participant_info().await;
+    assert!(
+        !participants
+            .iter()
+            .find(|p| p.user_id == user_id)
+            .expect("peer present")
+            .muted,
+        "ParticipantInfo.muted should reflect unmute"
+    );
+}
+
+/// Toggling self-mute multiple times is deterministic — the effective
+/// mute state always tracks the latest value, with no sleeps or timing.
+#[tokio::test]
+async fn self_mute_toggle_is_deterministic() {
+    let sfu = build_sfu();
+    let room = sfu.get_or_create_room(Uuid::new_v4()).await;
+
+    let user_id = Uuid::new_v4();
+    let (tx, _rx) = mpsc::channel::<OutboundMsg>(32);
+    let peer = sfu
+        .create_peer(
+            user_id,
+            "carol".into(),
+            "Carol Display".into(),
+            room.channel_id,
+            tx,
+        )
+        .await
+        .expect("create_peer");
+    room.add_peer(peer.clone()).await.expect("add_peer");
+
+    for &muted in &[true, false, true, true, false, false, true] {
+        peer.set_self_muted(muted).await;
+        assert_eq!(
+            peer.is_self_muted().await,
+            muted,
+            "is_self_muted should match the last-set value ({muted})"
+        );
+        assert_eq!(
+            peer.is_effectively_muted().await,
+            muted,
+            "is_effectively_muted should track self-mute when no server mute is active"
+        );
+    }
+}
+
+/// Multiple peers have independent mute state: muting one must not
+/// affect the others. This guards the invariant that the SFU's
+/// mute-drop logic is keyed on the *source* peer, not a global.
+#[tokio::test]
+async fn per_peer_mute_state_is_independent() {
+    let sfu = build_sfu();
+    let room = sfu.get_or_create_room(Uuid::new_v4()).await;
+
+    let alice_id = Uuid::new_v4();
+    let bob_id = Uuid::new_v4();
+
+    let (tx_a, _rx_a) = mpsc::channel::<OutboundMsg>(32);
+    let alice = sfu
+        .create_peer(
+            alice_id,
+            "alice".into(),
+            "Alice Display".into(),
+            room.channel_id,
+            tx_a,
+        )
+        .await
+        .expect("create_peer alice");
+    room.add_peer(alice.clone()).await.expect("add_peer alice");
+
+    let (tx_b, _rx_b) = mpsc::channel::<OutboundMsg>(32);
+    let bob = sfu
+        .create_peer(
+            bob_id,
+            "bob".into(),
+            "Bob Display".into(),
+            room.channel_id,
+            tx_b,
+        )
+        .await
+        .expect("create_peer bob");
+    room.add_peer(bob.clone()).await.expect("add_peer bob");
+
+    alice.set_self_muted(true).await;
+
+    assert!(alice.is_effectively_muted().await, "alice should be muted");
+    assert!(
+        !bob.is_effectively_muted().await,
+        "bob should NOT be affected by alice's mute — the forwarder's \
+         mute-check is per-peer, so bob's audio packets must still flow"
+    );
+
+    // Confirm via public room surface.
+    let participants = room.get_participant_info().await;
+    let alice_info = participants
+        .iter()
+        .find(|p| p.user_id == alice_id)
+        .expect("alice present");
+    let bob_info = participants
+        .iter()
+        .find(|p| p.user_id == bob_id)
+        .expect("bob present");
+
+    assert!(alice_info.muted, "alice.muted = true");
+    assert!(!bob_info.muted, "bob.muted = false");
+}
+
+/// Documents the forwarder's *narrow* mute-drop policy: only
+/// `TrackSource::Microphone` is dropped on self-mute — system audio
+/// (`ScreenAudio`) and all video sources are forwarded unchanged.
+///
+/// The forwarder contract, from `spawn_rtp_forwarder`:
+///
+/// ```ignore
+/// if source_type == TrackSource::Microphone && peer.is_effectively_muted().await {
+///     continue;
+/// }
+/// ```
+///
+/// The per-variant `is_audio()`/`is_video()` classification is already
+/// covered by in-crate unit tests in `voice::track_types` — this test
+/// guards only the two properties the forwarder relies on that are
+/// *not* covered there:
+///
+/// 1. `Microphone` and `ScreenAudio` are distinct variants, so the
+///    narrow `== TrackSource::Microphone` match excludes system audio
+///    from the mute-drop path.
+/// 2. `ScreenAudio` is classified as audio — a status-quo pin so that
+///    if the policy ever broadens from "drop muted microphone" to
+///    "drop all muted audio", the forwarder must be updated in lockstep.
+#[test]
+fn track_source_forwarder_mute_policy_contract() {
+    let stream_id = Uuid::new_v4();
+
+    assert_ne!(
+        TrackSource::Microphone,
+        TrackSource::ScreenAudio(stream_id),
+        "Microphone must be distinct from ScreenAudio so the forwarder's \
+         `source_type == TrackSource::Microphone` check can exclude system audio"
+    );
+
+    // Status-quo pin: if this ever flips, the forwarder's narrow
+    // `Microphone`-only mute-drop needs a second look.
+    assert!(
+        TrackSource::ScreenAudio(stream_id).is_audio(),
+        "ScreenAudio is classified as audio — forwarder policy only drops \
+         Microphone, not all audio; revisit spawn_rtp_forwarder if this changes"
+    );
+}

--- a/server/tests/integration/voice_rate_limit.rs
+++ b/server/tests/integration/voice_rate_limit.rs
@@ -1,0 +1,100 @@
+//! Integration tests for voice signaling rate limiting.
+
+use std::time::Duration;
+use uuid::Uuid;
+use vc_server::voice::rate_limit::{EventClass, VoiceRateLimiter};
+
+#[tokio::test(start_paused = true)]
+async fn ice_candidate_rate_limit_publisher_exhausts_at_capacity() {
+    let limiter = VoiceRateLimiter::new();
+    let peer = Uuid::new_v4();
+
+    // ICE publisher bucket is capacity=200 per spec.
+    for _ in 0..200 {
+        assert!(limiter.try_acquire(peer, EventClass::IceCandidatePublisher));
+    }
+    assert!(!limiter.try_acquire(peer, EventClass::IceCandidatePublisher));
+}
+
+#[tokio::test(start_paused = true)]
+async fn ice_candidate_buckets_are_independent_per_pc_type() {
+    let limiter = VoiceRateLimiter::new();
+    let peer = Uuid::new_v4();
+
+    // Drain the publisher bucket
+    for _ in 0..200 {
+        assert!(limiter.try_acquire(peer, EventClass::IceCandidatePublisher));
+    }
+    // Subscriber bucket is still full — independent per (peer, pc_type)
+    for _ in 0..200 {
+        assert!(limiter.try_acquire(peer, EventClass::IceCandidateSubscriber));
+    }
+    assert!(!limiter.try_acquire(peer, EventClass::IceCandidatePublisher));
+    assert!(!limiter.try_acquire(peer, EventClass::IceCandidateSubscriber));
+}
+
+#[tokio::test(start_paused = true)]
+async fn publisher_offer_rate_limit_refills_on_virtual_time() {
+    let limiter = VoiceRateLimiter::new();
+    let peer = Uuid::new_v4();
+
+    // Burst of 5 passes (capacity=5)
+    for _ in 0..5 {
+        assert!(limiter.try_acquire(peer, EventClass::PublisherOffer));
+    }
+    // Sixth fails
+    assert!(!limiter.try_acquire(peer, EventClass::PublisherOffer));
+
+    // Advance virtual time — refill is 1/sec, so 5 seconds = 5 tokens back (capped at capacity).
+    tokio::time::advance(Duration::from_secs(5)).await;
+
+    // 5 more pass
+    for _ in 0..5 {
+        assert!(limiter.try_acquire(peer, EventClass::PublisherOffer));
+    }
+    assert!(!limiter.try_acquire(peer, EventClass::PublisherOffer));
+}
+
+#[tokio::test(start_paused = true)]
+async fn rate_limits_are_per_peer() {
+    let limiter = VoiceRateLimiter::new();
+    let peer_a = Uuid::new_v4();
+    let peer_b = Uuid::new_v4();
+
+    // A exhausts publisher offer bucket
+    for _ in 0..5 {
+        assert!(limiter.try_acquire(peer_a, EventClass::PublisherOffer));
+    }
+    assert!(!limiter.try_acquire(peer_a, EventClass::PublisherOffer));
+
+    // B is unaffected
+    for _ in 0..5 {
+        assert!(limiter.try_acquire(peer_b, EventClass::PublisherOffer));
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn forget_peer_frees_all_buckets_for_that_peer() {
+    let limiter = VoiceRateLimiter::new();
+    let peer_a = Uuid::new_v4();
+    let peer_b = Uuid::new_v4();
+
+    // Exhaust multiple bucket classes for peer_a and peer_b
+    for _ in 0..5 {
+        assert!(limiter.try_acquire(peer_a, EventClass::PublisherOffer));
+    }
+    for _ in 0..10 {
+        assert!(limiter.try_acquire(peer_a, EventClass::MuteOrWebcamToggle));
+    }
+    for _ in 0..5 {
+        assert!(limiter.try_acquire(peer_b, EventClass::PublisherOffer));
+    }
+
+    limiter.forget_peer(peer_a);
+
+    // peer_a's fresh bucket is full again after forget; peer_b remains exhausted
+    for _ in 0..5 {
+        assert!(limiter.try_acquire(peer_a, EventClass::PublisherOffer));
+    }
+    assert!(!limiter.try_acquire(peer_b, EventClass::PublisherOffer));
+}

--- a/server/tests/integration/voice_rate_limit.rs
+++ b/server/tests/integration/voice_rate_limit.rs
@@ -1,6 +1,7 @@
 //! Integration tests for voice signaling rate limiting.
 
 use std::time::Duration;
+
 use uuid::Uuid;
 use vc_server::voice::rate_limit::{EventClass, VoiceRateLimiter};
 


### PR DESCRIPTION
## Summary
- Drop RTP packets from self-muted peers at the server (true mute enforcement)
- Add per-peer, per-event-class token bucket rate limiter for voice signaling events (ICE, publisher offer, mute toggle, etc.)
- Fix screen share slot leak when a duplicate `stream_id` arrives (reorder check before `limiter.start`)

PR A of the Phase 1 voice/screen-share critical-fixes spec. Five independent PRs total; recommended merge order A → B → C → D → E.

Spec: \`docs/superpowers/specs/2026-04-15-voice-screenshare-fixes-design.md\`
Plan: \`docs/superpowers/plans/2026-04-15-voice-screenshare-fixes.md\`

## Changes
- \`server/src/voice/peer.rs\` — rename \`muted\` → \`self_muted\`, add \`server_muted\` prep flag (for future moderation PR), add \`is_effectively_muted()\` accessor
- \`server/src/voice/track.rs\` — thread \`Arc<Peer>\` through \`spawn_rtp_forwarder\`, drop audio packets when peer is effectively muted (video unaffected)
- \`server/src/voice/rate_limit.rs\` — new \`TokenBucket\`/\`VoiceRateLimiter\` (uses \`tokio::time::Instant\` for virtual-time testing); convert \`VoiceStatsLimiter::default()\` to a proper \`Default\` impl
- \`server/src/voice/ws_handler.rs\` — wire rate limiter into \`handle_voice_event\` dispatch; forget peer buckets on leave
- \`server/src/ws/handlers.rs\` — also forget peer buckets on WS drop (ping timeout / TCP reset)
- \`server/src/voice/error.rs\` — \`RateLimited\` carries \`&'static str\` scope; add typed \`DuplicateStreamId\` variant (HTTP 409)
- \`server/src/voice/ws_handler.rs\` — screen share duplicate check now runs **before** \`limiter.start()\` so a duplicate doesn't leak a slot
- Tests: \`voice_mute_enforcement.rs\`, \`voice_rate_limit.rs\` integration tests (latter uses \`#[tokio::test(start_paused = true)]\` for deterministic refill assertions)

## Test plan
- [x] \`SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test -p vc-server --lib\` — 437/437 pass
- [x] \`cargo test -p vc-server --test integration voice_mute_enforcement voice_rate_limit\` — new tests pass
- [ ] Manual: two-client voice session, mute one, verify other no longer receives audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)