### PR TITLE
docs: Phase 2.5 open-topics cleanup — spec + 4 block plans

### DIFF
--- a/docs/superpowers/plans/2026-04-16-block1-ci-drift-fix.md
+++ b/docs/superpowers/plans/2026-04-16-block1-ci-drift-fix.md
@@ -1,0 +1,426 @@
+# Block 1 — CI Drift Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn `main`'s CI green without admin override by fixing the nightly-rustfmt docstring drift in `server/src/ws/handlers.rs:73`, patching the `rustls-webpki` RUSTSEC-2026-0099 advisory via `cargo update`, routing `Makefile` fmt targets through nightly toolchain, and documenting the nightly requirement in standards.
+
+**Architecture:** Four surgical commits in one PR. No new code. Two fixes for the CI red (fmt + advisory), two preventive changes so contributors don't re-introduce the same drift (Makefile + docs).
+
+**Tech Stack:** Rust stable + nightly (for rustfmt), `cargo`, `cargo-deny`, GNU Make.
+
+**Spec:** `docs/superpowers/specs/2026-04-16-open-topics-cleanup-design.md` — Block 1.
+
+**Parallelization safe:** Single PR. No cross-PR dependencies within Phase 2.5. **Block 1 is the hard prerequisite for Block 2**; Blocks 3 and 4 can proceed in parallel to Block 1's review.
+
+---
+
+## Pre-flight Check (BLOCKING — run before creating the worktree)
+
+- [ ] **Confirm `nightly` rustfmt is installed**
+
+```bash
+rustup toolchain list | grep -E '^nightly'
+```
+
+Expected: a line like `nightly-x86_64-unknown-linux-gnu`. If absent, install:
+
+```bash
+rustup toolchain install nightly --profile minimal -c rustfmt
+```
+
+- [ ] **Confirm `cargo-deny` is available**
+
+```bash
+cargo deny --version
+```
+
+Expected: something like `cargo-deny 0.X.Y`. If absent, install:
+
+```bash
+cargo install cargo-deny --locked
+```
+
+- [ ] **Confirm drift still matches spec's assumptions**
+
+```bash
+cd /home/detair/GIT/detair/kaiku
+cargo +nightly fmt --all -- --check 2>&1 | grep -E "^Diff in" | head -5
+```
+
+Expected: exactly one line matching `Diff in /home/.../server/src/ws/handlers.rs:73:`. If more lines appear (other files have drifted since 2026-04-16), expand Task 1's scope but otherwise proceed.
+
+```bash
+cargo deny check advisories 2>&1 | grep -E "RUSTSEC-2026-0099"
+```
+
+Expected: at least one hit referencing `rustls-webpki 0.103.10`. If RUSTSEC-2026-0099 no longer appears (upstream yanked or `Cargo.lock` already updated), skip Task 2.
+
+---
+
+## Worktree Setup (run once after pre-flight passes)
+
+```bash
+cd /home/detair/GIT/detair/kaiku
+git fetch origin
+git worktree add .claude/worktrees/ci-drift-fix -b fix/ci-drift-main origin/main
+cd .claude/worktrees/ci-drift-fix
+```
+
+Working branch: `fix/ci-drift-main`, based on latest `origin/main`. Working directory for all tasks below: `/home/detair/GIT/detair/kaiku/.claude/worktrees/ci-drift-fix`.
+
+---
+
+## File Map
+
+| Path | Action |
+|------|--------|
+| `server/src/ws/handlers.rs` | Modify — apply nightly rustfmt (Task 1) |
+| `Cargo.lock` | Modify — `cargo update -p rustls-webpki` delta (Task 2) |
+| `Makefile` | Modify — lines 139, 143 (Task 3) |
+| `docs/developer-guide/development/standards.md` | Modify — add nightly-rustfmt note (Task 4) |
+
+---
+
+## Task 1: Apply `cargo +nightly fmt` to the repo
+
+**Files:**
+- Modify: `server/src/ws/handlers.rs:73` (and any other files the nightly formatter flags)
+
+- [ ] **Step 1: Confirm the failing check reproduces locally**
+
+```bash
+cargo +nightly fmt --all -- --check
+```
+
+Expected: exit code 1, diff output mentioning `server/src/ws/handlers.rs:73`.
+
+- [ ] **Step 2: Apply the formatter**
+
+```bash
+cargo +nightly fmt --all
+```
+
+Expected: no stdout output, exit code 0.
+
+- [ ] **Step 3: Confirm the check now passes**
+
+```bash
+cargo +nightly fmt --all -- --check
+```
+
+Expected: exit code 0, no diff output.
+
+- [ ] **Step 4: Inspect the diff**
+
+```bash
+git diff --stat
+git diff server/src/ws/handlers.rs
+```
+
+Expected: exactly one file changed (`server/src/ws/handlers.rs`), delta concentrated around line 73 — a docstring rewrap. If more files show a diff, read each to confirm the change is purely cosmetic (whitespace, line wrapping in comments/docstrings) before proceeding.
+
+- [ ] **Step 5: Run the server test suite to verify no semantic regression**
+
+```bash
+cargo test -p vc-server 2>&1 | tail -10
+```
+
+Expected: `test result: ok`. Fmt-only changes cannot regress tests, but running them is cheap insurance against accidentally-included unrelated edits.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/src/ws/handlers.rs
+git status --short  # confirm only this file (plus any other fmt-only files)
+git commit -m "fix(infra): apply cargo +nightly fmt to handlers.rs docstring"
+```
+
+If Step 4 revealed additional fmt-touched files outside `server/src/ws/handlers.rs`, stage them in the same commit — the message still applies (the drift is one topic).
+
+---
+
+## Task 2: Bump `rustls-webpki` for RUSTSEC-2026-0099
+
+**Files:**
+- Modify: `Cargo.lock` (only)
+
+- [ ] **Step 1: Confirm the advisory reproduces**
+
+```bash
+cargo deny check advisories 2>&1 | grep -E "RUSTSEC-2026-0099|rustls-webpki" | head -5
+```
+
+Expected: output referencing `RUSTSEC-2026-0099` and `rustls-webpki v0.103.10`.
+
+- [ ] **Step 2: Run the update**
+
+```bash
+cargo update -p rustls-webpki
+```
+
+Expected: stdout like `Updating rustls-webpki v0.103.10 -> v0.103.12` (exact version ≥0.103.12).
+
+- [ ] **Step 3: Verify the advisory is resolved**
+
+```bash
+cargo deny check advisories 2>&1 | grep -E "RUSTSEC-2026-0099"
+```
+
+Expected: no output (exit code from the prior pipe may be non-zero; that's OK). If RUSTSEC-2026-0099 still appears, the update did not reach a non-vulnerable version — investigate `Cargo.toml` pins or transitive constraints.
+
+- [ ] **Step 4: Confirm the full advisories check now passes**
+
+```bash
+cargo deny check advisories 2>&1 | tail -5
+```
+
+Expected: `advisories ok` or equivalent green terminal line. Any other RUSTSEC hits that were already on `main` before this task remain — we are only patching `RUSTSEC-2026-0099`.
+
+- [ ] **Step 5: Run server tests to ensure no binary-compat break**
+
+```bash
+cargo test -p vc-server 2>&1 | tail -5
+```
+
+Expected: `test result: ok`. `rustls-webpki` is a transitive dep of `rustls`; a patch bump (0.103.10 → 0.103.12) should be ABI-stable, but verification is cheap.
+
+- [ ] **Step 6: Inspect `Cargo.lock` delta**
+
+```bash
+git diff Cargo.lock | head -40
+```
+
+Expected: delta localized to `rustls-webpki` version entries. If unrelated deps moved (e.g., `tokio`, `serde`), stop and investigate — that would signal an unintended full-dependency-graph update.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Cargo.lock
+git commit -m "chore(infra): cargo update -p rustls-webpki for RUSTSEC-2026-0099"
+```
+
+---
+
+## Task 3: Route `Makefile` fmt targets through nightly toolchain
+
+**Files:**
+- Modify: `Makefile:139` and `Makefile:143`
+
+- [ ] **Step 1: Confirm current target contents**
+
+```bash
+sed -n '138,145p' Makefile
+```
+
+Expected:
+```
+fmt: ## Format all code
+	cargo fmt --all
+	cd client && bun run format
+
+fmt-check: ## Check code formatting
+	cargo fmt --all -- --check
+	cd client && bun run format -- --check
+```
+
+- [ ] **Step 2: Edit the two `cargo fmt` invocations**
+
+Use `sed`, your editor of choice, or the Edit tool. Target transformations:
+
+- Line 139: `	cargo fmt --all` → `	cargo +nightly fmt --all`
+- Line 143: `	cargo fmt --all -- --check` → `	cargo +nightly fmt --all -- --check`
+
+(Preserve the leading TAB character — `Makefile` requires tabs for recipe lines, not spaces.)
+
+One-liner if preferred:
+
+```bash
+sed -i -E 's|^\tcargo fmt --all$|\tcargo +nightly fmt --all|; s|^\tcargo fmt --all -- --check$|\tcargo +nightly fmt --all -- --check|' Makefile
+```
+
+- [ ] **Step 3: Verify edits**
+
+```bash
+sed -n '138,145p' Makefile
+```
+
+Expected:
+```
+fmt: ## Format all code
+	cargo +nightly fmt --all
+	cd client && bun run format
+
+fmt-check: ## Check code formatting
+	cargo +nightly fmt --all -- --check
+	cd client && bun run format -- --check
+```
+
+Leading characters must be tabs — if `cat -A Makefile | sed -n '139p'` shows `^Icargo +nightly fmt --all$` then tabs are preserved.
+
+- [ ] **Step 4: Sanity-run `make fmt-check`**
+
+```bash
+make fmt-check
+```
+
+Expected: exit code 0 — prior tasks fixed the Rust side; the client `bun run format --check` should also pass on clean main. If the client-side check fails, that's pre-existing frontend drift and out of Block 1's scope; revert only the Makefile edit and escalate.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Makefile
+git commit -m "chore(infra): route Makefile fmt targets through nightly toolchain"
+```
+
+---
+
+## Task 4: Document nightly rustfmt requirement in standards.md
+
+**Files:**
+- Modify: `docs/developer-guide/development/standards.md` — append a new subsection under an existing "Development" / "Rust Tooling" heading if one exists, otherwise append a new top-level section before the final `---` separator.
+
+- [ ] **Step 1: Locate an appropriate insertion point**
+
+```bash
+grep -nE '^##|^###' docs/developer-guide/development/standards.md | head -40
+```
+
+Find a section like "Rust" / "Development Tooling" / "Formatting" if present. If none fits cleanly, append a new `## Rust Formatting` section at the end of the file.
+
+- [ ] **Step 2: Write the note**
+
+Insert this content (adjust heading depth to match the surrounding document):
+
+```markdown
+### Rust Formatting Requires Nightly `rustfmt`
+
+Kaiku's `rustfmt.toml` enables unstable features (`wrap_comments`, `format_code_in_doc_comments`, `comment_width = 100`, `normalize_comments`, `format_strings`, `imports_granularity`, `group_imports`) that only activate under nightly `rustfmt`. Stable `cargo fmt` silently ignores these options — so code that passes `cargo fmt --check` on stable can still fail CI's nightly fmt job.
+
+**Install nightly rustfmt once per machine:**
+
+```bash
+rustup toolchain install nightly --profile minimal -c rustfmt
+```
+
+**Use `make fmt` / `make fmt-check`** — both targets route through `cargo +nightly fmt --all` so local and CI stay in sync. Do not run `cargo fmt` directly without the `+nightly` selector.
+
+If `make fmt-check` fails with `error: no such command: +nightly`, you haven't installed nightly yet.
+```
+
+- [ ] **Step 3: Confirm the Markdown lints clean**
+
+```bash
+grep -c '^```' docs/developer-guide/development/standards.md
+```
+
+Expected: an even number (every opening fence has a closing fence).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/developer-guide/development/standards.md
+git commit -m "docs(infra): note nightly rustfmt requirement in standards.md"
+```
+
+---
+
+## Final Verification (before opening PR)
+
+- [ ] **All four checks green locally**
+
+```bash
+cargo +nightly fmt --all -- --check && echo "fmt OK"
+cargo deny check advisories 2>&1 | tail -3
+cargo deny check licenses 2>&1 | tail -3
+SQLX_OFFLINE=true cargo clippy --workspace -- -D warnings 2>&1 | tail -5
+make fmt-check
+```
+
+Expected:
+- `fmt OK`
+- `advisories ok` (no new RUSTSEC hits; RUSTSEC-2026-0099 resolved)
+- `licenses ok`
+- Clippy: `Finished` with no error-level diagnostics
+- `make fmt-check`: exit code 0
+
+- [ ] **Commit log review**
+
+```bash
+git log --oneline origin/main..HEAD
+```
+
+Expected exactly four commits, in order:
+1. `fix(infra): apply cargo +nightly fmt to handlers.rs docstring`
+2. `chore(infra): cargo update -p rustls-webpki for RUSTSEC-2026-0099`
+3. `chore(infra): route Makefile fmt targets through nightly toolchain`
+4. `docs(infra): note nightly rustfmt requirement in standards.md`
+
+- [ ] **Push and open PR**
+
+```bash
+git push -u origin fix/ci-drift-main
+gh pr create --base main --head fix/ci-drift-main \
+  --title "fix(infra): CI drift on main — fmt, rustls-webpki advisory, Makefile" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Block 1 of Phase 2.5 open-topics cleanup. Fixes the drift that required admin-merging #529-#534.
+
+- Apply `cargo +nightly fmt` to `server/src/ws/handlers.rs:73` (docstring the stable formatter silently ignored).
+- `cargo update -p rustls-webpki` to resolve RUSTSEC-2026-0099 (wildcard name-constraint bypass).
+- Route `Makefile`'s `fmt` / `fmt-check` targets through nightly so contributors can reproduce CI locally.
+- Document the nightly-rustfmt requirement in `docs/developer-guide/development/standards.md`.
+
+Spec: `docs/superpowers/specs/2026-04-16-open-topics-cleanup-design.md` — Block 1.
+
+## Test plan
+
+- [x] `cargo +nightly fmt --all -- --check` — exit 0
+- [x] `cargo deny check advisories` — RUSTSEC-2026-0099 resolved
+- [x] `cargo deny check licenses` — no regression
+- [x] `cargo test -p vc-server` — green
+- [x] `make fmt-check` — exit 0
+
+## Expected CI result
+
+`Rust Lint (fmt)`, `Rust Lint (clippy)`, `License Compliance` all **green** on this PR — the three checks that have been red on `main` since Phase 1 Phase 1 PR merges. No admin override required for merge.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Record the returned PR number for follow-up.
+
+- [ ] **Wait for CI to pass**
+
+```bash
+gh pr checks <PR_NUMBER> --watch
+```
+
+Expected: all checks pass. If `Rust Lint (fmt)` still fails, the nightly rustfmt version on CI may have moved past what was installed locally — rerun Task 1 Step 2 with the CI's nightly version (pin via `rustup toolchain install nightly-YYYY-MM-DD` matching the CI image date) and force-push.
+
+---
+
+## Post-merge cleanup
+
+After the PR is squash-merged:
+
+```bash
+cd /home/detair/GIT/detair/kaiku
+git worktree remove .claude/worktrees/ci-drift-fix
+git branch -d fix/ci-drift-main
+git push origin --delete fix/ci-drift-main
+git fetch --prune
+```
+
+Signal to Block 2: once this merges, the four remaining Phase 1 PRs (#529-#532) can begin rebasing onto the new `main`.
+
+---
+
+## Notes for the implementer
+
+- **Task ordering is semantically independent but commit-ordered for legibility.** Tasks 1 and 2 could run in either order; they don't interact. Task 3 can also run before Task 1 if preferred. The stated order matches the PR's commit log reader expectations (fix first, deps second, tooling third, docs last).
+- **If `cargo +nightly fmt` surfaces drift beyond `handlers.rs`,** include all affected files in Task 1's commit — the topic is unchanged ("apply the formatter the CI actually runs"). Do not split into per-file commits.
+- **If `cargo update -p rustls-webpki` pulls unrelated version bumps into `Cargo.lock`,** stop and investigate. A patch update of one crate should not perturb the rest of the graph; if it does, a `Cargo.toml` constraint is over-broad and needs a separate spec.
+- **Do not add a pre-commit hook** in this PR. The spec explicitly defers automated enforcement; re-evaluate only if drift recurs after this PR.

--- a/docs/superpowers/plans/2026-04-16-block2-merge-phase1-prs.md
+++ b/docs/superpowers/plans/2026-04-16-block2-merge-phase1-prs.md
@@ -1,0 +1,379 @@
+# Block 2 — Clean-merge Phase 1 PRs #529–#532 Runbook
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans. This is a shepherding runbook, not a traditional implementation plan — no new code is authored here. Each task is a per-PR rebase-test-push-merge cycle.
+
+**Goal:** Land the four remaining Phase 1 PRs (#529 server security, #530 web ICE buffering, #531 Tauri RTP protocol, #532 Tauri VP8 decode) on a post-Block-1 `main` with honest green CI — no `--admin` override.
+
+**Architecture:** Four serialized shepherding tasks, one per PR. Each task: rebase the existing worktree onto `origin/main`, resolve drift conflicts (most likely `Cargo.lock` and nightly-fmt deltas), run local gates, push, wait for green CI, squash-merge, clean up the worktree.
+
+**Tech Stack:** `git`, `gh`, `cargo`, `bun`, `cargo-deny`. No new libraries introduced.
+
+**Spec:** `docs/superpowers/specs/2026-04-16-open-topics-cleanup-design.md` — Block 2.
+
+**Parallelization safe:** No. Tasks serialize by design — each PR rebases onto the `main` that includes all prior Block-2 merges. Skipping ahead would force double-rebases later.
+
+---
+
+## Pre-flight Check (BLOCKING)
+
+- [ ] **Verify Block 1 has merged to `main`**
+
+```bash
+cd /home/detair/GIT/detair/kaiku
+git fetch origin
+git log origin/main --oneline | grep -E "ci-drift|CI drift|RUSTSEC-2026-0099" | head -3
+```
+
+Expected: at least one commit on `origin/main` referencing the Block 1 fix (e.g., `fix(infra): CI drift on main — fmt, rustls-webpki advisory, Makefile (#NNN)`). If nothing matches, **STOP** and complete Block 1 first.
+
+- [ ] **Verify the four PRs are still open and mergeable**
+
+```bash
+for n in 529 530 531 532; do
+  gh pr view $n --json number,title,state,headRefName,mergeable | python3 -c "import sys,json; d=json.load(sys.stdin); print(f\"#{d['number']} {d['state']} {d['mergeable']} {d['headRefName']}: {d['title']}\")"
+done
+```
+
+Expected: four lines with `state=OPEN`. If any PR shows `MERGED` or `CLOSED`, skip that task — it was handled out-of-band.
+
+- [ ] **Verify the four worktrees exist**
+
+```bash
+git worktree list | grep -E 'voice-server-security|web-voice-ice-buffering|tauri-voice-rtp-protocol|tauri-vp8-decode'
+```
+
+Expected: four matching paths. If any is missing, recreate via `git worktree add .claude/worktrees/<name> <branch>` before starting the corresponding task.
+
+- [ ] **Environment for gradle (only Tauri/Android tasks touch it; harmless to set once)**
+
+```bash
+export JAVA_HOME="$HOME/.local/share/jdk/jdk-17.0.18+8"
+export ANDROID_HOME="$HOME/.local/share/android-sdk"
+export PATH="$JAVA_HOME/bin:$PATH"
+```
+
+---
+
+## File Map
+
+Block 2 authors zero files. The authoritative file list for each PR is owned by its original author. This runbook only rebases existing worktrees and resolves drift conflicts.
+
+Expected *rebase conflict* files (per PR, approximate):
+
+| PR | Likely drift files | Notes |
+|----|--------------------|-------|
+| #529 (server security) | `server/src/ws/handlers.rs`, `Cargo.lock` | #529 edits server code; both Block 1's fmt and its advisory bump are server-adjacent |
+| #530 (web ICE buffering) | `Cargo.lock` only | Web client; should not interact with server fmt |
+| #531 (Tauri RTP protocol) | `Cargo.lock` | Tauri client; may pull on `rustls-webpki` transitively — conflict likely trivial |
+| #532 (Tauri VP8 decode) | `Cargo.lock`, possibly `client/src-tauri/src/*` | Depends on #531's protocol shape |
+
+---
+
+## Task 1: Merge #529 — server security
+
+**Why first:** Security-sensitive fix for server rate-limiting, self-mute, and screen-share slot leak. Landing first reduces exposure time.
+
+**Branch:** `fix/voice-server-security`
+**Worktree:** `.claude/worktrees/voice-server-security`
+
+- [ ] **Step 1: Enter the worktree and fetch latest**
+
+```bash
+cd /home/detair/GIT/detair/kaiku/.claude/worktrees/voice-server-security
+git fetch origin
+git status
+```
+
+Expected: `On branch fix/voice-server-security`, no local uncommitted changes. If uncommitted work exists, stop and ask — it was left by another session.
+
+- [ ] **Step 2: Rebase onto origin/main**
+
+```bash
+git rebase origin/main
+```
+
+Expected: either clean rebase ("Successfully rebased") or conflicts enumerated by git.
+
+- [ ] **Step 3 (conditional): Resolve conflicts**
+
+If rebase halts on conflicts:
+
+- For `Cargo.lock` conflicts: regenerate cleanly via `cargo build -p vc-server` (or just `cargo metadata > /dev/null`), then `git add Cargo.lock`.
+- For `server/src/ws/handlers.rs` conflicts: apply nightly fmt to reconcile, then stage:
+
+```bash
+cargo +nightly fmt --all
+git add server/src/ws/handlers.rs
+```
+
+- For any other conflict: read both sides carefully; prefer the PR's semantic change over `main`'s formatting change. Run `cargo +nightly fmt --all` after manual resolution. Escalate to the PR author if the conflict involves overlapping semantic edits.
+
+Continue the rebase:
+
+```bash
+git rebase --continue
+```
+
+Repeat until rebase completes.
+
+- [ ] **Step 4: Local gate — server tests + fmt + clippy + deny**
+
+```bash
+cargo +nightly fmt --all -- --check
+SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings 2>&1 | tail -5
+cargo test -p vc-server 2>&1 | tail -5
+cargo deny check advisories 2>&1 | tail -3
+```
+
+Expected: fmt clean, clippy green, `test result: ok`, `advisories ok`. If any fail, **STOP** — either fix in place (if it's a trivial drift issue) or re-assign the conflict resolution to the PR author.
+
+- [ ] **Step 5: Force-push with lease**
+
+```bash
+git push --force-with-lease origin fix/voice-server-security
+```
+
+- [ ] **Step 6: Wait for CI to pass — no admin override**
+
+```bash
+gh pr checks 529 --watch
+```
+
+Expected: all checks pass. If any check fails that was not failing before Block 1, escalate — that's a real regression, not drift.
+
+- [ ] **Step 7: Squash-merge**
+
+```bash
+gh pr merge 529 --squash
+```
+
+**Do NOT pass `--admin`.** If CI is still red, either the checks are not actually green (re-read output) or a PR-specific issue needs the author's attention.
+
+- [ ] **Step 8: Verify merge landed on `main`**
+
+```bash
+git fetch origin
+git log origin/main --oneline -3
+```
+
+Expected: newest commit is the squash of #529.
+
+- [ ] **Step 9: Clean up**
+
+```bash
+cd /home/detair/GIT/detair/kaiku
+git worktree remove .claude/worktrees/voice-server-security
+git branch -D fix/voice-server-security
+git fetch --prune
+```
+
+Remote deletion happens automatically on squash-merge; `--prune` removes the local tracking ref.
+
+---
+
+## Task 2: Merge #530 — web ICE buffering
+
+**Branch:** `fix/web-voice-ice-buffering`
+**Worktree:** `.claude/worktrees/web-voice-ice-buffering`
+
+- [ ] **Step 1: Enter worktree, fetch, rebase**
+
+```bash
+cd /home/detair/GIT/detair/kaiku/.claude/worktrees/web-voice-ice-buffering
+git fetch origin
+git rebase origin/main
+```
+
+Expected: clean rebase. Web-client changes should not conflict with server fmt or server-side `Cargo.lock` bumps.
+
+- [ ] **Step 2 (conditional): Resolve conflicts**
+
+If `Cargo.lock` conflicts (unlikely for a web-only PR), regenerate via `cargo metadata > /dev/null` and stage. For any `client/src/**/*.ts` or `client/src/**/*.tsx` conflicts, read both sides; prefer the PR's semantic change.
+
+- [ ] **Step 3: Local gate — web tests**
+
+```bash
+cd client
+bun install --frozen-lockfile
+bun run format -- --check
+bun run test:run 2>&1 | tail -10
+cd ..
+```
+
+Expected: format clean, `Test Files  X passed` reported. If any fail, stop.
+
+- [ ] **Step 4: Push**
+
+```bash
+git push --force-with-lease origin fix/web-voice-ice-buffering
+```
+
+- [ ] **Step 5: Wait for CI**
+
+```bash
+gh pr checks 530 --watch
+```
+
+Expected: green.
+
+- [ ] **Step 6: Squash-merge**
+
+```bash
+gh pr merge 530 --squash
+```
+
+- [ ] **Step 7: Verify + clean up**
+
+```bash
+git fetch origin
+git log origin/main --oneline -3  # expect squash of #530
+
+cd /home/detair/GIT/detair/kaiku
+git worktree remove .claude/worktrees/web-voice-ice-buffering
+git branch -D fix/web-voice-ice-buffering
+git fetch --prune
+```
+
+---
+
+## Task 3: Merge #531 — Tauri RTP protocol
+
+**Why before #532:** #532's native VP8 decode path depends on #531's per-session RTP sequence/timestamp handling and the VP8 payload-type wire change.
+
+**Branch:** `fix/tauri-voice-rtp-protocol`
+**Worktree:** `.claude/worktrees/tauri-voice-rtp-protocol`
+
+- [ ] **Step 1: Rebase**
+
+```bash
+cd /home/detair/GIT/detair/kaiku/.claude/worktrees/tauri-voice-rtp-protocol
+git fetch origin
+git rebase origin/main
+```
+
+- [ ] **Step 2 (conditional): Resolve conflicts**
+
+Most likely `Cargo.lock`. Also possible: `client/src-tauri/src/voice*.rs` files if #529's server changes required matching Tauri-side adjustments in a shared protocol module — read carefully if that occurs. Rerun `cargo +nightly fmt --all` after manual resolution.
+
+- [ ] **Step 3: Local gate — Tauri tests**
+
+```bash
+cargo +nightly fmt --all -- --check
+# Tauri tests may be blocked by libspa on some Linux dev hosts (documented in
+# Workstream A spec's "Out of scope" and Workstream G backlog). If so, skip the
+# Tauri cargo test and rely on CI. Frontend + server tests still run:
+SQLX_OFFLINE=true cargo clippy -p vc-client -- -D warnings 2>&1 | tail -5
+cargo test -p vc-client 2>&1 | tail -10 || true  # tolerate libspa build failure
+```
+
+Expected: fmt + clippy green. `cargo test -p vc-client` may fail to build on Linux due to `libspa` / pipewire-sys — that's a known pre-existing environmental issue (Workstream G). CI (which runs on ubuntu-24.04 with the right system libs) will test authoritatively.
+
+- [ ] **Step 4: Push and wait**
+
+```bash
+git push --force-with-lease origin fix/tauri-voice-rtp-protocol
+gh pr checks 531 --watch
+```
+
+- [ ] **Step 5: Squash-merge and clean up**
+
+```bash
+gh pr merge 531 --squash
+
+git fetch origin
+git log origin/main --oneline -3
+
+cd /home/detair/GIT/detair/kaiku
+git worktree remove .claude/worktrees/tauri-voice-rtp-protocol
+git branch -D fix/tauri-voice-rtp-protocol
+git fetch --prune
+```
+
+---
+
+## Task 4: Merge #532 — Tauri VP8 decode
+
+**Branch:** `feat/tauri-vp8-decode`
+**Worktree:** `.claude/worktrees/tauri-vp8-decode`
+
+- [ ] **Step 1: Rebase onto post-#531 main**
+
+```bash
+cd /home/detair/GIT/detair/kaiku/.claude/worktrees/tauri-vp8-decode
+git fetch origin
+git rebase origin/main
+```
+
+- [ ] **Step 2 (conditional): Resolve conflicts**
+
+Because #532's content depends on #531's RTP changes, conflicts here are more likely than the other PRs — #531 just landed the per-session sequence/timestamp APIs that #532 consumes. Read both sides carefully; if the PR's VP8 decode path references an older signature of #531's now-renamed APIs, adjust the call sites (not the API definitions).
+
+- [ ] **Step 3: Local gate — Tauri tests (same caveats as Task 3)**
+
+```bash
+cargo +nightly fmt --all -- --check
+SQLX_OFFLINE=true cargo clippy -p vc-client -- -D warnings 2>&1 | tail -5
+cargo test -p vc-client 2>&1 | tail -10 || true
+```
+
+- [ ] **Step 4: Push and wait**
+
+```bash
+git push --force-with-lease origin feat/tauri-vp8-decode
+gh pr checks 532 --watch
+```
+
+- [ ] **Step 5: Squash-merge and clean up**
+
+```bash
+gh pr merge 532 --squash
+
+git fetch origin
+git log origin/main --oneline -3
+
+cd /home/detair/GIT/detair/kaiku
+git worktree remove .claude/worktrees/tauri-vp8-decode
+git branch -D feat/tauri-vp8-decode
+git fetch --prune
+```
+
+---
+
+## Final Verification
+
+- [ ] **All four PRs merged**
+
+```bash
+for n in 529 530 531 532; do
+  gh pr view $n --json number,state,mergedAt | python3 -c "import sys,json; d=json.load(sys.stdin); print(f\"#{d['number']} {d['state']} merged at {d['mergedAt']}\")"
+done
+```
+
+Expected: four `MERGED` lines with recent timestamps.
+
+- [ ] **No orphan worktrees or branches remain**
+
+```bash
+git worktree list | grep -E 'voice-server-security|web-voice-ice-buffering|tauri-voice-rtp-protocol|tauri-vp8-decode'
+git branch --list 'fix/voice-server-security' 'fix/web-voice-ice-buffering' 'fix/tauri-voice-rtp-protocol' 'feat/tauri-vp8-decode'
+```
+
+Expected: both commands return no output.
+
+- [ ] **`main` CI is green**
+
+```bash
+gh run list --branch main --limit 1 --json conclusion,headSha,createdAt | python3 -c "import sys,json; d=json.load(sys.stdin)[0]; print(f\"{d['headSha'][:7]} {d['conclusion']} at {d['createdAt']}\")"
+```
+
+Expected: `success` (not `failure`). If `failure`, a PR-specific issue slipped past local testing — investigate, open a follow-up fix PR, and do not admin-merge.
+
+---
+
+## Notes for the implementer
+
+- **Do not bundle PRs.** Each task is its own rebase-test-merge cycle. Rebasing all four at once risks cascading conflicts and loses the "one PR, one green CI" signal Block 2 is trying to restore.
+- **Do not rewrite PR history beyond rebase.** Squashing, amending, or reordering commits within an open PR is the author's prerogative, not the shepherd's. Force-push is only for the rebased tip.
+- **If a PR's CI fails on something that wasn't failing on `main` before the rebase,** the PR itself has a real bug. Leave a comment on the PR pinging the author, skip to the next task, and revisit when the author pushes a fix.
+- **`cargo test -p vc-client`** may fail to build on Linux due to missing `libspa` / pipewire-sys system libraries. This is a known environmental gap tracked in the Workstream G backlog. Rely on CI for authoritative results on Tauri PRs.
+- **Admin override is forbidden** in this plan. If you feel the need to `--admin` any merge, stop — the point of Block 2 is to restore honest CI signal on `main`. Admin-merging a PR here defeats the entire Phase 2.5 purpose.

--- a/docs/superpowers/plans/2026-04-16-block3-test-triage-spike.md
+++ b/docs/superpowers/plans/2026-04-16-block3-test-triage-spike.md
@@ -1,0 +1,467 @@
+# Block 3 — Android Test-Failure Triage Spike Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert the 13 pre-existing Android unit-test failures (carved out of Workstream A as "root cause unknown") into a classification document that clusters them by root cause, estimates per-cluster fix size, and seeds follow-up workstream specs. Optionally inline S-rated fixes if any cluster resolves in ≤30 minutes of code change.
+
+**Architecture:** Bounded investigation spike. 90-minute wall-clock budget for investigation; additional ≤30-minute budget for inline fixes (120-min total worst case). Primary deliverable is a triage doc at `docs/developer-guide/testing/2026-04-16-android-test-failure-triage.md`. Optional secondary deliverable: test fix commits for S-rated clusters.
+
+**Tech Stack:** Gradle 8.x, JUnit 4, MockK, Turbine, Hilt test, kotlinx-coroutines-test. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-04-16-open-topics-cleanup-design.md` — Block 3.
+
+**Parallelization safe:** Yes — runs in parallel with Block 2 and Block 4 once Block 1 has merged. The only dependency is that `main`'s CI is green so baseline measurements are trustworthy.
+
+---
+
+## Pre-flight Check (BLOCKING)
+
+- [ ] **Verify Block 1 has merged**
+
+```bash
+cd /home/detair/GIT/detair/kaiku
+git fetch origin
+git log origin/main --oneline | grep -E "ci-drift|CI drift|RUSTSEC-2026-0099" | head -3
+```
+
+Expected: a commit referencing the Block 1 CI drift fix. Block 1 need not land before Block 3 *starts*, but the triage should run against `main` with Block 1 applied so the baseline is stable.
+
+- [ ] **Verify the 13 failures are still present**
+
+Set up Java/Android env once:
+
+```bash
+export JAVA_HOME="$HOME/.local/share/jdk/jdk-17.0.18+8"
+export ANDROID_HOME="$HOME/.local/share/android-sdk"
+export PATH="$JAVA_HOME/bin:$PATH"
+```
+
+From a fresh checkout of `origin/main`:
+
+```bash
+git worktree add /tmp/kaiku-main-check origin/main  # temporary, deleted after check
+cd /tmp/kaiku-main-check/mobile/android
+./gradlew :app:testDebugUnitTest --rerun-tasks 2>&1 | tail -5
+python3 -c "
+import xml.etree.ElementTree as ET, glob
+total=skips=fails=errors=0
+per = []
+for f in sorted(glob.glob('app/build/test-results/testDebugUnitTest/*.xml')):
+    r = ET.parse(f).getroot()
+    t = int(r.get('tests',0)); s = int(r.get('skipped',0)); fl = int(r.get('failures',0)); e = int(r.get('errors',0))
+    total += t; skips += s; fails += fl; errors += e
+    if fl or e: per.append((r.get('name'), fl+e))
+print(f'TOTAL tests={total} skipped={skips} failures={fails} errors={errors}')
+for n, c in per: print(f'  {n}: {c}')
+"
+```
+
+Expected: 13 failures across `AuthStateTest` (2), `AuthFlowTest` (5), `MessageFlowTest` (5), `QrLoginFlowTest` (1). Total test count may have increased from the Workstream A baseline of 174 (Block 4's un-ignore would add 1 to the total once it lands).
+
+Clean up:
+
+```bash
+cd /home/detair/GIT/detair/kaiku
+git worktree remove /tmp/kaiku-main-check
+```
+
+If the failure count changed materially (different test classes, totally different count), **STOP** — a recent commit may have landed on `main` that resolved or introduced failures. Re-baseline before starting the spike.
+
+---
+
+## Worktree Setup (run once after pre-flight passes)
+
+```bash
+cd /home/detair/GIT/detair/kaiku
+git worktree add .claude/worktrees/test-failure-triage -b docs/android-test-triage origin/main
+cd .claude/worktrees/test-failure-triage
+
+export JAVA_HOME="$HOME/.local/share/jdk/jdk-17.0.18+8"
+export ANDROID_HOME="$HOME/.local/share/android-sdk"
+export PATH="$JAVA_HOME/bin:$PATH"
+```
+
+Working branch: `docs/android-test-triage`. Working directory for all tasks: `/home/detair/GIT/detair/kaiku/.claude/worktrees/test-failure-triage`.
+
+---
+
+## File Map
+
+| Path | Action |
+|------|--------|
+| `docs/developer-guide/testing/2026-04-16-android-test-failure-triage.md` | Create — triage deliverable (Task 4) |
+| `mobile/android/app/src/test/java/.../AuthStateTest.kt` | Possibly modify (Task 5, only if S-rated) |
+| `mobile/android/app/src/test/java/.../AuthFlowTest.kt` | Possibly modify (Task 5, only if S-rated) |
+| `mobile/android/app/src/test/java/.../MessageFlowTest.kt` | Possibly modify (Task 5, only if S-rated) |
+| `mobile/android/app/src/test/java/.../QrLoginFlowTest.kt` | Possibly modify (Task 5, only if S-rated) |
+
+---
+
+## Task 1: Capture full failure output (investigation ~15 min)
+
+**Goal:** Generate a complete, parseable record of every failing test — name, assertion, exception type, stack trace top frames, test file path.
+
+- [ ] **Step 1: Run the suite with XML + stdout capture**
+
+```bash
+cd mobile/android
+./gradlew :app:testDebugUnitTest --rerun-tasks 2>&1 | tee /tmp/android-test-run.log
+```
+
+Ignore the overall exit code (non-zero = at least one failure, which is expected). The run populates `app/build/test-results/testDebugUnitTest/*.xml` with structured results.
+
+- [ ] **Step 2: Extract per-failure metadata from the XML reports**
+
+```bash
+python3 <<'PY' > /tmp/android-failures.tsv
+import xml.etree.ElementTree as ET, glob
+print("class\ttest_name\tfailure_type\tmessage\tfirst_stack_frame")
+for f in sorted(glob.glob('app/build/test-results/testDebugUnitTest/*.xml')):
+    root = ET.parse(f).getroot()
+    cls_name = root.get('name')
+    for tc in root.findall('testcase'):
+        for tag in ('failure', 'error'):
+            node = tc.find(tag)
+            if node is not None:
+                msg = (node.get('message') or '').replace('\t', ' ').replace('\n', ' | ')[:200]
+                typ = node.get('type') or tag
+                body = (node.text or '').strip().split('\n')
+                frame = next((l.strip() for l in body if l.strip().startswith('at ')), '')[:200]
+                print(f"{cls_name}\t{tc.get('name')}\t{typ}\t{msg}\t{frame}")
+PY
+cat /tmp/android-failures.tsv | head -20
+wc -l /tmp/android-failures.tsv
+```
+
+Expected: 14 lines (1 header + 13 failure rows). If the row count is off, verify the XML parse caught every `<failure>`/`<error>` element.
+
+- [ ] **Step 3: Also capture full stack traces for each failure (searchable later)**
+
+```bash
+for f in app/build/test-results/testDebugUnitTest/*.xml; do
+    python3 <<PY
+import xml.etree.ElementTree as ET, sys
+r = ET.parse('$f').getroot()
+for tc in r.findall('testcase'):
+    for tag in ('failure', 'error'):
+        n = tc.find(tag)
+        if n is not None:
+            print(f"=== {r.get('name')}.{tc.get('name')} [{tag}/{n.get('type')}]")
+            print((n.text or '').strip())
+            print()
+PY
+done > /tmp/android-failures-full.txt
+wc -l /tmp/android-failures-full.txt
+```
+
+Expected: several hundred lines (13 stack traces × many frames each).
+
+- [ ] **Step 4: Confirm the 4 test source files exist and note their paths**
+
+```bash
+find mobile/android/app/src/test/java -type f \( -name 'AuthStateTest.kt' -o -name 'AuthFlowTest.kt' -o -name 'MessageFlowTest.kt' -o -name 'QrLoginFlowTest.kt' \)
+```
+
+Expected: four matching files. Record the full paths — Task 4 cites them.
+
+---
+
+## Task 2: Cluster the failures (investigation ~30 min)
+
+**Goal:** Identify shared root-cause signals across the 13 failures. Output: 1-3 candidate clusters with evidence.
+
+- [ ] **Step 1: Bucket failures by the "first differential frame"**
+
+For each failure in `/tmp/android-failures-full.txt`, find the first stack frame that points into Kaiku's own code (not Kotlin/JUnit/MockK framework). Group failures whose differential frame is the same file/line.
+
+```bash
+# Manually scan /tmp/android-failures-full.txt. For each === block, identify:
+#   - exception type
+#   - deepest non-framework frame (grep -E "at io.wolftown.kaiku")
+# Build a mental (or /tmp/android-clusters.md) table:
+#   Cluster A (shared fixture): AuthFlowTest×5, MessageFlowTest×5, QrLoginFlowTest×1 -- all fail at <same frame>
+#   Cluster B (state assertion): AuthStateTest×2 -- distinct frame
+```
+
+- [ ] **Step 2: Check for shared `@Before` / `setUp()` infrastructure**
+
+Common failure modes:
+- A Hilt `@HiltAndroidTest` component that depends on a now-renamed production binding.
+- A `MockWebServer` instance whose expected endpoints changed.
+- A `DataStore` fixture with a schema drift.
+- A `@Before` block that initialises `Dispatchers.setMain` but doesn't `resetMain` on failure paths.
+
+Read the `@Before` and class-level setup of each failing test class:
+
+```bash
+for f in $(find mobile/android/app/src/test/java -type f \( -name 'AuthStateTest.kt' -o -name 'AuthFlowTest.kt' -o -name 'MessageFlowTest.kt' -o -name 'QrLoginFlowTest.kt' \)); do
+    echo "=== $f"
+    grep -nE "@Before|@After|setUp|tearDown" "$f" | head -10
+done
+```
+
+Also grep for a shared test base:
+
+```bash
+find mobile/android/app/src/test -type f -name '*.kt' | xargs grep -lE "HiltAndroidTest|class .*TestBase|class .*TestHelper|TestApplication" | head -10
+```
+
+- [ ] **Step 3: Check recent git history for test-related changes**
+
+```bash
+git log --oneline --since='2026-03-01' -- mobile/android/app/src/test/ | head -20
+git log --oneline --since='2026-03-01' -- mobile/android/app/src/main/java/io/wolftown/kaiku/data/local/ mobile/android/app/src/main/java/io/wolftown/kaiku/data/repository/auth* | head -20
+```
+
+If a recent commit changed production data shape without updating test fixtures, that's a likely root cause.
+
+- [ ] **Step 4: Assign each failure to a cluster**
+
+For each of the 13 failures, tag one of:
+- **Cluster name** (e.g., "Shared integration-test Hilt component")
+- **Root cause hypothesis** (1 sentence, backed by the frame + shared-infra evidence)
+- **Size estimate**: `S` (<30 min inline fix), `M` (<4h, its own workstream), `L` (>4h, commissioned spec with deeper spike)
+
+If fewer than 13 assignments after this pass, create a "Cluster: unclassified" for the remainder and mark size `L` by default.
+
+- [ ] **Step 5: Budget checkpoint**
+
+After this step, **90-minute investigation budget is likely consumed**. If you have time remaining and any cluster is rated `S`, proceed to Task 5 (fix commits). Otherwise skip straight to Task 4 (write the doc).
+
+**If investigation exceeded 90 minutes**: stop classifying, write what you have, explicitly mark unclassified failures as `status: not yet triaged` in the doc, and commission a follow-up spike.
+
+---
+
+## Task 3: (Skipped — merged into Tasks 2 and 4)
+
+Task numbering matches the spec's commit plan. This slot reserved for "diagram the clusters" if the investigation produces a visual artifact — usually not needed for a triage doc.
+
+---
+
+## Task 4: Write the triage doc
+
+**Files:**
+- Create: `docs/developer-guide/testing/2026-04-16-android-test-failure-triage.md`
+
+- [ ] **Step 1: Scaffold the document**
+
+```bash
+mkdir -p docs/developer-guide/testing
+```
+
+- [ ] **Step 2: Fill in the template**
+
+The doc must contain these sections:
+
+```markdown
+# Android Unit Test Failure Triage — 2026-04-16
+
+**Context:** Workstream A (#534) carved 13 pre-existing Android unit test failures out of scope. This document classifies those 13 into root-cause clusters with per-cluster recommended next steps.
+
+**Spec:** `docs/superpowers/specs/2026-04-16-open-topics-cleanup-design.md` — Block 3.
+
+**Budget:** 90-minute investigation spike (per spec). [Note if exceeded.]
+
+## Baseline: all 13 failures
+
+| # | Class | Test method | Exception type | First non-framework frame | Cluster |
+|---|-------|-------------|----------------|---------------------------|---------|
+| 1 | `AuthStateTest` | `<method>` | `<type>` | `<file:line>` | `<A/B/…>` |
+| … | | | | | |
+
+(One row per failure. Cluster column uses letters A, B, C as assigned.)
+
+## Clusters
+
+### Cluster A — <Hypothesis in 5-10 words>
+
+**Failures covered:** <N of 13> (rows <1, 3, 5, …>)
+
+**Evidence:**
+- <shared stack frame / shared fixture / shared setup line>
+- <git-blame observation linking to recent change, if any>
+
+**Root cause hypothesis (1-2 sentences):**
+<statement>
+
+**Size rating:** `S` | `M` | `L`
+
+**Recommended action:**
+- If `S`: inline fix in this PR. Describe the change in 1-2 lines.
+- If `M` or `L`: seed a follow-up workstream. Propose a one-paragraph spec outline.
+
+### Cluster B — <Hypothesis>
+…
+
+## Recommended next steps
+
+- For each `S`-rated cluster: fix committed in this PR (link to commit SHAs once known).
+- For each `M`/`L`-rated cluster: follow-up workstream proposed.
+  - Proposed spec stub: <cluster name> — <one-sentence goal>.
+  - Suggested owner/area: <auth | messaging | qr-login | data-local>.
+
+## Out of scope for this spike
+
+- Actually fixing `M`/`L`-rated clusters (by design).
+- Adding test coverage for any production code uncovered as buggy during triage.
+- Robolectric / `androidTest/` migration.
+```
+
+- [ ] **Step 3: Populate the table from `/tmp/android-failures.tsv`**
+
+Convert each row of the TSV into a table row in the "Baseline" section. Use markdown pipe tables. Cluster column references the assignments from Task 2 Step 4.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/detair/GIT/detair/kaiku/.claude/worktrees/test-failure-triage
+git add docs/developer-guide/testing/2026-04-16-android-test-failure-triage.md
+git commit -m "docs(client): triage 13 pre-existing Android unit test failures"
+```
+
+---
+
+## Task 5 (CONDITIONAL): Apply S-rated cluster fixes
+
+**Skip this task entirely** if no cluster is rated `S`. Triage-doc-only PR is a complete deliverable.
+
+**If one or more clusters are rated `S`:**
+
+- [ ] **Step 1: Re-verify the 30-minute fix budget**
+
+Count of S-rated clusters × estimated fix time per cluster ≤ 30 minutes. If the total exceeds 30 minutes, downgrade the cheapest-to-defer cluster to `M` and re-run this budget check. Do not violate the 30-minute ceiling.
+
+- [ ] **Step 2: Apply one cluster's fix at a time**
+
+For each `S`-rated cluster, in any order:
+
+1. Read the failing test file(s) and the production code they touch.
+2. Write the minimal fix — usually: update a `@Before` stub, correct a mock expectation, fix a data-shape mismatch.
+3. Run the affected test class(es):
+   ```bash
+   cd mobile/android
+   ./gradlew :app:testDebugUnitTest --tests 'io.wolftown.kaiku.<pkg>.<ClassName>' --rerun-tasks 2>&1 | tail -10
+   ```
+   Expected: the previously-failing tests in that class now pass.
+4. Run the full suite to confirm no new regressions:
+   ```bash
+   ./gradlew :app:testDebugUnitTest --rerun-tasks 2>&1 | tail -3
+   python3 <<'PY'
+   import xml.etree.ElementTree as ET, glob
+   total=skips=fails=errors=0
+   for f in sorted(glob.glob('app/build/test-results/testDebugUnitTest/*.xml')):
+       r = ET.parse(f).getroot()
+       total += int(r.get('tests',0)); skips += int(r.get('skipped',0))
+       fails += int(r.get('failures',0)); errors += int(r.get('errors',0))
+   print(f'TOTAL tests={total} skipped={skips} failures={fails} errors={errors}')
+PY
+   ```
+   Expected: failure count decreased by the number of tests in the fixed cluster; no new failures outside the remaining clusters.
+
+5. Commit:
+   ```bash
+   git add mobile/android/app/src/test/java/io/wolftown/kaiku/<path>/<ClassName>.kt
+   git commit -m "test(client): <cluster name> — <1-sentence fix description>"
+   ```
+
+- [ ] **Step 3: Update the triage doc**
+
+After each S-rated fix commits, edit `2026-04-16-android-test-failure-triage.md`:
+- In the cluster's "Recommended action" section, replace the prospective description with the actual commit SHA + brief note.
+- In the "Recommended next steps" section, cross off the cluster.
+
+Commit the doc update as part of the fix commit (stage both files together) OR as a trailing commit — `docs(client): update triage doc with applied fixes`.
+
+---
+
+## Final Verification (before opening PR)
+
+- [ ] **Triage doc exists and is complete**
+
+```bash
+test -f docs/developer-guide/testing/2026-04-16-android-test-failure-triage.md && \
+  grep -cE '^| [0-9]+ ' docs/developer-guide/testing/2026-04-16-android-test-failure-triage.md
+```
+
+Expected: file exists; baseline table row count equals 13 (one line per failure).
+
+- [ ] **Test-suite status matches the doc's claims**
+
+```bash
+cd mobile/android
+./gradlew :app:testDebugUnitTest --rerun-tasks 2>&1 | tail -3
+```
+
+Expected:
+- If zero S-rated fixes applied: full-suite failure count still 13, in the same allowlist of classes.
+- If S-rated fixes applied: failure count reduced by exactly the number of tests the doc claims are now fixed.
+
+- [ ] **Commit log review**
+
+```bash
+git log --oneline origin/main..HEAD
+```
+
+Expected (minimum): one `docs(client): triage …` commit. Up to 3 additional `test(client): <cluster>` commits if S-rated fixes applied, plus an optional trailing `docs(client): update triage doc with applied fixes`.
+
+- [ ] **Push and open PR**
+
+```bash
+git push -u origin docs/android-test-triage
+gh pr create --base main --head docs/android-test-triage \
+  --title "docs(client): Android unit test failure triage + targeted fixes" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Block 3 of Phase 2.5 open-topics cleanup. Classifies the 13 pre-existing Android unit test failures (carved out of Workstream A) into root-cause clusters with per-cluster size ratings and next steps.
+
+Primary deliverable: `docs/developer-guide/testing/2026-04-16-android-test-failure-triage.md`.
+
+Optional inline fixes: [list S-rated clusters that were fixed, or "none — all clusters deferred to follow-up workstreams"].
+
+Spec: `docs/superpowers/specs/2026-04-16-open-topics-cleanup-design.md` — Block 3.
+
+## Budget
+
+- Investigation: [actual minutes] min (budget 90).
+- Inline fixes: [actual minutes] min (budget 30).
+
+## Remaining deferred clusters
+
+[Enumerate M/L-rated clusters with one-line proposed follow-up workstream descriptions.]
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Wait for CI green, merge**
+
+```bash
+gh pr checks <PR_NUMBER> --watch
+gh pr merge <PR_NUMBER> --squash
+```
+
+---
+
+## Post-merge cleanup
+
+```bash
+cd /home/detair/GIT/detair/kaiku
+git worktree remove .claude/worktrees/test-failure-triage
+git branch -D docs/android-test-triage
+git push origin --delete docs/android-test-triage
+git fetch --prune
+```
+
+Follow-up: for each M/L-rated cluster enumerated in the triage doc's "Recommended next steps", file a proposed workstream spec under `docs/superpowers/specs/YYYY-MM-DD-<cluster>-design.md` when the user commissions it.
+
+---
+
+## Notes for the implementer
+
+- **The 90-minute investigation budget is load-bearing.** If you finish the classification faster than 90 minutes, don't extend into deeper debugging — finalize the doc and consider Task 5. If you hit 90 minutes with unclassified failures, ship the doc in its partial state and explicitly mark `status: not yet triaged`.
+- **Do not expand scope mid-task.** If Cluster A is 10 failures rated M, don't decide to fix them "because it's right there" — that converts an M into an L due to context-switching, blows the budget, and breaks the spec's deliberate out-of-scope carve-out.
+- **Clusters of one failure are valid.** Sometimes there's no shared root cause. A cluster of exactly one failing test with its own hypothesis is a legitimate classification outcome.
+- **Prefer M-rated proposals over S-rated fixes when uncertain.** Ship the classification and let follow-up workstreams own real fixes, rather than half-fixing a cluster in a 30-minute budget and leaving a landmine.
+- **Test fixtures vs. production bugs.** If triage reveals an actual production bug (e.g., `AuthFlowTest` fails because `AuthRepository.refreshToken()` really does crash on empty input), document it as a production bug in the cluster's root-cause field and rate it at least M. Do not silently fix production code inside a triage spike.

--- a/docs/superpowers/plans/2026-04-16-block4-coroutine-scope-inject.md
+++ b/docs/superpowers/plans/2026-04-16-block4-coroutine-scope-inject.md
@@ -1,0 +1,730 @@
+# Block 4 — `CoroutineScope` Injection into `WebRtcManager` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Un-ignore `WebRtcManagerTest.voiceIceConnected emits true only when both PCs reach Connected` by making `WebRtcManager`'s internal `stateIn` scope injectable via Hilt. Drive the full 18-test voice suite to zero `@Ignore`s.
+
+**Architecture:** Add a `@VoiceCoroutineScope` qualifier annotation + a new `VoiceCoroutineScopeModule` (`@Provides` in an `object` module) that yields `CoroutineScope(SupervisorJob() + Dispatchers.IO)`. Inject this into `WebRtcManager` as a constructor parameter and replace the inline `CoroutineScope(Dispatchers.IO)` at `WebRtcManager.kt:159`. Tests gain control of the scope via `TestScope`/`backgroundScope`.
+
+**Tech Stack:** Kotlin, Hilt (Dagger 2), Coroutines (`kotlinx-coroutines-core` 1.9.0 + `kotlinx-coroutines-test` 1.9.0), MockK, JUnit 4.
+
+**Spec:** `docs/superpowers/specs/2026-04-16-open-topics-cleanup-design.md` — Block 4.
+
+**Parallelization safe:** Yes — runs in parallel with Blocks 2 and 3 after Block 1 merges. The only dependency is that `main`'s CI is green so Block 4's own CI run is trustworthy.
+
+---
+
+## Pre-flight Check (BLOCKING)
+
+- [ ] **Verify Block 1 has merged**
+
+```bash
+cd /home/detair/GIT/detair/kaiku
+git fetch origin
+git log origin/main --oneline | grep -E "ci-drift|CI drift|RUSTSEC-2026-0099" | head -3
+```
+
+Expected: at least one commit referencing the Block 1 fix. Block 4 doesn't strictly *require* Block 1's code changes, but CI must be green on `main` to give an honest signal on Block 4's PR.
+
+- [ ] **Verify Workstream A's code shape still matches assumptions**
+
+```bash
+grep -n 'class WebRtcManager\|eglBaseProvider\|@VoiceCoroutineScope' mobile/android/app/src/main/java/io/wolftown/kaiku/data/voice/WebRtcManager.kt | head -5
+grep -n 'CoroutineScope(Dispatchers.IO)' mobile/android/app/src/main/java/io/wolftown/kaiku/data/voice/WebRtcManager.kt | head -3
+```
+
+Expected:
+- `class WebRtcManager @Inject constructor(` at ~line 60
+- `private val eglBaseProvider: EglBaseProvider` parameter present at ~line 63 (Workstream A)
+- One `CoroutineScope(Dispatchers.IO)` match at ~line 159 — the inline scope this plan replaces
+- Zero `@VoiceCoroutineScope` matches (not yet created)
+
+If `eglBaseProvider` is missing, Workstream A has been reverted somehow — **STOP** and escalate. If `@VoiceCoroutineScope` already appears, someone pre-landed Block 4's scaffolding — **STOP** and rebase.
+
+- [ ] **Verify the `@Ignore` is still in place**
+
+```bash
+grep -nE '@Ignore|voiceIceConnected emits true' mobile/android/app/src/test/java/io/wolftown/kaiku/data/voice/WebRtcManagerTest.kt | head -4
+```
+
+Expected: one `@Ignore(` match near line 345, immediately followed by the `fun \`voiceIceConnected emits true only when both PCs reach Connected\`() = runTest {` test declaration.
+
+- [ ] **Environment for gradle**
+
+```bash
+export JAVA_HOME="$HOME/.local/share/jdk/jdk-17.0.18+8"
+export ANDROID_HOME="$HOME/.local/share/android-sdk"
+export PATH="$JAVA_HOME/bin:$PATH"
+```
+
+---
+
+## Worktree Setup (run once after pre-flight passes)
+
+```bash
+cd /home/detair/GIT/detair/kaiku
+git worktree add .claude/worktrees/voice-scope-inject -b feat/webrtc-scope-inject origin/main
+cd .claude/worktrees/voice-scope-inject
+```
+
+Working branch: `feat/webrtc-scope-inject`. Working directory for all tasks: `/home/detair/GIT/detair/kaiku/.claude/worktrees/voice-scope-inject`.
+
+---
+
+## File Map
+
+| Path | Action | Task |
+|------|--------|------|
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/di/VoiceCoroutineScope.kt` | Create | 1 |
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/di/VoiceCoroutineScopeModule.kt` | Create | 2 |
+| `mobile/android/app/src/main/java/io/wolftown/kaiku/data/voice/WebRtcManager.kt` | Modify (constructor + stateIn) | 3 |
+| `mobile/android/app/src/test/java/io/wolftown/kaiku/data/voice/WebRtcManagerTest.kt` | Modify (helper + un-ignore) | 4, 5 |
+| `mobile/android/app/src/test/AGENTS.md` | Modify (registry + canonical pattern) | 6 |
+| `CHANGELOG.md` | Modify (`### Fixed`) | 7 |
+
+---
+
+## Task 1: Create `@VoiceCoroutineScope` qualifier
+
+**Files:**
+- Create: `mobile/android/app/src/main/java/io/wolftown/kaiku/di/VoiceCoroutineScope.kt`
+
+- [ ] **Step 1: Write the qualifier annotation**
+
+```kotlin
+package io.wolftown.kaiku.di
+
+import javax.inject.Qualifier
+
+/**
+ * Qualifier for the [kotlinx.coroutines.CoroutineScope] used by voice-layer
+ * background work (e.g., [WebRtcManager.voiceIceConnected] stateIn collection).
+ *
+ * Tests inject a `TestScope` / `backgroundScope` via this qualifier so the
+ * `TestCoroutineScheduler` drives all emissions synchronously.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class VoiceCoroutineScope
+```
+
+- [ ] **Step 2: Verify compile**
+
+```bash
+cd mobile/android
+./gradlew :app:compileDebugKotlin 2>&1 | tail -5
+```
+
+Expected: `BUILD SUCCESSFUL`. The annotation stands alone — no consumers yet.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/detair/GIT/detair/kaiku/.claude/worktrees/voice-scope-inject
+git add mobile/android/app/src/main/java/io/wolftown/kaiku/di/VoiceCoroutineScope.kt
+git commit -m "feat(client): @VoiceCoroutineScope qualifier for voice-layer scope DI"
+```
+
+---
+
+## Task 2: Create `VoiceCoroutineScopeModule` `@Provides` module
+
+**Files:**
+- Create: `mobile/android/app/src/main/java/io/wolftown/kaiku/di/VoiceCoroutineScopeModule.kt`
+
+Rationale for a *new module* instead of adding to `VoiceModule`: `VoiceModule` is an `abstract class` (hosts `@Binds`). Hilt requires `@Provides` methods to live in either `object` modules or non-abstract classes. A dedicated `object` keeps the boundary clean and minimizes churn to the existing `@Binds`-style module.
+
+- [ ] **Step 1: Write the module**
+
+```kotlin
+package io.wolftown.kaiku.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import javax.inject.Singleton
+
+/**
+ * Provides the application-scoped [CoroutineScope] used by voice-layer
+ * background collectors (e.g., `WebRtcManager.voiceIceConnected.stateIn(...)`).
+ *
+ * Kept separate from [VoiceModule] because that module is `abstract` for
+ * `@Binds` entries; Hilt requires `@Provides` to live in `object` or
+ * non-abstract modules.
+ *
+ * `SupervisorJob` ensures a child coroutine's failure does not cascade to
+ * siblings. `Dispatchers.IO` matches the prior (inline) behavior.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object VoiceCoroutineScopeModule {
+    @Provides
+    @Singleton
+    @VoiceCoroutineScope
+    fun provideVoiceCoroutineScope(): CoroutineScope =
+        CoroutineScope(SupervisorJob() + Dispatchers.IO)
+}
+```
+
+- [ ] **Step 2: Verify compile + Hilt codegen**
+
+```bash
+cd mobile/android
+./gradlew :app:compileDebugKotlin 2>&1 | tail -10
+```
+
+Expected: `BUILD SUCCESSFUL`. Hilt KSP generates a `VoiceCoroutineScopeModule_ProvideVoiceCoroutineScopeFactory` class; no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/detair/GIT/detair/kaiku/.claude/worktrees/voice-scope-inject
+git add mobile/android/app/src/main/java/io/wolftown/kaiku/di/VoiceCoroutineScopeModule.kt
+git commit -m "feat(client): VoiceCoroutineScopeModule @Provides for voice-layer scope"
+```
+
+---
+
+## Task 3: Refactor `WebRtcManager` to consume the injected scope
+
+**Files:**
+- Modify: `mobile/android/app/src/main/java/io/wolftown/kaiku/data/voice/WebRtcManager.kt`
+
+### Step 1: Add the constructor parameter
+
+Current (lines 60-63):
+
+```kotlin
+@Singleton
+class WebRtcManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val voiceApi: VoiceApi,
+    private val eglBaseProvider: EglBaseProvider
+) {
+```
+
+Target:
+
+```kotlin
+@Singleton
+class WebRtcManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val voiceApi: VoiceApi,
+    private val eglBaseProvider: EglBaseProvider,
+    @VoiceCoroutineScope private val voiceScope: CoroutineScope,
+) {
+```
+
+Changes: add trailing comma to line 62, add new parameter line. The comma after `voiceScope: CoroutineScope` is optional but matches Kotlin trailing-comma style; preserve whatever style is most local to the existing file.
+
+Add the import (alphabetical with existing `io.wolftown.kaiku.di.*` imports, or next to `VoiceApi` import):
+
+```kotlin
+import io.wolftown.kaiku.di.VoiceCoroutineScope
+```
+
+`CoroutineScope` is already imported at line 7 — no new import needed.
+
+- [ ] **Apply the constructor change and add the import.**
+
+### Step 2: Replace the inline `CoroutineScope(Dispatchers.IO)` in `stateIn`
+
+Current (lines 154-162):
+
+```kotlin
+val voiceIceConnected: StateFlow<Boolean> =
+    combine(publisherIceState, subscriberIceState) { p, s ->
+        p == PeerConnection.IceConnectionState.CONNECTED &&
+            s == PeerConnection.IceConnectionState.CONNECTED
+    }.stateIn(
+        CoroutineScope(Dispatchers.IO),
+        SharingStarted.Eagerly,
+        false
+    )
+```
+
+Target:
+
+```kotlin
+val voiceIceConnected: StateFlow<Boolean> =
+    combine(publisherIceState, subscriberIceState) { p, s ->
+        p == PeerConnection.IceConnectionState.CONNECTED &&
+            s == PeerConnection.IceConnectionState.CONNECTED
+    }.stateIn(voiceScope, SharingStarted.Eagerly, false)
+```
+
+The three-line `.stateIn(...)` call collapses to a single line per Kotlin style — all three arguments fit on one line now that the scope expression is short. (If your style-check disagrees, keep the multi-line form with `voiceScope` replacing the inline scope expression.)
+
+- [ ] **Apply the stateIn change.**
+
+### Step 3: `dispose()` unchanged
+
+`WebRtcManager.dispose()` at line 371 does **not** change in this PR. The injected `voiceScope` is owned by Hilt's `SingletonComponent` and lives for the application lifetime; `WebRtcManager.dispose()` should not cancel a scope it does not own. (See spec Block 4's "Scope lifecycle decision" section for rationale.)
+
+- [ ] **Verify `dispose()` has not been touched in your diff.**
+
+### Step 4: Verify main-src compile + Hilt graph
+
+```bash
+cd mobile/android
+./gradlew :app:compileDebugKotlin 2>&1 | tail -10
+```
+
+Expected: `BUILD SUCCESSFUL`. Hilt regenerates `WebRtcManager_Factory` with the new 4-arg constructor.
+
+If compile fails with `Dagger MissingBinding: @VoiceCoroutineScope CoroutineScope`, Task 2's module is not registered. Verify `mobile/android/app/src/main/java/io/wolftown/kaiku/KaikuApplication.kt` (or wherever `@HiltAndroidApp` lives) doesn't have a manual module list excluding it — Hilt auto-discovers `@Module`s under `@InstallIn(SingletonComponent::class)` when Gradle is configured normally.
+
+### Step 5: Expect test compile to fail
+
+```bash
+./gradlew :app:compileDebugUnitTestKotlin 2>&1 | grep -E "^e:" | head -10
+```
+
+Expected: one or more errors in `WebRtcManagerTest.kt` — `newWebRtcManager()` calls the constructor with 3 args but the constructor now requires 4. This is by design; Task 4 fixes it.
+
+### Step 6: Commit
+
+```bash
+cd /home/detair/GIT/detair/kaiku/.claude/worktrees/voice-scope-inject
+git add mobile/android/app/src/main/java/io/wolftown/kaiku/data/voice/WebRtcManager.kt
+git status --short  # confirm only this file staged
+git commit -m "refactor(voice): WebRtcManager uses injected @VoiceCoroutineScope"
+```
+
+---
+
+## Task 4: Update `newWebRtcManager()` helper to accept a scope
+
+**Files:**
+- Modify: `mobile/android/app/src/test/java/io/wolftown/kaiku/data/voice/WebRtcManagerTest.kt:45-49`
+
+- [ ] **Step 1: Read the current helper**
+
+```bash
+sed -n '40,50p' mobile/android/app/src/test/java/io/wolftown/kaiku/data/voice/WebRtcManagerTest.kt
+```
+
+Expected: the helper as captured in pre-flight:
+
+```kotlin
+/**
+ * Construct a [WebRtcManager] with mocks suitable for tests that exercise
+ * signaling/state behavior without needing a real EGL or native PeerConnection.
+ * The provider's `create()` is never invoked unless the test reads `.eglBase`.
+ */
+private fun newWebRtcManager(): WebRtcManager = WebRtcManager(
+    context = mockk<Context>(relaxed = true),
+    voiceApi = mockk<VoiceApi>(relaxed = true),
+    eglBaseProvider = mockk<EglBaseProvider>(relaxed = true),
+)
+```
+
+- [ ] **Step 2: Change the helper signature to accept a `voiceScope` with a sensible default**
+
+```kotlin
+/**
+ * Construct a [WebRtcManager] with mocks suitable for tests that exercise
+ * signaling/state behavior without needing a real EGL or native PeerConnection.
+ * The provider's `create()` is never invoked unless the test reads `.eglBase`.
+ *
+ * [voiceScope] defaults to an `UnconfinedTestDispatcher`-backed [TestScope],
+ * which runs continuations synchronously on the calling thread. Tests that
+ * need scheduler control (i.e., `runCurrent()` / `advanceUntilIdle()` must
+ * drive the stateIn combine) should pass `backgroundScope` from a `runTest`
+ * block instead.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+private fun newWebRtcManager(
+    voiceScope: CoroutineScope = TestScope(UnconfinedTestDispatcher()),
+): WebRtcManager = WebRtcManager(
+    context = mockk<Context>(relaxed = true),
+    voiceApi = mockk<VoiceApi>(relaxed = true),
+    eglBaseProvider = mockk<EglBaseProvider>(relaxed = true),
+    voiceScope = voiceScope,
+)
+```
+
+Add the necessary imports (sorted into the existing alphabetical import block near the top of the file):
+
+```kotlin
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+```
+
+`kotlinx.coroutines.ExperimentalCoroutinesApi` is already imported for existing `@OptIn` uses — check `grep -n "ExperimentalCoroutinesApi" mobile/android/app/src/test/java/io/wolftown/kaiku/data/voice/WebRtcManagerTest.kt`. Reuse if present; add if missing.
+
+- [ ] **Step 3: Verify test-src compile now passes**
+
+```bash
+cd mobile/android
+./gradlew :app:compileDebugUnitTestKotlin 2>&1 | tail -5
+```
+
+Expected: `BUILD SUCCESSFUL`. The 5 existing callers of `newWebRtcManager()` still compile because the new parameter has a default.
+
+- [ ] **Step 4: Verify 5 previously-passing tests still pass under the new `UnconfinedTestDispatcher` default**
+
+```bash
+./gradlew :app:testDebugUnitTest --tests 'io.wolftown.kaiku.data.voice.WebRtcManagerTest' --rerun-tasks 2>&1 | tail -10
+```
+
+Expected: 18 tests, 1 skipped (the still-`@Ignore`d scheduler test), 0 failed. If any previously-passing test now fails, the `UnconfinedTestDispatcher` default is causing unexpected scheduling — downgrade the default to a vanilla `CoroutineScope(EmptyCoroutineContext)` *or* switch to `StandardTestDispatcher()` and re-run. Ordering-sensitive tests may prefer Standard.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/detair/GIT/detair/kaiku/.claude/worktrees/voice-scope-inject
+git add mobile/android/app/src/test/java/io/wolftown/kaiku/data/voice/WebRtcManagerTest.kt
+git commit -m "test(client): newWebRtcManager helper accepts injected voiceScope"
+```
+
+---
+
+## Task 5: Un-`@Ignore` the scheduler test and drive it with `backgroundScope`
+
+**Files:**
+- Modify: `mobile/android/app/src/test/java/io/wolftown/kaiku/data/voice/WebRtcManagerTest.kt:343-360`
+
+- [ ] **Step 1: Confirm the current @Ignore block**
+
+```bash
+sed -n '343,360p' mobile/android/app/src/test/java/io/wolftown/kaiku/data/voice/WebRtcManagerTest.kt
+```
+
+Expected: the `@Ignore(...)` annotation followed by `fun \`voiceIceConnected emits true only when both PCs reach Connected\`() = runTest {`.
+
+- [ ] **Step 2: Remove the `@Ignore` and pass `backgroundScope` into `newWebRtcManager`**
+
+Current:
+
+```kotlin
+@OptIn(ExperimentalCoroutinesApi::class)
+@Test
+@Ignore(
+    "voiceIceConnected uses stateIn(CoroutineScope(Dispatchers.IO), Eagerly) " +
+        "whose re-emissions can't be driven by TestCoroutineScheduler. Unblock by " +
+        "injecting the CoroutineScope into WebRtcManager (separate workstream)."
+)
+fun `voiceIceConnected emits true only when both PCs reach Connected`() = runTest {
+    val webRtcManager = newWebRtcManager()
+
+    // ... existing body unchanged
+}
+```
+
+Target:
+
+```kotlin
+@OptIn(ExperimentalCoroutinesApi::class)
+@Test
+fun `voiceIceConnected emits true only when both PCs reach Connected`() = runTest {
+    val webRtcManager = newWebRtcManager(voiceScope = backgroundScope)
+
+    // ... existing body unchanged
+}
+```
+
+`backgroundScope` is a property of `TestScope` (the receiver inside `runTest { ... }`) that gives a `CoroutineScope` backed by the same `TestCoroutineScheduler`. Using it means `runCurrent()` now actually drains the combine re-emission triggered by `setPublisherIceStateForTest`/`setSubscriberIceStateForTest`.
+
+- [ ] **Step 3: Remove the `import org.junit.Ignore` line if no other `@Ignore` usages remain**
+
+```bash
+grep -c '@Ignore' mobile/android/app/src/test/java/io/wolftown/kaiku/data/voice/WebRtcManagerTest.kt
+```
+
+Expected: 0 (after Step 2's deletion). If 0, remove the import:
+
+```bash
+# In your editor, delete the line: import org.junit.Ignore
+# Or via sed:
+sed -i '/^import org.junit.Ignore$/d' mobile/android/app/src/test/java/io/wolftown/kaiku/data/voice/WebRtcManagerTest.kt
+```
+
+- [ ] **Step 4: Run the scheduler test**
+
+```bash
+cd mobile/android
+./gradlew :app:testDebugUnitTest --tests 'io.wolftown.kaiku.data.voice.WebRtcManagerTest.voiceIceConnected emits true only when both PCs reach Connected' --rerun-tasks 2>&1 | tail -10
+```
+
+Expected: **1 test, 0 skipped, 0 failed.**
+
+If the test fails with `AssertionError` on `assertTrue(webRtcManager.voiceIceConnected.value)`, the `stateIn` may still need one extra `runCurrent()` after setting the second ICE state — add it if needed (the original test already has `runCurrent()` between each `setXxxIceStateForTest` and its assertion; no new calls should be required).
+
+- [ ] **Step 5: Run the full `WebRtcManagerTest` to confirm no regressions**
+
+```bash
+./gradlew :app:testDebugUnitTest --tests 'io.wolftown.kaiku.data.voice.WebRtcManagerTest' --rerun-tasks 2>&1 | tail -10
+python3 <<'PY'
+import xml.etree.ElementTree as ET
+r = ET.parse('app/build/test-results/testDebugUnitTest/TEST-io.wolftown.kaiku.data.voice.WebRtcManagerTest.xml').getroot()
+print(f"tests={r.get('tests')} skipped={r.get('skipped')} failures={r.get('failures')} errors={r.get('errors')}")
+PY
+```
+
+Expected: `tests=18 skipped=0 failures=0 errors=0`.
+
+- [ ] **Step 6: Verify no `@Ignore` remains anywhere in voice tests**
+
+```bash
+grep -rn '@Ignore' mobile/android/app/src/test/java/io/wolftown/kaiku/data/voice/
+```
+
+Expected: empty output.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/detair/GIT/detair/kaiku/.claude/worktrees/voice-scope-inject
+git add mobile/android/app/src/test/java/io/wolftown/kaiku/data/voice/WebRtcManagerTest.kt
+git commit -m "test(client): un-ignore voiceIceConnected test; inject backgroundScope"
+```
+
+---
+
+## Task 6: Update `mobile/android/app/src/test/AGENTS.md`
+
+**Files:**
+- Modify: `mobile/android/app/src/test/AGENTS.md`
+
+Workstream A introduced this file with a "Currently `@Ignore`d tests" section listing one entry, and a "`CoroutineScope(Dispatchers.IO)` + `StandardTestDispatcher` caveat" section proposing three workarounds of which option 2 was "inject the scope." This task makes option 2 canonical (now that it's been applied) and updates the registry.
+
+- [ ] **Step 1: Update the "Currently `@Ignore`d tests" section**
+
+Find the section:
+
+```bash
+grep -nE '^## Currently @Ignore|^- `WebRtcManagerTest' mobile/android/app/src/test/AGENTS.md
+```
+
+Replace the content of that section — currently lists the `voiceIceConnected` test — with a single-line statement:
+
+```markdown
+## Currently `@Ignore`d tests
+
+None.
+
+If you add a new `@Ignore`, append it here with a one-line reason and link
+an issue or ticket.
+```
+
+- [ ] **Step 2: Update the `CoroutineScope(Dispatchers.IO)` + `StandardTestDispatcher` caveat section**
+
+Find the section:
+
+```bash
+grep -nE '^## `CoroutineScope|option 2|Inject the scope' mobile/android/app/src/test/AGENTS.md
+```
+
+Replace the three-option list with a single canonical recommendation pointing at `@VoiceCoroutineScope`:
+
+```markdown
+## `CoroutineScope(Dispatchers.IO)` + `StandardTestDispatcher` caveat
+
+Production code that wraps a flow in `stateIn(CoroutineScope(Dispatchers.IO), Eagerly, …)`
+or launches collectors on its own `Dispatchers.IO` scope cannot be driven by
+`TestCoroutineScheduler`. `runCurrent()` / `advanceUntilIdle()` only drain the
+test dispatcher, so synchronous assertions on `.value` right after mutating the
+source flow may read stale state.
+
+**Canonical fix: inject the scope via Hilt with a dedicated qualifier.**
+
+```kotlin
+// Production — in a Hilt module
+@Module @InstallIn(SingletonComponent::class)
+object MyFeatureScopeModule {
+    @Provides @Singleton @MyFeatureScope
+    fun provideScope(): CoroutineScope =
+        CoroutineScope(SupervisorJob() + Dispatchers.IO)
+}
+
+// Production — in the consumer
+class MyFeature @Inject constructor(
+    @MyFeatureScope private val scope: CoroutineScope,
+) {
+    val state: StateFlow<Boolean> = combine(...).stateIn(scope, Eagerly, false)
+}
+
+// Test
+@Test fun test() = runTest {
+    val feature = MyFeature(scope = backgroundScope)
+    // TestCoroutineScheduler now drives the stateIn combine.
+}
+```
+
+`WebRtcManager`'s `voiceIceConnected` uses this pattern via `@VoiceCoroutineScope`
+(`mobile/android/app/src/main/java/io/wolftown/kaiku/di/VoiceCoroutineScope.kt`).
+
+**Fallbacks (avoid unless the injection path is genuinely blocked):**
+
+- `@VisibleForTesting internal var scope` setter — requires making the
+  downstream `StateFlow` `by lazy` and introduces a test-only code path.
+- `Dispatchers.Unconfined` for `stateIn` — sidesteps scheduling but runs
+  continuations on the emitter's thread, with subtle correctness risks.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/detair/GIT/detair/kaiku/.claude/worktrees/voice-scope-inject
+git add mobile/android/app/src/test/AGENTS.md
+git commit -m "docs(client): update AGENTS.md — no @Ignore'd voice tests; canonical scope inject"
+```
+
+---
+
+## Task 7: CHANGELOG entry
+
+**Files:**
+- Modify: `CHANGELOG.md` — top-most `### Fixed` under `## [Unreleased]`.
+
+- [ ] **Step 1: Locate the insertion point**
+
+```bash
+grep -nE '^## \[Unreleased\]|^### Fixed' CHANGELOG.md | head -5
+```
+
+Find the first `### Fixed` that falls inside `## [Unreleased]`.
+
+- [ ] **Step 2: Append a new bullet at the top of that `### Fixed` block**
+
+```markdown
+- Android: voice-layer `CoroutineScope` is now DI-provided, making the full `WebRtcManager` test suite runnable under `TestCoroutineScheduler` and unblocking CI coverage for dual-PC ICE state transitions
+```
+
+(Do not introduce a new `## [Unreleased]` section — use the existing one.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/detair/GIT/detair/kaiku/.claude/worktrees/voice-scope-inject
+git add CHANGELOG.md
+git commit -m "docs(client): CHANGELOG entry for voice-layer scope injection"
+```
+
+---
+
+## Final Verification (before opening PR)
+
+- [ ] **Compile + full unit test suite**
+
+```bash
+cd mobile/android
+./gradlew :app:compileDebugKotlin 2>&1 | grep -E "BUILD (SUCCESSFUL|FAILED)" | tail -2
+./gradlew :app:testDebugUnitTest --rerun-tasks 2>&1 | tail -3
+python3 <<'PY'
+import xml.etree.ElementTree as ET, glob
+total=skips=fails=errors=0
+by_cls = []
+for f in sorted(glob.glob('app/build/test-results/testDebugUnitTest/*.xml')):
+    r = ET.parse(f).getroot()
+    t = int(r.get('tests',0)); s = int(r.get('skipped',0)); fl = int(r.get('failures',0)); e = int(r.get('errors',0))
+    total += t; skips += s; fails += fl; errors += e
+    if fl or e: by_cls.append((r.get('name'), fl+e))
+print(f"TOTAL tests={total} skipped={skips} failures={fails} errors={errors}")
+for n, c in by_cls: print(f"  {n}: {c}")
+PY
+```
+
+Expected:
+- `BUILD SUCCESSFUL` on compile.
+- `tests=175` (Workstream A baseline 174 + 1 un-skipped = same 174 if backed by the same set; more likely 174 with 1 fewer skipped).
+- `skipped=0` (dropped from 1).
+- `failures=13` — the Block 3 allowlist (`AuthStateTest×2, AuthFlowTest×5, MessageFlowTest×5, QrLoginFlowTest×1`). No new classes.
+
+If any failure class appears outside the allowlist, **STOP** — Block 4 has introduced a regression. Likely suspect: the `UnconfinedTestDispatcher` default in `newWebRtcManager()` reordered emissions for a previously-passing test. Diagnose by switching the default to a vanilla `CoroutineScope` and re-running.
+
+- [ ] **Grep for residual anti-patterns**
+
+```bash
+grep -rn '@Ignore' mobile/android/app/src/test/java/io/wolftown/kaiku/data/voice/
+grep -rn 'CoroutineScope(Dispatchers.IO)' mobile/android/app/src/main/java/io/wolftown/kaiku/data/voice/
+```
+
+Expected: both empty. The first confirms no voice tests are ignored; the second confirms `WebRtcManager` no longer constructs its own scope.
+
+- [ ] **Commit log review**
+
+```bash
+cd /home/detair/GIT/detair/kaiku/.claude/worktrees/voice-scope-inject
+git log --oneline origin/main..HEAD
+```
+
+Expected 7 commits in this order:
+
+1. `feat(client): @VoiceCoroutineScope qualifier for voice-layer scope DI`
+2. `feat(client): VoiceCoroutineScopeModule @Provides for voice-layer scope`
+3. `refactor(voice): WebRtcManager uses injected @VoiceCoroutineScope`
+4. `test(client): newWebRtcManager helper accepts injected voiceScope`
+5. `test(client): un-ignore voiceIceConnected test; inject backgroundScope`
+6. `docs(client): update AGENTS.md — no @Ignore'd voice tests; canonical scope inject`
+7. `docs(client): CHANGELOG entry for voice-layer scope injection`
+
+- [ ] **Push and open PR**
+
+```bash
+git push -u origin feat/webrtc-scope-inject
+gh pr create --base main --head feat/webrtc-scope-inject \
+  --title "feat(voice): inject @VoiceCoroutineScope into WebRtcManager" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Block 4 of Phase 2.5 open-topics cleanup. Un-ignores `WebRtcManagerTest.voiceIceConnected emits true only when both PCs reach Connected` (the last `@Ignore` in the Android voice-test suite) by making `WebRtcManager`'s internal `stateIn` scope injectable via a `@VoiceCoroutineScope` Hilt qualifier.
+
+- New qualifier: `io.wolftown.kaiku.di.VoiceCoroutineScope`
+- New module: `VoiceCoroutineScopeModule` with `@Provides @Singleton` for `CoroutineScope(SupervisorJob() + Dispatchers.IO)`
+- `WebRtcManager` gains a 4th constructor parameter; inline `CoroutineScope(Dispatchers.IO)` at `WebRtcManager.kt:159` is replaced
+- Test helper `newWebRtcManager()` accepts an optional `voiceScope` (default `TestScope(UnconfinedTestDispatcher())`); the previously-`@Ignore`d test passes `backgroundScope`
+- AGENTS.md updated: `@Ignore` registry now "None"; scope-injection becomes the canonical pattern
+
+Spec: `docs/superpowers/specs/2026-04-16-open-topics-cleanup-design.md` — Block 4.
+
+## Test plan
+
+- [x] `./gradlew :app:compileDebugKotlin` — BUILD SUCCESSFUL
+- [x] `./gradlew :app:testDebugUnitTest --tests WebRtcManagerTest` — 18 tests, 0 skipped, 0 failed
+- [x] Full `:app:testDebugUnitTest` — 13 remaining failures, all in Block 3's pre-existing allowlist (`AuthStateTest`, `AuthFlowTest`, `MessageFlowTest`, `QrLoginFlowTest`)
+- [x] `grep -rn '@Ignore' mobile/android/app/src/test/java/io/wolftown/kaiku/data/voice/` — empty
+
+## Scope lifecycle
+
+The injected `CoroutineScope` is owned by Hilt's `SingletonComponent`. `WebRtcManager.dispose()` does **not** cancel it — `SupervisorJob` keeps sibling children alive, and the scope may gain future consumers. Scope-cancellation semantics on app shutdown are a separate concern deferred per spec.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Wait for CI green and merge**
+
+```bash
+gh pr checks <PR_NUMBER> --watch
+gh pr merge <PR_NUMBER> --squash
+```
+
+---
+
+## Post-merge cleanup
+
+```bash
+cd /home/detair/GIT/detair/kaiku
+git worktree remove .claude/worktrees/voice-scope-inject
+git branch -D feat/webrtc-scope-inject
+git push origin --delete feat/webrtc-scope-inject
+git fetch --prune
+```
+
+---
+
+## Notes for the implementer
+
+- **Do not batch Tasks 1 and 2 into Task 3's refactor.** The qualifier + provider are standalone and compile-clean on their own; keeping them as separate commits produces a readable history where each commit is an atomically-reviewable DI addition.
+- **The `UnconfinedTestDispatcher` default in `newWebRtcManager`** is a conservative choice. It runs continuations synchronously on the calling thread, which matches the prior behavior of the pure-data tests that never touched the scope at all. If any of the 5 previously-passing tests start failing after Task 4, swap to `StandardTestDispatcher()` and re-run; they may have picked up an implicit ordering assumption.
+- **Hilt auto-discovery of the new module.** Both `VoiceCoroutineScopeModule` (new) and `VoiceModule` (existing) are `@InstallIn(SingletonComponent::class)`. Gradle's Hilt plugin picks both up automatically — no manual registration in `KaikuApplication` needed.
+- **If Task 5's scheduler test fails after un-ignoring** with an `AssertionError`, the most likely cause is that `runTest { backgroundScope }` is not what you think. `backgroundScope` is the `CoroutineScope` property of the `TestScope` *receiver* inside `runTest { … }` — it's already bound to the test's `TestCoroutineScheduler`. If you see "backgroundScope not resolved," make sure the test lambda is a `TestScope.() -> Unit` (which `runTest` is), and that `kotlinx-coroutines-test:1.9.0` is on the classpath (verified during spec writing).
+- **Do not add scope cancellation to `dispose()`** even if it feels "tidy." Spec Block 4 explicitly defers that to a follow-up workstream. Landing it here couples this small injection PR to a broader lifecycle-audit concern that isn't ready to ship.

--- a/docs/superpowers/specs/2026-04-16-open-topics-cleanup-design.md
+++ b/docs/superpowers/specs/2026-04-16-open-topics-cleanup-design.md
@@ -1,0 +1,331 @@
+# Phase 2.5 — Open Topics Cleanup
+
+**Date:** 2026-04-16
+**Status:** Draft
+**Goal:** Close the open items left behind by Phase 1's admin-merged PRs (#529–#534) and by Workstream A's deliberate scope carve-outs: restore honest-green CI on `main`, land the four remaining Phase 1 PRs without admin override, classify the 13 pre-existing Android test failures into actionable clusters, and un-ignore the last voice test by injecting `WebRtcManager`'s internal `CoroutineScope`.
+
+## Context
+
+Phase 1 shipped five voice/screen-share PRs (#529–#533) and Phase 2 Workstream A shipped #534 (Android test infrastructure). Both phases reached `main` via `gh pr merge --admin` because `main`'s CI had two pre-existing drift failures that predate the Phase 1 branches and affected every PR that branched from any recent commit of `main`:
+
+- **`Rust Lint (fmt)`** — `server/src/ws/handlers.rs:73` has a docstring that nightly `rustfmt` wants reformatted under `wrap_comments=true` (an unstable feature in the project's `rustfmt.toml`). Contributors running `make fmt` or `cargo fmt` on stable silently pass because stable rustfmt ignores unstable features; CI runs nightly for the fmt check and flags the drift.
+- **`License Compliance` (advisories)** — `rustls-webpki 0.103.10` is pinned by transitive deps, and `RUSTSEC-2026-0099` (name-constraint bypass for wildcard certs) was published against this version. Fix is a `cargo update -p rustls-webpki` bumping to `≥0.103.12`.
+
+`Rust Lint (clippy)` fails as a cascade of the fmt workflow's cancellation; fixing fmt should unblock clippy automatically.
+
+Workstream A (#534) also left two intentional scope carve-outs:
+
+- **13 pre-existing Android unit test failures** in `AuthStateTest` (×2), `AuthFlowTest` (×5), `MessageFlowTest` (×5), `QrLoginFlowTest` (×1). Three of the four classes are integration tests, suggesting a shared fixture/component is the likely root cause — but that is an untested hypothesis.
+- **1 `@Ignore`d voice test** — `WebRtcManagerTest.voiceIceConnected emits true only when both PCs reach Connected`. `WebRtcManager.voiceIceConnected` uses `stateIn(CoroutineScope(Dispatchers.IO), Eagerly, false)` with an *inline* anonymous scope. `TestCoroutineScheduler` cannot drive that scope, so `runCurrent()` never flushes the combine re-emission, and the assertion reads stale state.
+
+Finally, PRs #529 (server security), #530 (web ICE buffering), #531 (Tauri RTP protocol), #532 (Tauri VP8 decode) from Phase 1 remain open with the same CI drift blocking them.
+
+This workstream closes all of the above.
+
+## Scope
+
+Four sub-workstreams, each shipping as its own PR (or set of PRs for Block 2). Block 1 is the sequencing prerequisite; Blocks 3 and 4 parallelize with Block 2 once Block 1 lands.
+
+**Out of scope (deliberate):**
+
+- **Phase 2 Workstreams B, C, D, E, F, G** — commissioned separately by the user with their own specs (B.2 error UX, G Tauri test gaps, etc.).
+- **Actually fixing production bugs in auth/messaging/qr-login** if Block 3's triage uncovers them — those are commissioned as follow-up workstreams off the triage report, not landed under Block 3.
+- **Scope lifecycle refactor** — injecting `CoroutineScope` (Block 4) does not introduce scope-cancellation on `WebRtcManager.dispose()`. That is a separate concern that would require auditing all scope consumers; deferred.
+
+## Block 1 — CI drift fix
+
+**Goal:** Turn `main`'s CI back to honest-green and prevent the Makefile-fmt trap that allowed the drift to accumulate.
+
+**Changes (single PR, four commits):**
+
+1. **Fix the fmt drift.** Run `cargo +nightly fmt --all`. Confirmed single-file delta in `server/src/ws/handlers.rs:73` — a docstring the nightly `wrap_comments=true` feature wants rewrapped.
+2. **Patch the security advisory.** Run `cargo update -p rustls-webpki` to bump from `0.103.10` → `≥0.103.12`. Resolves `RUSTSEC-2026-0099`. `Cargo.lock` delta only; the bump is semver-patch and MSRV-compatible with the existing `rustls 0.23.x` + `hyper-rustls 0.27.x` graph.
+3. **Route `Makefile` fmt targets through nightly.** `Makefile:139` changes `cargo fmt --all` → `cargo +nightly fmt --all`; `Makefile:143` changes `cargo fmt --all -- --check` → `cargo +nightly fmt --all -- --check`. Contributors running `make fmt` / `make fmt-check` now reproduce CI's check locally.
+4. **Document the nightly requirement.** Short paragraph in `docs/developer-guide/development/standards.md` flagging that fmt requires nightly rustfmt and noting `rustup toolchain install nightly -c rustfmt` as the install command.
+
+**Commits:**
+
+1. `fix(infra): apply cargo +nightly fmt to handlers.rs docstring`
+2. `chore(infra): cargo update -p rustls-webpki for RUSTSEC-2026-0099`
+3. `chore(infra): route Makefile fmt targets through nightly toolchain`
+4. `docs(infra): note nightly rustfmt requirement in standards.md`
+
+(CLAUDE.md allowed commit types are `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `perf`, `style`; allowed scopes include `infra` which covers tooling/CI/Makefile changes.)
+
+**Success criteria:**
+
+- `Rust Lint (fmt)`, `Rust Lint (clippy)`, `License Compliance` — all green on the PR and on `main` post-merge.
+- `cargo deny check advisories` locally returns 0 matches for `RUSTSEC-2026-0099`.
+- `make fmt-check` on a contributor machine with nightly installed returns no diff.
+- `make fmt-check` on a contributor machine *without* nightly produces a clear error pointing to the standards.md note (rustup returns a missing-toolchain message; acceptable).
+
+**Risks:**
+
+- **`rustls-webpki` bump breaks another transitive consumer.** Low probability (patch bump). Mitigated by running `cargo test` in the workspace before pushing.
+- **More fmt drift discovered once nightly fmt runs.** Confirmed via `cargo +nightly fmt --check` that the only diff is `handlers.rs:73` — no other drift hidden. If that changes between now and PR creation, expand scope of commit 1 accordingly.
+- **No pre-commit hook.** Deliberate — drift rate is ~1 file per quarter; not worth the tooling overhead. Re-evaluate if drift recurs after this PR.
+
+## Block 2 — Clean-merge Phase 1 PRs #529–#532
+
+**Goal:** Land the four remaining Phase 1 PRs on a green-CI `main` without admin override. Restores real CI signal for future PRs.
+
+**Hard dependency:** Block 1 must merge first.
+
+**Sequence and rationale:**
+
+1. **#529 — `fix(voice): server security — self-mute, rate limiting, screen share slot leak`.** Rust server. Independent. Security-sensitive; goes first to reduce exposure time.
+2. **#530 — `fix(client): buffer ICE candidates until remote description is set`.** Web client. Independent of #529 and Tauri PRs. Can merge any time after #529.
+3. **#531 — `fix(voice): Tauri RTP protocol — per-session seq/ts, VP8 payload_type`.** Tauri client. Must precede #532 (content dependency: #532's VP8 decode path relies on #531's RTP protocol fixes).
+4. **#532 — `feat(voice): native VP8 decode for remote screen shares in Tauri`.** Tauri client. After #531.
+
+**Per-PR shepherding protocol:**
+
+Worktrees are already set up in `.claude/worktrees/{voice-server-security,web-voice-ice-buffering,tauri-voice-rtp-protocol,tauri-vp8-decode}`. For each PR in sequence:
+
+1. `cd <worktree>`
+2. `git fetch origin && git rebase origin/main` (new `main` includes Block 1 fixes + any previously-landed PRs in this sequence)
+3. Resolve any drift conflicts — most likely in `Cargo.lock` (due to Block 1's `rustls-webpki` bump interacting with the PR's own dep deltas). For text-file drift in `server/src/ws/handlers.rs` or similar, rerun `cargo +nightly fmt --all` after rebasing.
+4. Run local gates per CLAUDE.md: `cargo test` + `bun run test:run` (if the PR touches frontend) + `SQLX_OFFLINE=true cargo clippy -- -D warnings` (if server).
+5. `git push --force-with-lease`.
+6. Wait for CI green (no admin override).
+7. `gh pr merge <n> --squash`.
+8. Post-merge cleanup: `git worktree remove <worktree> && git branch -D <branch> && git push origin --delete <branch>`.
+
+**No new code.** We are not the owners of these PRs. Block 2's sole deliverable is that all four squash-land with honest green CI.
+
+**Commits:** Block 2 contributes zero commits of its own; it's purely a merge-shepherding activity. PR bodies are authored by the PR owners.
+
+**Success criteria:**
+
+- All four PRs merged to `main`.
+- Final merge commits' CI status on `main` is green.
+- All four feature worktrees removed; all four remote branches deleted; `git branch --list` shows no `[gone]` entries for these branches.
+
+**Risks:**
+
+- **#529 content introduces new `handlers.rs` drift.** Possible — #529 touches server code likely including WebSocket handlers. Mitigated by rerunning `cargo +nightly fmt --all` during rebase and committing any additional fmt delta.
+- **`Cargo.lock` merge conflicts.** Possible — Block 1 bumps `rustls-webpki` and #529 might transitively pull different versions. Standard resolution: accept main's version, rerun `cargo build` to regenerate `Cargo.lock` cleanly.
+- **Test regressions under the fixed toolchain.** If Block 1's nightly rustfmt pass surfaces an issue clippy doesn't catch, #529's Rust Tests could fail in ways that didn't before. Mitigated by running `cargo test` locally during rebase. If regressions appear, surface to PR owner; do not silently fix.
+
+## Block 3 — Test-failure triage spike
+
+**Goal:** Convert "13 unknown failures" into "clustered root causes with actionable next steps" within a bounded investigation budget.
+
+**Budget:** 90 minutes wall-clock for investigation. Additionally, up to 30 minutes for inline fix commits if clusters resolve to S-rated quick fixes — for a 120-minute total worst case. The 30-minute fix budget is *additive* to the 90-minute investigation budget, not carved out of it. If investigation alone exceeds 90 minutes, the PR ships as a classification document only and any fix work is commissioned as a follow-up.
+
+**Investigation method:**
+
+1. Run `./gradlew :app:testDebugUnitTest` with full stack traces captured to a scratch file.
+2. For each of the 13 failing tests, record: fully-qualified test name, assertion/exception message, first 5 frames of the stack trace, test file path.
+3. Cluster by root cause signal:
+   - Shared fixture failure? (e.g., `@Before` consistently throws the same error across all tests in a class)
+   - Shared infrastructure failure? (e.g., a Hilt test component, mocked HTTP server, datastore fixture used by all three integration-test classes)
+   - Independent real bugs in production code under test?
+4. For each cluster, document: (i) root-cause hypothesis backed by evidence, (ii) estimated fix size (S/M/L: <30 min, <4h, >4h), (iii) domain owner (auth, messaging, qr-login, data-local), (iv) recommended approach (inline fix, dedicated workstream, permanent `@Ignore` with tracker link).
+
+**PR deliverable:** `docs/developer-guide/testing/2026-04-16-android-test-failure-triage.md` containing:
+
+- Per-class failure tables with the data from step 2.
+- A cluster index: 1–3 clusters, each with the step-4 attributes.
+- For each cluster rated "S": fix commits in the same PR.
+- For each cluster rated "M" or "L": a one-paragraph spec proposal that could seed a follow-up `docs/superpowers/specs/YYYY-MM-DD-<cluster>-design.md`.
+
+**Commits (single PR):**
+
+1. `docs(client): triage 13 pre-existing Android unit test failures`
+2. (Zero or more) `test(client): <cluster fix>` — only for S-rated clusters.
+
+**Success criteria:**
+
+- Triage doc committed.
+- Every one of the 13 failing tests appears in the doc's per-class table.
+- At least one cluster has a clear fix path (even if rated M/L and deferred).
+- If any S-rated fixes land inline, those tests pass in the PR's CI run.
+- No new test failures introduced by the PR.
+
+**Risks:**
+
+- **No clustering emerges — 13 genuinely independent bugs.** Possible but unlikely given 3 integration-test classes failing together. Mitigation: the doc still ships as "no shared root cause" and each failure gets its own L-rated proposal. The spike's deliverable is classification, not fix-everything.
+- **Investigation overruns the 90-minute budget.** Acknowledged risk. If the budget is exceeded, the spike MUST stop; partial findings ship as a `status: incomplete` section of the doc, and a follow-up spike gets commissioned. Do not let investigation become a rabbit hole.
+
+## Block 4 — `CoroutineScope` injection into `WebRtcManager`
+
+**Goal:** Un-ignore `WebRtcManagerTest.voiceIceConnected emits true only when both PCs reach Connected` (the only remaining `@Ignore` in the Android voice-test suite) by making `WebRtcManager`'s `stateIn` scope injectable.
+
+### Changes
+
+**1. New qualifier annotation:** `mobile/android/app/src/main/java/io/wolftown/kaiku/di/VoiceCoroutineScope.kt`
+
+```kotlin
+package io.wolftown.kaiku.di
+
+import javax.inject.Qualifier
+
+/**
+ * Qualifier for the [CoroutineScope] used by voice-layer background work
+ * (e.g., [WebRtcManager.voiceIceConnected] stateIn collection).
+ *
+ * Tests inject a [kotlinx.coroutines.test.TestScope] via this qualifier so the
+ * test scheduler drives all emissions.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class VoiceCoroutineScope
+```
+
+**2. New Hilt provider module** (`mobile/android/app/src/main/java/io/wolftown/kaiku/di/VoiceCoroutineScopeModule.kt`):
+
+```kotlin
+package io.wolftown.kaiku.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object VoiceCoroutineScopeModule {
+    @Provides
+    @Singleton
+    @VoiceCoroutineScope
+    fun provideVoiceCoroutineScope(): CoroutineScope =
+        CoroutineScope(SupervisorJob() + Dispatchers.IO)
+}
+```
+
+New `object` module (distinct from `VoiceModule` which is an `abstract class` for `@Binds`). Hilt requires `@Provides` methods to live in either `object` or concrete classes.
+
+**3. `WebRtcManager` constructor addition:**
+
+```kotlin
+@Singleton
+class WebRtcManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val voiceApi: VoiceApi,
+    private val eglBaseProvider: EglBaseProvider,
+    @VoiceCoroutineScope private val voiceScope: CoroutineScope,
+) {
+    ...
+    val voiceIceConnected: StateFlow<Boolean> =
+        combine(publisherIceState, subscriberIceState) { p, s ->
+            p == PeerConnection.IceConnectionState.CONNECTED &&
+                s == PeerConnection.IceConnectionState.CONNECTED
+        }.stateIn(voiceScope, SharingStarted.Eagerly, false)
+}
+```
+
+The inline `CoroutineScope(Dispatchers.IO)` at `WebRtcManager.kt:159` is replaced by the injected `voiceScope`.
+
+### Scope lifecycle decision
+
+`WebRtcManager.dispose()` does **not** cancel `voiceScope`. Rationale:
+
+- The scope is provided at `SingletonComponent` level; its lifetime is the application lifetime.
+- `SupervisorJob` means a child coroutine's failure does not cancel the scope itself.
+- The scope may gain additional consumers in future workstreams; a singleton's `dispose()` unilaterally cancelling a DI-owned resource is the wrong default.
+- If a future workstream needs scope-cancellation-on-dispose, it can explicitly own a scoped child via `coroutineScope { ... }` or `launch` on a local `Job`.
+
+Tests provide their own scope (see test update below), so scope leakage is not a JVM-unit-test concern.
+
+### Test update
+
+**`WebRtcManagerTest.kt`:**
+
+- The existing `newWebRtcManager()` helper gains a 4th parameter `voiceScope`:
+  ```kotlin
+  private fun newWebRtcManager(
+      voiceScope: CoroutineScope = TestScope(UnconfinedTestDispatcher()),
+  ): WebRtcManager = WebRtcManager(
+      context = mockk<Context>(relaxed = true),
+      voiceApi = mockk<VoiceApi>(relaxed = true),
+      eglBaseProvider = mockk<EglBaseProvider>(relaxed = true),
+      voiceScope = voiceScope,
+  )
+  ```
+  Default is `TestScope(UnconfinedTestDispatcher())` so tests that don't care about scheduler control get synchronous emission.
+- For `voiceIceConnected emits true only when both PCs reach Connected`, the `runTest` block passes `this.backgroundScope` (the `TestScope`-provided `CoroutineScope` backed by the same scheduler as `runTest`):
+  ```kotlin
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
+  fun `voiceIceConnected emits true only when both PCs reach Connected`() = runTest {
+      val webRtcManager = newWebRtcManager(voiceScope = backgroundScope)
+      // ... existing test body unchanged; runCurrent() now actually drives the combine
+  }
+  ```
+- The `@Ignore` annotation and its import (`org.junit.Ignore`) are removed.
+
+**`mobile/android/app/src/test/AGENTS.md` update (from Workstream A):**
+
+- "Currently `@Ignore`d tests" section changes from one entry to "None".
+- "`CoroutineScope(Dispatchers.IO)` + `StandardTestDispatcher` caveat" section's workaround #2 ("Inject the scope") becomes the canonical pattern with a reference to `@VoiceCoroutineScope`.
+
+### Commits (single PR)
+
+1. `feat(client): @VoiceCoroutineScope qualifier + Hilt provider`
+2. `refactor(voice): WebRtcManager uses injected @VoiceCoroutineScope`
+3. `test(client): un-ignore voiceIceConnected test; inject TestScope`
+4. `docs(client): update AGENTS.md — no more @Ignore`d voice tests`
+5. `docs(client): CHANGELOG entry`
+
+### Success criteria
+
+- `./gradlew :app:testDebugUnitTest --tests 'io.wolftown.kaiku.data.voice.WebRtcManagerTest'` reports **18 tests, 0 skipped, 0 failed**.
+- `grep -rn '@Ignore' mobile/android/app/src/test/java/io/wolftown/kaiku/data/voice/` returns no matches.
+- `AGENTS.md` "Currently `@Ignore`d tests" section reads `None`.
+- Full `testDebugUnitTest` still has failures only in the Block 3 allowlist (`AuthStateTest`, `AuthFlowTest`, `MessageFlowTest`, `QrLoginFlowTest`).
+
+### Risks
+
+- **New Hilt graph cycle.** Low probability — `CoroutineScope` has no dependencies beyond JDK types. Hilt codegen catches cycles at compile time.
+- **`backgroundScope` is missing on older `kotlinx-coroutines-test`.** `backgroundScope` is available from 1.7.0+; the project uses `1.9.0` per `build.gradle.kts:140`. Safe.
+- **Test flakiness from `UnconfinedTestDispatcher` default.** `UnconfinedTestDispatcher` runs continuations eagerly on the current thread — fine for the existing tests that don't care about scheduling. The scheduler-sensitive test explicitly overrides with `backgroundScope` (`StandardTestDispatcher`-equivalent). No regression risk for the 5 other un-ignored tests.
+
+## Sequencing & dependencies
+
+```
+Block 1 (PR A: CI drift fix) — hard gate
+   │
+   ├──► Block 2 PR1 (#529 server security)
+   │       └──► Block 2 PR2 (#530 web ICE)
+   │              └──► Block 2 PR3 (#531 Tauri RTP)
+   │                     └──► Block 2 PR4 (#532 Tauri VP8)
+   │
+   ├──► Block 3 (PR C: test triage) — parallelizable with Block 2
+   │
+   └──► Block 4 (PR D: CoroutineScope inject) — parallelizable with Block 2 & 3
+```
+
+- Block 1 is the only hard prerequisite. It must merge before Block 2's first PR and should merge before Blocks 3 and 4's PRs open so they inherit green-CI baseline.
+- Block 2 serializes among its four PRs (#529 → #530 → #531 → #532). #530 actually has no content dependency on #529 and could race, but serializing reduces CI-rebasing churn and keeps merge history legible.
+- Blocks 3 and 4 are fully independent and can open in parallel.
+
+## Success criteria (workstream-level)
+
+1. `main`'s CI is green on three consecutive commits without admin override.
+2. All four Phase 1 PRs (#529, #530, #531, #532) merged.
+3. `./gradlew :app:testDebugUnitTest --tests 'io.wolftown.kaiku.data.voice.*'` reports **zero** `@Ignore`'d tests and zero failures.
+4. `docs/developer-guide/testing/2026-04-16-android-test-failure-triage.md` exists and classifies all 13 pre-existing failures.
+5. Workstream-A and Phase-2.5 worktrees + branches cleaned up (`.claude/worktrees/` contains only active work).
+
+## CHANGELOG entries
+
+Per CLAUDE.md, user-relevant changes go under `## [Unreleased]` in `CHANGELOG.md`. Not every block warrants one:
+
+- **Block 1:** `### Security` — "Upgrade `rustls-webpki` to patch RUSTSEC-2026-0099 (name-constraint bypass for wildcard certs)." Fmt / Makefile changes are tooling; not user-visible.
+- **Block 2:** Each of the four PRs already carries its own CHANGELOG entry from its original author; no new entries from this workstream.
+- **Block 3:** None unless S-rated fixes land (those get their own entry per cluster).
+- **Block 4:** `### Fixed` — "Android: voice-layer `CoroutineScope` is now DI-provided, making the full `WebRtcManager` test suite runnable under `TestCoroutineScheduler` and unblocking CI coverage for dual-PC ICE state transitions."
+
+## Out of scope
+
+- **Phase 2 Workstreams B/C/D/E/F/G** — separate specs, user-commissioned.
+- **Production fixes for any auth/messaging/qr-login bugs surfaced by Block 3's triage** — those are commissioned as follow-up workstreams, not landed inside Block 3.
+- **Scope-cancellation semantics on `WebRtcManager.dispose()`** — explicitly deferred; Block 4 leaves the scope owned by Hilt's `SingletonComponent`.
+- **Robolectric adoption, instrumented `androidTest/` coverage, or any expansion of the Android test pyramid** — carries forward Workstream A's decision to focus on JVM unit tests only.
+- **Pre-commit hooks or other automated fmt enforcement beyond the Makefile fix** — re-evaluate if drift recurs after Block 1.
+- **Cleaning up `[gone]` branches and stale worktrees not related to the four blocks** — trivial git housekeeping, out of design scope.


### PR DESCRIPTION
## Summary

Ships the design spec and four implementation plans for Phase 2.5 open-topics cleanup. No code changes — docs only.

- `docs/superpowers/specs/2026-04-16-open-topics-cleanup-design.md` — master design covering four sub-workstreams (CI drift fix, merge Phase 1 PRs, triage 13 pre-existing test failures, inject `@VoiceCoroutineScope` into `WebRtcManager`)
- `docs/superpowers/plans/2026-04-16-block1-ci-drift-fix.md`
- `docs/superpowers/plans/2026-04-16-block2-merge-phase1-prs.md`
- `docs/superpowers/plans/2026-04-16-block3-test-triage-spike.md`
- `docs/superpowers/plans/2026-04-16-block4-coroutine-scope-inject.md`

Brainstormed + spec-reviewed + plan-reviewed via the superpowers skill pipeline. Each block lands as its own implementation PR; the spec/plans live on `main` first so those PRs can reference them by path.

## Execution sequence

- **Block 1** (CI drift fix) is the hard gate — it's what turns `main`'s CI green and ends the admin-merge habit. Start immediately after this docs PR merges.
- **Block 2** (merge #529–#532) serializes after Block 1.
- **Blocks 3 and 4** can parallelize with Block 2 once Block 1 lands.

## Expected CI

This PR will hit the same three pre-existing drift failures on `main` (`Rust Lint (fmt)`, `Rust Lint (clippy)`, `License Compliance`). They are NOT caused by this PR (docs-only, zero code delta) and are exactly the failures Block 1 fixes. Merging via `--admin` is appropriate for this last-docs-before-the-fix case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)