### PR TITLE
fix(voice): Tauri RTP protocol — per-session seq/ts, VP8 payload_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sending multiple messages rapidly no longer reorders them in the chat view
 - Slow WebSocket clients are now disconnected instead of blocking the message bus
 - Typing indicators no longer trigger database permission queries on every keystroke
+- Desktop voice audio is now clear at session start (fixed RTP sequence number regression on reconnect)
+- Desktop screen share now actually reaches other participants (fixed VP8 payload type)
 
 ### Security
 - E2EE Megolm session cache is now cleared on logout — prevents stale session keys from persisting

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10648,6 +10648,7 @@ dependencies = [
  "nnnoiseless",
  "nokhwa",
  "opus",
+ "rand 0.8.5",
  "reqwest 0.13.2",
  "rodio",
  "rusqlite",

--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -91,6 +91,7 @@ hmac = "0.12"
 aes-gcm = "0.10"
 argon2.workspace = true
 getrandom = "0.2"
+rand = "0.8"
 
 # Zeroize
 zeroize.workspace = true

--- a/client/src-tauri/src/commands/voice.rs
+++ b/client/src-tauri/src/commands/voice.rs
@@ -2,7 +2,7 @@
 //!
 //! Tauri commands for voice chat functionality.
 
-use std::sync::atomic::{AtomicU16, AtomicU32, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use tauri::{command, AppHandle, Emitter, State};
@@ -716,9 +716,11 @@ async fn send_audio_to_track(
     track: Arc<TrackLocalStaticRTP>,
     mut audio_rx: mpsc::Receiver<Vec<u8>>,
 ) {
-    // RTP state - using atomics for simplicity
-    static SEQUENCE_NUMBER: AtomicU16 = AtomicU16::new(0);
-    static TIMESTAMP: AtomicU32 = AtomicU32::new(0);
+    // Per RFC 3550 §5.1: start seq and timestamp at random values for each session.
+    // SSRC is already per-session (derived from SystemTime at spawn), so combining
+    // with a random seq start ensures receivers see a fresh stream after reconnect.
+    let mut seq: u16 = rand::random();
+    let mut timestamp: u32 = rand::random();
 
     // Calculate samples per frame (20ms at 48kHz)
     const SAMPLES_PER_FRAME: u32 = SAMPLE_RATE / 1000 * FRAME_SIZE_MS as u32;
@@ -736,10 +738,6 @@ async fn send_audio_to_track(
     info!("Starting RTP audio sender task (SSRC: {})", ssrc);
 
     while let Some(opus_data) = audio_rx.recv().await {
-        // Get current sequence number and timestamp
-        let seq = SEQUENCE_NUMBER.fetch_add(1, Ordering::Relaxed);
-        let ts = TIMESTAMP.fetch_add(SAMPLES_PER_FRAME, Ordering::Relaxed);
-
         // Create RTP packet
         let rtp_packet = RtpPacket {
             header: webrtc::rtp::header::Header {
@@ -749,7 +747,7 @@ async fn send_audio_to_track(
                 marker: false,
                 payload_type: OPUS_PAYLOAD_TYPE,
                 sequence_number: seq,
-                timestamp: ts,
+                timestamp,
                 ssrc,
                 ..Default::default()
             },
@@ -761,6 +759,11 @@ async fn send_audio_to_track(
             warn!("Failed to write RTP packet: {}", e);
             // Don't break - connection might recover
         }
+
+        // Advance state for next packet. The first packet uses the random
+        // initial values per RFC 3550 §5.1.
+        seq = seq.wrapping_add(1);
+        timestamp = timestamp.wrapping_add(SAMPLES_PER_FRAME);
     }
 
     info!("RTP audio sender task ended");

--- a/client/src-tauri/src/video/rtp.rs
+++ b/client/src-tauri/src/video/rtp.rs
@@ -17,6 +17,11 @@ use super::{EncodedPacket, VideoError};
 /// Maximum RTP payload size before fragmentation.
 const MAX_PAYLOAD_SIZE: usize = 1200;
 
+/// VP8 payload type — matches the server media engine's VP8 codec registration.
+///
+/// See also: `server/src/voice/sfu.rs` and this crate's `webrtc::mod::<API build>` media engine.
+pub const VP8_PAYLOAD_TYPE: u8 = 96;
+
 /// VP8 RTP payload descriptor (1-byte, no extensions).
 ///
 /// Layout (MSB-first):
@@ -36,6 +41,7 @@ const fn build_vp8_payload_descriptor(is_first: bool) -> u8 {
 pub struct VideoRtpSender {
     track: Arc<TrackLocalStaticRTP>,
     seq: AtomicU16,
+    ssrc: u32,
 }
 
 impl VideoRtpSender {
@@ -43,7 +49,8 @@ impl VideoRtpSender {
     pub fn new(track: Arc<TrackLocalStaticRTP>) -> Self {
         Self {
             track,
-            seq: AtomicU16::new(0),
+            seq: AtomicU16::new(rand::random()),
+            ssrc: rand::random(),
         }
     }
 
@@ -80,9 +87,11 @@ impl VideoRtpSender {
             let rtp_packet = RtpPacket {
                 header: Header {
                     version: 2,
+                    payload_type: VP8_PAYLOAD_TYPE,
                     marker: is_last,
                     sequence_number: seq,
                     timestamp,
+                    ssrc: self.ssrc,
                     ..Default::default()
                 },
                 payload: payload.into(),

--- a/client/src-tauri/src/webrtc/mod.rs
+++ b/client/src-tauri/src/webrtc/mod.rs
@@ -28,6 +28,8 @@ use webrtc::track::track_local::track_local_static_rtp::TrackLocalStaticRTP;
 use webrtc::track::track_local::TrackLocal;
 use webrtc::track::track_remote::TrackRemote;
 
+use crate::video::rtp::VP8_PAYLOAD_TYPE;
+
 /// Build 3-layer simulcast encoding parameters (high / medium / low).
 ///
 /// **Limitation:** webrtc-rs 0.11 `add_transceiver_from_track` accepts
@@ -193,7 +195,7 @@ impl WebRtcClient {
                         sdp_fmtp_line: String::new(),
                         rtcp_feedback: video_rtcp_feedback,
                     },
-                    payload_type: 96,
+                    payload_type: VP8_PAYLOAD_TYPE,
                     ..Default::default()
                 },
                 RTPCodecType::Video,


### PR DESCRIPTION
## Summary
- Reset RTP sequence number and timestamp per voice session (RFC 3550 §5.1); audio is now clear at session start after reconnects
- Set VP8 \`payload_type=96\` and a stable SSRC on outbound video RTP packets; screen share now actually reaches remote participants (was defaulted to \`payload_type=0\` which the SFU silently rejected)

PR C of the Phase 1 voice/screen-share critical-fixes spec.

Spec: \`docs/superpowers/specs/2026-04-15-voice-screenshare-fixes-design.md\`
Plan: \`docs/superpowers/plans/2026-04-15-voice-screenshare-fixes.md\`

## Changes
- \`client/src-tauri/src/commands/voice.rs\` — replace process-static \`SEQUENCE_NUMBER\`/\`TIMESTAMP\` atomics with per-task \`let mut seq: u16 = rand::random()\` / \`timestamp: u32 = rand::random()\` at the top of \`send_audio_to_track\`; advance at end of loop body so first packet uses the random initial values
- \`client/src-tauri/src/video/rtp.rs\` — add \`pub const VP8_PAYLOAD_TYPE: u8 = 96;\`, add stable \`ssrc: u32\` field on \`VideoRtpSender\`, set both fields explicitly in RTP header construction (was defaulted to 0 via \`..Default::default()\`); seq starts at \`rand::random()\` too
- \`client/src-tauri/src/webrtc/mod.rs\` — import \`VP8_PAYLOAD_TYPE\`, reference it in the VP8 codec registration (eliminates the magic 96 literal)
- \`client/src-tauri/Cargo.toml\` — add \`rand = \"0.8\"\` as direct dep (already transitively present via \`webrtc\`)

## Test plan
- [ ] \`cargo clippy\` / \`cargo test\` — blocked locally by pre-existing libspa/pipewire header mismatch on Linux dev hosts (documented in \`docs/superpowers/plans/2026-03-23-pr485-review-fixes.md\`); verify on CI
- [ ] Manual: Tauri desktop voice session — no audio glitch at reconnect (Fix 5); Tauri screen share visible on another client (Fix 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)