### PR TITLE
fix(client): buffer ICE candidates until remote description is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Android: rapid channel taps no longer silently drop navigation events (#8)
 - Android: scrolling up to read history no longer snaps back to the bottom when new messages arrive (#9)
 - Android: guild icons are properly announced as interactive buttons by screen readers (#24)
+- Browser voice connections no longer fail under restrictive NATs due to ICE candidate race (candidates now buffered until remote description is set)
 - Guild settings modal no longer overflows the viewport at 800px window width (#11)
 - Emoji delete button is now visible on touch devices instead of requiring hover (#31)
 - All `text-text-secondary/50` instances replaced with `text-text-muted` for WCAG-compliant contrast (#29)

--- a/client/src/lib/webrtc/__tests__/browser.test.ts
+++ b/client/src/lib/webrtc/__tests__/browser.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Unit tests for ICE candidate buffering in BrowserVoiceAdapter.
+ *
+ * Covers the buffer-until-setRemoteDescription logic added in
+ * `fix(client): buffer ICE candidates until remote description is set`.
+ *
+ * Restrictive-NAT deployments can deliver trickle ICE candidates before the
+ * SDP answer/offer is applied; adding them pre-SRD throws InvalidStateError
+ * and silently breaks connectivity. These tests verify the buffer + drain
+ * behaviour closes that race correctly.
+ *
+ * Race model under test: handlePublisher{Answer,Offer} resets the buffer,
+ * awaits setRemoteDescription, then drains. Candidates that arrive *during*
+ * the SRD await land in the (freshly reset) buffer and must drain afterwards.
+ * The fakes use a deferred promise so tests can interleave candidate arrivals
+ * at exactly that moment.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { BrowserVoiceAdapter } from "../browser";
+
+/** Identity constructor for RTCIceCandidate — stores init dict verbatim. */
+class FakeRtcIceCandidate {
+  constructor(public readonly init: RTCIceCandidateInit) {}
+}
+
+/** Passthrough for RTCSessionDescription. */
+class FakeRtcSessionDescription {
+  constructor(public readonly init: RTCSessionDescriptionInit) {}
+}
+
+/** Simple deferred/resolver for gating async steps in tests. */
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/**
+ * Fake RTCPeerConnection. `setRemoteDescription` awaits `srdGate.promise` so
+ * tests can queue ICE candidates between the handler's buffer-reset and its
+ * drain step. No state machine is modelled beyond what the buffer logic
+ * inspects, because the adapter gates `addIceCandidate` on its own
+ * `remoteDescriptionSet` flag.
+ */
+class FakeRtcPc {
+  remoteDesc: RTCSessionDescriptionInit | null = null;
+  addedCandidates: RTCIceCandidateInit[] = [];
+  setRemoteDescriptionCalls = 0;
+  srdGate = deferred<void>();
+
+  async setRemoteDescription(desc: FakeRtcSessionDescription): Promise<void> {
+    this.setRemoteDescriptionCalls += 1;
+    this.remoteDesc = desc.init;
+    await this.srdGate.promise;
+  }
+
+  async addIceCandidate(c: FakeRtcIceCandidate): Promise<void> {
+    this.addedCandidates.push(c.init);
+  }
+
+  async createAnswer(): Promise<RTCSessionDescriptionInit> {
+    return { type: "answer", sdp: "v=0\r\n" };
+  }
+
+  async setLocalDescription(_: RTCSessionDescriptionInit): Promise<void> {}
+
+  close(): void {}
+  addEventListener(): void {}
+  removeEventListener(): void {}
+  dispatchEvent(_: Event): boolean {
+    return false;
+  }
+
+  /** Allow the in-flight setRemoteDescription to resolve and arm a fresh gate. */
+  openSrd(): void {
+    this.srdGate.resolve();
+    this.srdGate = deferred<void>();
+  }
+}
+
+/** Construct a fresh PcState-like object. */
+function makePcState(pc: FakeRtcPc) {
+  return {
+    pc,
+    remoteDescriptionSet: false,
+    pendingCandidates: [] as RTCIceCandidateInit[],
+  };
+}
+
+/** Build a candidate JSON string as the adapter expects (it parses JSON). */
+function candidateJson(idx: number): string {
+  return JSON.stringify({
+    candidate: `candidate:${idx} 1 udp 2122260223 192.0.2.${idx % 256} ${40000 + idx} typ host`,
+    sdpMid: "0",
+    sdpMLineIndex: 0,
+  });
+}
+
+/** Yield to the microtask queue so awaited promises can progress. */
+async function flushMicrotasks(): Promise<void> {
+  // Two turns is plenty — the handler has at most 1 await between
+  // buffer-reset and the drain loop.
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+type AdapterPrivate = {
+  channelId: string;
+  publisherState: ReturnType<typeof makePcState>;
+  subscriberState: ReturnType<typeof makePcState>;
+};
+
+describe("BrowserVoiceAdapter ICE buffering", () => {
+  const CHANNEL_ID = "test-channel";
+  let adapter: BrowserVoiceAdapter;
+  let publisherPc: FakeRtcPc;
+  let subscriberPc: FakeRtcPc;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  // Silence noisy info logs from the adapter during tests.
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.stubGlobal("RTCPeerConnection", FakeRtcPc);
+    vi.stubGlobal("RTCIceCandidate", FakeRtcIceCandidate);
+    vi.stubGlobal("RTCSessionDescription", FakeRtcSessionDescription);
+
+    adapter = new BrowserVoiceAdapter();
+    publisherPc = new FakeRtcPc();
+    subscriberPc = new FakeRtcPc();
+
+    // Inject fake state directly. `private` is compile-time-only in TS, and
+    // exercising the buffer via `join()` would drag in getUserMedia, ICE
+    // fetches, and WebSocket wiring — overkill for a narrow buffer test.
+    const a = adapter as unknown as AdapterPrivate;
+    a.channelId = CHANNEL_ID;
+    a.publisherState = makePcState(publisherPc);
+    a.subscriberState = makePcState(subscriberPc);
+
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    logSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it("buffers candidates before remote description is set on publisher PC", async () => {
+    // Kick off the answer handler. It resets the buffer and then awaits SRD;
+    // our FakeRtcPc holds SRD open via srdGate.
+    const answerPromise = adapter.handlePublisherAnswer(
+      CHANNEL_ID,
+      "v=0\r\nanswer-sdp",
+    );
+    await flushMicrotasks();
+
+    // SRD is in-flight. remoteDescriptionSet is false, so incoming candidates
+    // buffer rather than throwing InvalidStateError.
+    const publisherState = (adapter as unknown as AdapterPrivate)
+      .publisherState;
+    expect(publisherState.remoteDescriptionSet).toBe(false);
+    expect(publisherPc.setRemoteDescriptionCalls).toBe(1);
+
+    for (let i = 0; i < 5; i += 1) {
+      const result = await adapter.handleIceCandidate(
+        CHANNEL_ID,
+        candidateJson(i),
+        "publisher",
+      );
+      expect(result.ok).toBe(true);
+    }
+
+    // Nothing applied yet — everything is in the buffer.
+    expect(publisherPc.addedCandidates).toHaveLength(0);
+    expect(publisherState.pendingCandidates).toHaveLength(5);
+
+    // Release SRD; the handler flips the flag and drains.
+    publisherPc.openSrd();
+    const result = await answerPromise;
+    expect(result.ok).toBe(true);
+
+    // All 5 candidates applied in order.
+    expect(publisherPc.addedCandidates).toHaveLength(5);
+    for (let i = 0; i < 5; i += 1) {
+      expect(publisherPc.addedCandidates[i]).toMatchObject({
+        sdpMid: "0",
+        sdpMLineIndex: 0,
+      });
+      expect(publisherPc.addedCandidates[i].candidate).toContain(
+        `candidate:${i} `,
+      );
+    }
+
+    // Buffer drained.
+    expect(publisherState.pendingCandidates).toHaveLength(0);
+    expect(publisherState.remoteDescriptionSet).toBe(true);
+  });
+
+  it("buffers candidates before remote description is set on subscriber PC", async () => {
+    const offerPromise = adapter.handleSubscriberOffer(
+      CHANNEL_ID,
+      "v=0\r\noffer-sdp",
+    );
+    await flushMicrotasks();
+
+    const subscriberState = (adapter as unknown as AdapterPrivate)
+      .subscriberState;
+    expect(subscriberState.remoteDescriptionSet).toBe(false);
+    expect(subscriberPc.setRemoteDescriptionCalls).toBe(1);
+
+    for (let i = 0; i < 5; i += 1) {
+      const result = await adapter.handleIceCandidate(
+        CHANNEL_ID,
+        candidateJson(i),
+        "subscriber",
+      );
+      expect(result.ok).toBe(true);
+    }
+
+    expect(subscriberPc.addedCandidates).toHaveLength(0);
+    expect(subscriberState.pendingCandidates).toHaveLength(5);
+
+    subscriberPc.openSrd();
+    const result = await offerPromise;
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      // handleSubscriberOffer returns the answer SDP.
+      expect(typeof result.value).toBe("string");
+      expect(result.value.length).toBeGreaterThan(0);
+    }
+
+    expect(subscriberPc.addedCandidates).toHaveLength(5);
+    expect(subscriberState.pendingCandidates).toHaveLength(0);
+    expect(subscriberState.remoteDescriptionSet).toBe(true);
+  });
+
+  it("drops candidates exceeding MAX_PENDING_CANDIDATES (100)", async () => {
+    const answerPromise = adapter.handlePublisherAnswer(
+      CHANNEL_ID,
+      "v=0\r\nanswer-sdp",
+    );
+    await flushMicrotasks();
+
+    // Queue 105 candidates while SRD is still in-flight. Entries 100..104
+    // should be dropped with a console.warn each; return values stay ok:true
+    // because the drop is deliberate, not an error condition for the caller.
+    for (let i = 0; i < 105; i += 1) {
+      const result = await adapter.handleIceCandidate(
+        CHANNEL_ID,
+        candidateJson(i),
+        "publisher",
+      );
+      expect(result.ok).toBe(true);
+    }
+
+    const publisherState = (adapter as unknown as AdapterPrivate)
+      .publisherState;
+    expect(publisherState.pendingCandidates).toHaveLength(100);
+
+    // Exactly 5 buffer-full warnings were logged.
+    const bufferFullWarns = warnSpy.mock.calls.filter(
+      (args: unknown[]) =>
+        typeof args[0] === "string" &&
+        args[0].includes("ICE candidate buffer full"),
+    );
+    expect(bufferFullWarns).toHaveLength(5);
+
+    // Drain: only the first 100 survive.
+    publisherPc.openSrd();
+    const result = await answerPromise;
+    expect(result.ok).toBe(true);
+    expect(publisherPc.addedCandidates).toHaveLength(100);
+    expect(publisherPc.addedCandidates[0].candidate).toContain(
+      "candidate:0 ",
+    );
+    expect(publisherPc.addedCandidates[99].candidate).toContain(
+      "candidate:99 ",
+    );
+  });
+
+  it("resets buffer on renegotiation", async () => {
+    // Round 1: 3 candidates arrive while the first SRD is in-flight.
+    const firstAnswer = adapter.handlePublisherAnswer(
+      CHANNEL_ID,
+      "v=0\r\nanswer-1",
+    );
+    await flushMicrotasks();
+
+    for (let i = 0; i < 3; i += 1) {
+      const result = await adapter.handleIceCandidate(
+        CHANNEL_ID,
+        candidateJson(i),
+        "publisher",
+      );
+      expect(result.ok).toBe(true);
+    }
+
+    const publisherState = (adapter as unknown as AdapterPrivate)
+      .publisherState;
+    expect(publisherState.pendingCandidates).toHaveLength(3);
+
+    publisherPc.openSrd();
+    const firstResult = await firstAnswer;
+    expect(firstResult.ok).toBe(true);
+    expect(publisherPc.addedCandidates).toHaveLength(3);
+    expect(publisherPc.setRemoteDescriptionCalls).toBe(1);
+    expect(publisherState.remoteDescriptionSet).toBe(true);
+    expect(publisherState.pendingCandidates).toHaveLength(0);
+
+    // Post-SRD, any new candidate applies directly (no buffering).
+    const directResult = await adapter.handleIceCandidate(
+      CHANNEL_ID,
+      candidateJson(100),
+      "publisher",
+    );
+    expect(directResult.ok).toBe(true);
+    expect(publisherPc.addedCandidates).toHaveLength(4);
+    expect(publisherPc.addedCandidates[3].candidate).toContain(
+      "candidate:100 ",
+    );
+    expect(publisherState.pendingCandidates).toHaveLength(0);
+
+    // Round 2: renegotiation. A second answer resets the buffer and awaits
+    // SRD again; any candidates arriving during that window must re-buffer
+    // under the new session and drain cleanly. Stale candidates from round 1
+    // must not reappear.
+    const secondAnswer = adapter.handlePublisherAnswer(
+      CHANNEL_ID,
+      "v=0\r\nanswer-2",
+    );
+    await flushMicrotasks();
+    expect(publisherState.remoteDescriptionSet).toBe(false);
+    expect(publisherState.pendingCandidates).toHaveLength(0);
+    expect(publisherPc.setRemoteDescriptionCalls).toBe(2);
+
+    for (let i = 200; i < 202; i += 1) {
+      const result = await adapter.handleIceCandidate(
+        CHANNEL_ID,
+        candidateJson(i),
+        "publisher",
+      );
+      expect(result.ok).toBe(true);
+    }
+    expect(publisherState.pendingCandidates).toHaveLength(2);
+    // No new addIceCandidate calls yet — still 4 from the direct post-SRD-1 add.
+    expect(publisherPc.addedCandidates).toHaveLength(4);
+
+    publisherPc.openSrd();
+    const secondResult = await secondAnswer;
+    expect(secondResult.ok).toBe(true);
+
+    // The 2 re-buffered candidates drained after the second SRD.
+    expect(publisherPc.addedCandidates).toHaveLength(6);
+    expect(publisherPc.addedCandidates[4].candidate).toContain(
+      "candidate:200 ",
+    );
+    expect(publisherPc.addedCandidates[5].candidate).toContain(
+      "candidate:201 ",
+    );
+    expect(publisherState.pendingCandidates).toHaveLength(0);
+    expect(publisherState.remoteDescriptionSet).toBe(true);
+  });
+});

--- a/client/src/lib/webrtc/browser.ts
+++ b/client/src/lib/webrtc/browser.ts
@@ -46,6 +46,28 @@ type AudioElementWithSinkId = HTMLAudioElement & {
   setSinkId(id: string): Promise<void>;
 };
 
+/**
+ * Maximum number of ICE candidates buffered per PeerConnection while waiting
+ * for `setRemoteDescription` to complete. Bounded to prevent unbounded memory
+ * growth from a misbehaving or malicious server.
+ */
+const MAX_PENDING_CANDIDATES = 100;
+
+/**
+ * Bundled peer-connection state: the PC itself plus the flag/queue needed to
+ * buffer ICE candidates that arrive before the remote description is applied.
+ *
+ * Restrictive-NAT deployments can deliver trickle ICE candidates before the
+ * SDP answer/offer is applied; adding them pre-SRD throws `InvalidStateError`
+ * and silently breaks connectivity. Buffering here, then draining on SRD
+ * completion, closes that race.
+ */
+interface PcState {
+  pc: RTCPeerConnection;
+  remoteDescriptionSet: boolean;
+  pendingCandidates: RTCIceCandidateInit[];
+}
+
 export class BrowserVoiceAdapter implements VoiceAdapter {
   private state: VoiceConnectionState = "disconnected";
   private channelId: string | null = null;
@@ -53,9 +75,9 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
   private deafened = false;
   private noiseSuppression = true;
 
-  // WebRTC — dual PeerConnection model
-  private publisherPC: RTCPeerConnection | null = null;
-  private subscriberPC: RTCPeerConnection | null = null;
+  // WebRTC — dual PeerConnection model with ICE candidate buffering
+  private publisherState: PcState | null = null;
+  private subscriberState: PcState | null = null;
   private localStream: MediaStream | null = null;
   private remoteStreams = new Map<string, MediaStream>();
 
@@ -119,7 +141,7 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
     console.log(`[BrowserVoiceAdapter] Joining channel: ${channelId}`);
 
     // Clean up any stale connection (e.g., from WebSocket reconnect)
-    if (this.publisherPC || this.subscriberPC) {
+    if (this.publisherState || this.subscriberState) {
       console.log("[BrowserVoiceAdapter] Cleaning up stale connection");
       this.cleanup();
     }
@@ -149,9 +171,17 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
       // Fetch ICE servers (STUN + TURN) from the API
       const config = await this.fetchIceConfig();
 
-      // Create dual PeerConnections
-      this.publisherPC = new RTCPeerConnection(config);
-      this.subscriberPC = new RTCPeerConnection(config);
+      // Create dual PeerConnections with bundled state for ICE buffering
+      this.publisherState = {
+        pc: new RTCPeerConnection(config),
+        remoteDescriptionSet: false,
+        pendingCandidates: [],
+      };
+      this.subscriberState = {
+        pc: new RTCPeerConnection(config),
+        remoteDescriptionSet: false,
+        pendingCandidates: [],
+      };
       this.setupPublisherPC(channelId);
       this.setupSubscriberPC(channelId);
 
@@ -213,7 +243,7 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
       // Add mic track to publisherPC — this triggers onnegotiationneeded
       // which creates and sends the publisher offer automatically
       this.localStream.getTracks().forEach((track) => {
-        this.publisherPC!.addTrack(track, this.localStream!);
+        this.publisherState!.pc.addTrack(track, this.localStream!);
       });
 
       console.log("[BrowserVoiceAdapter] Mic tracks added, publisher offer will be sent via onnegotiationneeded");
@@ -371,7 +401,8 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
       `[BrowserVoiceAdapter] Handling publisher answer for channel: ${channelId}`,
     );
 
-    if (!this.publisherPC) {
+    const state = this.publisherState;
+    if (!state) {
       return {
         ok: false,
         error: { type: "not_connected" },
@@ -389,11 +420,35 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
       };
     }
 
+    // Reset buffering flags for this negotiation — any candidates queued from
+    // a prior session or stale renegotiation must not be reused.
+    state.remoteDescriptionSet = false;
+    state.pendingCandidates = [];
+
     try {
-      await this.publisherPC.setRemoteDescription(
+      await state.pc.setRemoteDescription(
         new RTCSessionDescription({ type: "answer", sdp }),
       );
       console.log("[BrowserVoiceAdapter] Publisher answer applied");
+
+      // Mark remote description applied and drain any buffered candidates.
+      state.remoteDescriptionSet = true;
+      const candidates = state.pendingCandidates.splice(0);
+      for (const candidate of candidates) {
+        try {
+          await state.pc.addIceCandidate(new RTCIceCandidate(candidate));
+        } catch (err) {
+          console.warn(
+            "[BrowserVoiceAdapter] Drained publisher ICE candidate failed:",
+            err,
+          );
+        }
+      }
+      if (candidates.length > 0) {
+        console.log(
+          `[BrowserVoiceAdapter] Drained ${candidates.length} buffered publisher ICE candidate(s)`,
+        );
+      }
 
       // Release negotiation lock
       this.isNegotiating = false;
@@ -401,7 +456,7 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
       // Drain pending negotiation
       if (this.pendingNegotiation) {
         this.pendingNegotiation = false;
-        this.publisherPC.dispatchEvent(new Event("negotiationneeded"));
+        state.pc.dispatchEvent(new Event("negotiationneeded"));
       }
 
       return { ok: true, value: undefined };
@@ -426,7 +481,8 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
       `[BrowserVoiceAdapter] Handling subscriber offer for channel: ${channelId}`,
     );
 
-    if (!this.subscriberPC) {
+    const state = this.subscriberState;
+    if (!state) {
       return {
         ok: false,
         error: { type: "not_connected" },
@@ -444,12 +500,37 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
       };
     }
 
+    // Reset buffering flags for this negotiation — any candidates queued from
+    // a prior session or stale renegotiation must not be reused.
+    state.remoteDescriptionSet = false;
+    state.pendingCandidates = [];
+
     try {
-      await this.subscriberPC.setRemoteDescription(
+      await state.pc.setRemoteDescription(
         new RTCSessionDescription({ type: "offer", sdp }),
       );
-      const answer = await this.subscriberPC.createAnswer();
-      await this.subscriberPC.setLocalDescription(answer);
+
+      // Mark remote description applied and drain any buffered candidates.
+      state.remoteDescriptionSet = true;
+      const candidates = state.pendingCandidates.splice(0);
+      for (const candidate of candidates) {
+        try {
+          await state.pc.addIceCandidate(new RTCIceCandidate(candidate));
+        } catch (err) {
+          console.warn(
+            "[BrowserVoiceAdapter] Drained subscriber ICE candidate failed:",
+            err,
+          );
+        }
+      }
+      if (candidates.length > 0) {
+        console.log(
+          `[BrowserVoiceAdapter] Drained ${candidates.length} buffered subscriber ICE candidate(s)`,
+        );
+      }
+
+      const answer = await state.pc.createAnswer();
+      await state.pc.setLocalDescription(answer);
 
       console.log("[BrowserVoiceAdapter] Subscriber answer created");
 
@@ -484,9 +565,10 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
   ): Promise<VoiceResult<void>> {
     const startTime = performance.now();
 
-    const pc = pcType === "subscriber" ? this.subscriberPC : this.publisherPC;
+    const state =
+      pcType === "subscriber" ? this.subscriberState : this.publisherState;
 
-    if (!pc) {
+    if (!state) {
       console.warn(
         `[BrowserVoiceAdapter] No ${pcType} peer connection for ICE candidate`,
       );
@@ -511,9 +593,28 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
     }
 
     try {
-      // Parse and add ICE candidate immediately (critical for NAT traversal)
-      const candidateInit = JSON.parse(candidate);
-      await pc.addIceCandidate(new RTCIceCandidate(candidateInit));
+      const candidateInit: RTCIceCandidateInit = JSON.parse(candidate);
+
+      // Buffer until `setRemoteDescription` completes. On restrictive NATs the
+      // server's ICE candidates can arrive before the SDP answer/offer is
+      // applied; adding them early throws InvalidStateError and silently
+      // breaks the connection.
+      if (!state.remoteDescriptionSet) {
+        if (state.pendingCandidates.length >= MAX_PENDING_CANDIDATES) {
+          console.warn(
+            `[BrowserVoiceAdapter] ICE candidate buffer full for ${pcType} (${MAX_PENDING_CANDIDATES} queued), dropping candidate`,
+          );
+          return { ok: true, value: undefined };
+        }
+        state.pendingCandidates.push(candidateInit);
+        const elapsed = performance.now() - startTime;
+        console.log(
+          `[BrowserVoiceAdapter] ICE candidate (${pcType}) buffered — remote description not yet set (${elapsed.toFixed(2)}ms, ${state.pendingCandidates.length} pending)`,
+        );
+        return { ok: true, value: undefined };
+      }
+
+      await state.pc.addIceCandidate(new RTCIceCandidate(candidateInit));
 
       const elapsed = performance.now() - startTime;
       console.log(
@@ -572,11 +673,11 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
   }
 
   async getConnectionMetrics(): Promise<ConnectionMetrics | null> {
-    if (!this.publisherPC) return null;
+    if (!this.publisherState) return null;
 
     try {
       // RTT comes from the publisher PC's candidate-pair stats
-      const pubStats = await this.publisherPC.getStats();
+      const pubStats = await this.publisherState.pc.getStats();
       let latency = 0;
       let jitter = 0;
       let totalLost = 0;
@@ -589,8 +690,8 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
       });
 
       // Inbound audio stats come from the subscriber PC (incoming tracks)
-      if (this.subscriberPC) {
-        const subStats = await this.subscriberPC.getStats();
+      if (this.subscriberState) {
+        const subStats = await this.subscriberState.pc.getStats();
         subStats.forEach((report) => {
           if (report.type === "inbound-rtp" && report.kind === "audio") {
             totalLost += report.packetsLost ?? 0;
@@ -734,7 +835,7 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
     this.inputDeviceId = deviceId;
 
     // If already in a call, restart the stream with the new device
-    if (this.localStream && this.publisherPC) {
+    if (this.localStream && this.publisherState) {
       try {
         // Stop VAD before replacing the stream — the cloned monitor track
         // references the old mic and would go stale (deliver silence).
@@ -757,7 +858,7 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
           await navigator.mediaDevices.getUserMedia(constraints);
 
         // Replace tracks in publisher peer connection
-        const sender = this.publisherPC
+        const sender = this.publisherState.pc
           .getSenders()
           .find((s) => s.track?.kind === "audio");
         if (sender) {
@@ -871,7 +972,8 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
   async startScreenShare(
     options?: ScreenShareOptions,
   ): Promise<VoiceResult<void>> {
-    if (!this.publisherPC) {
+    const publisher = this.publisherState;
+    if (!publisher) {
       return { ok: false, error: { type: "not_connected" } };
     }
 
@@ -889,13 +991,13 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
 
       // Add video track to publisher PC
       const videoTrack = stream.getVideoTracks()[0];
-      const videoSender = this.publisherPC.addTrack(videoTrack, stream);
+      const videoSender = publisher.pc.addTrack(videoTrack, stream);
 
       // Add audio track if present
       let audioSender: RTCRtpSender | null = null;
       const audioTrack = stream.getAudioTracks()[0];
       if (audioTrack) {
-        audioSender = this.publisherPC.addTrack(audioTrack, stream);
+        audioSender = publisher.pc.addTrack(audioTrack, stream);
       }
 
       // onnegotiationneeded fires automatically -> creates offer -> server answers -> RTP flows
@@ -919,7 +1021,8 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
   }
 
   async stopScreenShare(streamId?: string): Promise<VoiceResult<void>> {
-    if (!this.publisherPC) {
+    const publisher = this.publisherState;
+    if (!publisher) {
       return { ok: false, error: { type: "not_connected" } };
     }
 
@@ -940,9 +1043,9 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
     }
 
     // Remove tracks from publisher PC
-    this.publisherPC.removeTrack(share.videoSender);
+    publisher.pc.removeTrack(share.videoSender);
     if (share.audioSender) {
-      this.publisherPC.removeTrack(share.audioSender);
+      publisher.pc.removeTrack(share.audioSender);
     }
 
     // Stop media tracks
@@ -982,7 +1085,8 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
   }
 
   async startWebcam(options?: WebcamOptions): Promise<VoiceResult<void>> {
-    if (!this.publisherPC) {
+    const publisher = this.publisherState;
+    if (!publisher) {
       return { ok: false, error: { type: "not_connected" } };
     }
 
@@ -1024,7 +1128,7 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
 
       // Add video track to publisher peer connection with simulcast encodings
       const webcamBitrate = QUALITY_BITRATES[options?.quality ?? "medium"];
-      const webcamTransceiver = this.publisherPC.addTransceiver(videoTrack, {
+      const webcamTransceiver = publisher.pc.addTransceiver(videoTrack, {
         direction: "sendonly",
         streams: [stream],
         sendEncodings: simulcastEncodings(webcamBitrate),
@@ -1195,8 +1299,8 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
 
   private cleanupWebcamState(): void {
     // Remove track from publisher peer connection
-    if (this.publisherPC && this.webcamSender) {
-      this.publisherPC.removeTrack(this.webcamSender);
+    if (this.publisherState && this.webcamSender) {
+      this.publisherState.pc.removeTrack(this.webcamSender);
     }
 
     // Stop the stream tracks
@@ -1210,13 +1314,15 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
   }
 
   private setupPublisherPC(channelId: string) {
-    if (!this.publisherPC) return;
+    const publisher = this.publisherState;
+    if (!publisher) return;
 
     // Client-initiated negotiation: create offer and send to server
     // Uses a negotiation lock to prevent concurrent offers when multiple
     // tracks are added in quick succession (e.g., mic + screen share).
-    this.publisherPC.onnegotiationneeded = async () => {
-      if (!this.publisherPC) return;
+    publisher.pc.onnegotiationneeded = async () => {
+      const current = this.publisherState;
+      if (!current) return;
 
       if (this.isNegotiating) {
         this.pendingNegotiation = true;
@@ -1225,8 +1331,8 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
 
       this.isNegotiating = true;
       try {
-        const offer = await this.publisherPC.createOffer();
-        await this.publisherPC.setLocalDescription(offer);
+        const offer = await current.pc.createOffer();
+        await current.pc.setLocalDescription(offer);
 
         const { wsSend } = await import("@/lib/tauri");
         await wsSend({
@@ -1241,7 +1347,7 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
     };
 
     // ICE candidate handler for publisher
-    this.publisherPC.onicecandidate = (event) => {
+    publisher.pc.onicecandidate = (event) => {
       if (event.candidate) {
         const candidateJson = JSON.stringify(event.candidate.toJSON());
         // Send ICE candidate with pc_type via WS
@@ -1261,8 +1367,8 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
     };
 
     // Connection state change — publisher PC determines connected state
-    this.publisherPC.onconnectionstatechange = () => {
-      const state = this.publisherPC!.connectionState;
+    publisher.pc.onconnectionstatechange = () => {
+      const state = this.publisherState?.pc.connectionState;
       console.log(`[BrowserVoiceAdapter] Publisher connection state: ${state}`);
 
       switch (state) {
@@ -1295,10 +1401,11 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
   }
 
   private setupSubscriberPC(channelId: string) {
-    if (!this.subscriberPC) return;
+    const subscriber = this.subscriberState;
+    if (!subscriber) return;
 
     // Remote track handler — all remote tracks arrive on subscriberPC
-    this.subscriberPC.ontrack = (event) => {
+    subscriber.pc.ontrack = (event) => {
       const track = event.track;
       const stream = event.streams[0];
 
@@ -1369,7 +1476,7 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
     };
 
     // ICE candidate handler for subscriber
-    this.subscriberPC.onicecandidate = (event) => {
+    subscriber.pc.onicecandidate = (event) => {
       if (event.candidate) {
         const candidateJson = JSON.stringify(event.candidate.toJSON());
         import("@/lib/tauri")
@@ -1388,8 +1495,8 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
     };
 
     // Subscriber connection state (log only, publisher determines main state)
-    this.subscriberPC.onconnectionstatechange = () => {
-      const state = this.subscriberPC?.connectionState;
+    subscriber.pc.onconnectionstatechange = () => {
+      const state = this.subscriberState?.pc.connectionState;
       console.log(`[BrowserVoiceAdapter] Subscriber connection state: ${state}`);
 
       if (state === "failed") {
@@ -1527,14 +1634,14 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
       this.localStream = null;
     }
 
-    // Close both peer connections
-    if (this.publisherPC) {
-      this.publisherPC.close();
-      this.publisherPC = null;
+    // Close both peer connections (also drops buffered ICE candidates)
+    if (this.publisherState) {
+      this.publisherState.pc.close();
+      this.publisherState = null;
     }
-    if (this.subscriberPC) {
-      this.subscriberPC.close();
-      this.subscriberPC = null;
+    if (this.subscriberState) {
+      this.subscriberState.pc.close();
+      this.subscriberState = null;
     }
 
     // Clear remote streams


### PR DESCRIPTION
## Summary
- Buffer WebRTC ICE candidates per-PC until \`setRemoteDescription\` completes, then drain; fixes silent voice failures on restrictive NATs (TURN path)
- Matches the existing Android buffering pattern (MAX 100 per PC)

PR B of the Phase 1 voice/screen-share critical-fixes spec.

Spec: \`docs/superpowers/specs/2026-04-15-voice-screenshare-fixes-design.md\`
Plan: \`docs/superpowers/plans/2026-04-15-voice-screenshare-fixes.md\`

## Changes
- \`client/src/lib/webrtc/browser.ts\`:
  - New \`PcState { pc, remoteDescriptionSet, pendingCandidates }\` bundle
  - Fields \`publisherPC\`/\`subscriberPC: RTCPeerConnection\` → \`publisherState\`/\`subscriberState: PcState\` (47 internal references updated)
  - \`handleIceCandidate\` now buffers when \`!remoteDescriptionSet\` and caps at \`MAX_PENDING_CANDIDATES = 100\`
  - \`handlePublisherAnswer\` / \`handleSubscriberOffer\` reset the buffer before \`setRemoteDescription\` (stale ufrag/pwd) and drain after success
  - \`cleanup()\` closes both PCs before nulling state
- \`client/src/lib/webrtc/__tests__/browser.test.ts\` (new) — 4 vitest tests using a deferred SRD gate to simulate the exact race

## Test plan
- [x] \`bun run test:run\` — all 581 tests pass (4 new in \`browser.test.ts\`)
- [x] \`bun run build\` clean
- [x] \`bunx tsc --noEmit\` clean
- [ ] Manual: voice join on restrictive NAT where TURN is required

🤖 Generated with [Claude Code](https://claude.com/claude-code)