### PR TITLE
feat(voice): inject @VoiceCoroutineScope into WebRtcManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Voice signaling events are rate-limited per peer to prevent flooding
 
 ### Fixed
+- Android: voice-layer `CoroutineScope` is now DI-provided, making the full `WebRtcManager` test suite runnable under `TestCoroutineScheduler` and unblocking CI coverage for dual-PC ICE state transitions
 - Screen share slots are no longer leaked by duplicate stream IDs
 - Android: test infrastructure now injects EglBase via a provider so unit tests can be written without native EGL14 stubs; unblocks CI coverage for voice signaling
 - Android: OIDC callback path matching is now exact instead of prefix-based, preventing potential intent collisions

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/data/voice/WebRtcManager.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/data/voice/WebRtcManager.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.wolftown.kaiku.data.api.IceServer
 import io.wolftown.kaiku.data.api.VoiceApi
+import io.wolftown.kaiku.di.VoiceCoroutineScope
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -60,7 +60,8 @@ import javax.inject.Singleton
 class WebRtcManager @Inject constructor(
     @ApplicationContext private val context: Context,
     private val voiceApi: VoiceApi,
-    private val eglBaseProvider: EglBaseProvider
+    private val eglBaseProvider: EglBaseProvider,
+    @VoiceCoroutineScope private val voiceScope: CoroutineScope,
 ) {
     companion object {
         private val logger = Logger.getLogger("WebRtcManager")
@@ -155,11 +156,7 @@ class WebRtcManager @Inject constructor(
         combine(publisherIceState, subscriberIceState) { p, s ->
             p == PeerConnection.IceConnectionState.CONNECTED &&
                 s == PeerConnection.IceConnectionState.CONNECTED
-        }.stateIn(
-            CoroutineScope(Dispatchers.IO),
-            SharingStarted.Eagerly,
-            false
-        )
+        }.stateIn(voiceScope, SharingStarted.Eagerly, false)
 
     // -- Callbacks ------------------------------------------------------------
 

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/di/VoiceCoroutineScope.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/di/VoiceCoroutineScope.kt
@@ -1,0 +1,14 @@
+package io.wolftown.kaiku.di
+
+import javax.inject.Qualifier
+
+/**
+ * Qualifier for the [kotlinx.coroutines.CoroutineScope] used by voice-layer
+ * background work (e.g., [WebRtcManager.voiceIceConnected] stateIn collection).
+ *
+ * Tests inject a `TestScope` / `backgroundScope` via this qualifier so the
+ * `TestCoroutineScheduler` drives all emissions synchronously.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class VoiceCoroutineScope

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/di/VoiceCoroutineScopeModule.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/di/VoiceCoroutineScopeModule.kt
@@ -1,0 +1,31 @@
+package io.wolftown.kaiku.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import javax.inject.Singleton
+
+/**
+ * Provides the application-scoped [CoroutineScope] used by voice-layer
+ * background collectors (e.g., `WebRtcManager.voiceIceConnected.stateIn(...)`).
+ *
+ * Kept separate from [VoiceModule] because that module is `abstract` for
+ * `@Binds` entries; Hilt requires `@Provides` to live in `object` or
+ * non-abstract modules.
+ *
+ * `SupervisorJob` ensures a child coroutine's failure does not cascade to
+ * siblings. `Dispatchers.IO` matches the prior (inline) behavior.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object VoiceCoroutineScopeModule {
+    @Provides
+    @Singleton
+    @VoiceCoroutineScope
+    fun provideVoiceCoroutineScope(): CoroutineScope =
+        CoroutineScope(SupervisorJob() + Dispatchers.IO)
+}

--- a/mobile/android/app/src/test/AGENTS.md
+++ b/mobile/android/app/src/test/AGENTS.md
@@ -92,24 +92,44 @@ or launches collectors on its own `Dispatchers.IO` scope cannot be driven by
 test dispatcher, so synchronous assertions on `.value` right after mutating the
 source flow may read stale state.
 
-Workarounds (in order of preference):
+**Canonical fix: inject the scope via Hilt with a dedicated qualifier.**
 
-1. **Use `turbine.test { }` with `awaitItem()`** — turbine's default timeout
-   (1s) covers real IO emission, so downstream state changes are observable
-   even though the producer runs on `Dispatchers.IO`.
-2. **Inject the scope** — make the production class accept a `CoroutineScope`
-   constructor parameter so tests can pass `TestScope(testDispatcher)`. Best
-   long-term fix; requires a Hilt `@Provides` for the default scope.
-3. **`@Ignore` with explicit reason** — acceptable when the test can only be
-   driven synchronously and option 2 is out of scope. Leave a one-line reason
-   referencing this constraint.
+```kotlin
+// Production — in a Hilt module
+@Module @InstallIn(SingletonComponent::class)
+object MyFeatureScopeModule {
+    @Provides @Singleton @MyFeatureScope
+    fun provideScope(): CoroutineScope =
+        CoroutineScope(SupervisorJob() + Dispatchers.IO)
+}
+
+// Production — in the consumer
+class MyFeature @Inject constructor(
+    @MyFeatureScope private val scope: CoroutineScope,
+) {
+    val state: StateFlow<Boolean> = combine(...).stateIn(scope, Eagerly, false)
+}
+
+// Test
+@Test fun test() = runTest {
+    val feature = MyFeature(scope = backgroundScope)
+    // TestCoroutineScheduler now drives the stateIn combine.
+}
+```
+
+`WebRtcManager`'s `voiceIceConnected` uses this pattern via `@VoiceCoroutineScope`
+(`mobile/android/app/src/main/java/io/wolftown/kaiku/di/VoiceCoroutineScope.kt`).
+
+**Fallbacks (avoid unless the injection path is genuinely blocked):**
+
+- `@VisibleForTesting internal var scope` setter — requires making the
+  downstream `StateFlow` `by lazy` and introduces a test-only code path.
+- `Dispatchers.Unconfined` for `stateIn` — sidesteps scheduling but runs
+  continuations on the emitter's thread, with subtle correctness risks.
 
 ## Currently `@Ignore`d tests
 
-- `WebRtcManagerTest.voiceIceConnected emits true only when both PCs reach Connected`
-  — blocked by option 2 above: `WebRtcManager.voiceIceConnected` uses
-  `stateIn(CoroutineScope(Dispatchers.IO), …)`. Un-ignore when the scope is
-  injectable.
+None.
 
 If you add a new `@Ignore`, append it here with a one-line reason and link
 an issue or ticket.

--- a/mobile/android/app/src/test/java/io/wolftown/kaiku/data/voice/WebRtcManagerTest.kt
+++ b/mobile/android/app/src/test/java/io/wolftown/kaiku/data/voice/WebRtcManagerTest.kt
@@ -3,7 +3,10 @@ package io.wolftown.kaiku.data.voice
 import android.content.Context
 import io.mockk.mockk
 import io.wolftown.kaiku.data.api.VoiceApi
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
@@ -41,11 +44,21 @@ class WebRtcManagerTest {
      * Construct a [WebRtcManager] with mocks suitable for tests that exercise
      * signaling/state behavior without needing a real EGL or native PeerConnection.
      * The provider's `create()` is never invoked unless the test reads `.eglBase`.
+     *
+     * [voiceScope] defaults to an `UnconfinedTestDispatcher`-backed [TestScope],
+     * which runs continuations synchronously on the calling thread. Tests that
+     * need scheduler control (i.e., `runCurrent()` / `advanceUntilIdle()` must
+     * drive the stateIn combine) should pass `backgroundScope` from a `runTest`
+     * block instead.
      */
-    private fun newWebRtcManager(): WebRtcManager = WebRtcManager(
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun newWebRtcManager(
+        voiceScope: CoroutineScope = TestScope(UnconfinedTestDispatcher()),
+    ): WebRtcManager = WebRtcManager(
         context = mockk<Context>(relaxed = true),
         voiceApi = mockk<VoiceApi>(relaxed = true),
         eglBaseProvider = mockk<EglBaseProvider>(relaxed = true),
+        voiceScope = voiceScope,
     )
 
     // ========================================================================

--- a/mobile/android/app/src/test/java/io/wolftown/kaiku/data/voice/WebRtcManagerTest.kt
+++ b/mobile/android/app/src/test/java/io/wolftown/kaiku/data/voice/WebRtcManagerTest.kt
@@ -14,7 +14,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Ignore
 import org.junit.Test
 import org.webrtc.PeerConnection
 
@@ -355,13 +354,8 @@ class WebRtcManagerTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    @Ignore(
-        "voiceIceConnected uses stateIn(CoroutineScope(Dispatchers.IO), Eagerly) " +
-            "whose re-emissions can't be driven by TestCoroutineScheduler. Unblock by " +
-            "injecting the CoroutineScope into WebRtcManager (separate workstream)."
-    )
     fun `voiceIceConnected emits true only when both PCs reach Connected`() = runTest {
-        val webRtcManager = newWebRtcManager()
+        val webRtcManager = newWebRtcManager(voiceScope = backgroundScope)
 
         // Only publisher CONNECTED — combined is still false.
         webRtcManager.setPublisherIceStateForTest(


### PR DESCRIPTION
## Summary

Block 4 of Phase 2.5 open-topics cleanup. Un-ignores `WebRtcManagerTest.voiceIceConnected emits true only when both PCs reach Connected` (the last `@Ignore` in the Android voice-test suite) by making `WebRtcManager`'s internal `stateIn` scope injectable via a `@VoiceCoroutineScope` Hilt qualifier.

- New qualifier: `io.wolftown.kaiku.di.VoiceCoroutineScope`
- New module: `VoiceCoroutineScopeModule` with `@Provides @Singleton` for `CoroutineScope(SupervisorJob() + Dispatchers.IO)`
- `WebRtcManager` gains a 4th constructor parameter; inline `CoroutineScope(Dispatchers.IO)` at `WebRtcManager.kt:159` is replaced
- Test helper `newWebRtcManager()` accepts an optional `voiceScope` (default `TestScope(UnconfinedTestDispatcher())`); the previously-`@Ignore`d test passes `backgroundScope`
- AGENTS.md updated: `@Ignore` registry now "None"; scope-injection becomes the canonical pattern

Spec: `docs/superpowers/specs/2026-04-16-open-topics-cleanup-design.md` — Block 4.

## Canonical pattern for follow-ups

This PR establishes `@<Feature>CoroutineScope` qualifier + dedicated `@Provides` module as the canonical scope-injection pattern. Block 3's triage doc (`docs/developer-guide/testing/2026-04-16-android-test-failure-triage.md`) proposed two follow-up workstreams that will reuse this pattern:

- `@AuthCoroutineScope` — Cluster A (`AuthStateTest`, `AuthFlowTest`, `QrLoginFlowTest`)
- `@ChatCoroutineScope` — Cluster B (`MessageFlowTest`)

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` — BUILD SUCCESSFUL
- [x] `./gradlew :app:testDebugUnitTest --tests WebRtcManagerTest` — 18 tests, 0 skipped, 0 failed
- [x] Full `:app:testDebugUnitTest` — 174 tests, 0 skipped, 13 pre-existing failures; all in Block 3's allowlist (`AuthStateTest`×2, `AuthFlowTest`×5, `MessageFlowTest`×5, `QrLoginFlowTest`×1)
- [x] `grep -rn '@Ignore' mobile/android/app/src/test/java/io/wolftown/kaiku/data/voice/` — empty
- [x] `grep -rn 'CoroutineScope(Dispatchers.IO)' mobile/android/app/src/main/java/io/wolftown/kaiku/data/voice/` — empty

## Scope lifecycle

The injected `CoroutineScope` is owned by Hilt's `SingletonComponent`. `WebRtcManager.dispose()` does **not** cancel it — `SupervisorJob` keeps sibling children alive, and the scope may gain future consumers. Scope-cancellation semantics on app shutdown are a separate concern deferred per spec.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>