### PR TITLE
fix(auth): inject @AuthCoroutineScope into AuthState to resolve Cluster A failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Voice signaling events are rate-limited per peer to prevent flooding
 
 ### Fixed
+- Android: `AuthState`'s `CoroutineScope` is now DI-provided via `@AuthCoroutineScope`, resolving 8 failing unit/integration tests (`AuthStateTest`, `AuthFlowTest`, `QrLoginFlowTest`) that previously read stale `StateFlow` values under `TestCoroutineScheduler`
 - Android: `ChatRepository`'s `CoroutineScope` is now DI-provided via `@ChatCoroutineScope`, resolving 5 failing unit tests (`MessageFlowTest`) that previously missed WebSocket events emitted off-scheduler
 - Android: voice-layer `CoroutineScope` is now DI-provided, making the full `WebRtcManager` test suite runnable under `TestCoroutineScheduler` and unblocking CI coverage for dual-PC ICE state transitions
 - Screen share slots are no longer leaked by duplicate stream IDs

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/data/local/AuthState.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/data/local/AuthState.kt
@@ -1,9 +1,7 @@
 package io.wolftown.kaiku.data.local
 
+import io.wolftown.kaiku.di.AuthCoroutineScope
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -20,9 +18,9 @@ sealed class AuthSession {
 }
 
 @Singleton
-class AuthState @Inject constructor() : Closeable {
-
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+class AuthState @Inject constructor(
+    @AuthCoroutineScope private val scope: CoroutineScope,
+) : Closeable {
 
     private val _session = MutableStateFlow<AuthSession>(AuthSession.LoggedOut)
     val session: StateFlow<AuthSession> = _session.asStateFlow()
@@ -66,6 +64,8 @@ class AuthState @Inject constructor() : Closeable {
     }
 
     override fun close() {
-        scope.cancel()
+        // Scope is now owned by Hilt's SingletonComponent (see AuthCoroutineScopeModule)
+        // — do not cancel here. Same rationale as WebRtcManager.dispose() after #538:
+        // SupervisorJob, potential future shared consumers, app-lifetime ownership.
     }
 }

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/di/AuthCoroutineScope.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/di/AuthCoroutineScope.kt
@@ -1,0 +1,15 @@
+package io.wolftown.kaiku.di
+
+import javax.inject.Qualifier
+
+/**
+ * Qualifier for the [kotlinx.coroutines.CoroutineScope] used by auth-layer
+ * background work (e.g., `AuthState.isLoggedIn` / `currentUserId` stateIn
+ * collection).
+ *
+ * Tests inject a `TestScope` / `backgroundScope` via this qualifier so the
+ * `TestCoroutineScheduler` drives all emissions synchronously.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class AuthCoroutineScope

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/di/AuthCoroutineScopeModule.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/di/AuthCoroutineScopeModule.kt
@@ -1,0 +1,33 @@
+package io.wolftown.kaiku.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import javax.inject.Singleton
+
+/**
+ * Provides the application-scoped [CoroutineScope] used by auth-layer
+ * background collectors (e.g., `AuthState.isLoggedIn.stateIn(...)`).
+ *
+ * Kept separate from [AuthModule] because that module is `abstract` for
+ * `@Binds` entries; Hilt requires `@Provides` to live in `object` or
+ * non-abstract modules.
+ *
+ * `SupervisorJob` ensures a child coroutine's failure does not cascade to
+ * siblings. `Dispatchers.Default` matches the prior (inline) behavior —
+ * the scope's only work is a cheap `.map` transform on an in-memory flow,
+ * not I/O.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object AuthCoroutineScopeModule {
+    @Provides
+    @Singleton
+    @AuthCoroutineScope
+    fun provideAuthCoroutineScope(): CoroutineScope =
+        CoroutineScope(SupervisorJob() + Dispatchers.Default)
+}

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/MainActivity.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/MainActivity.kt
@@ -85,8 +85,8 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 fun KaikuApp(
+    authState: AuthState,
     startDestination: String = "server_url",
-    authState: AuthState? = null,
     appVersion: String = ""
 ) {
     KaikuTheme(darkTheme = true) {
@@ -98,7 +98,7 @@ fun KaikuApp(
             KaikuNavGraph(
                 navController = navController,
                 startDestination = startDestination,
-                authState = authState ?: AuthState(),
+                authState = authState,
                 appVersion = appVersion
             )
         }

--- a/mobile/android/app/src/test/java/io/wolftown/kaiku/data/local/AuthStateTest.kt
+++ b/mobile/android/app/src/test/java/io/wolftown/kaiku/data/local/AuthStateTest.kt
@@ -3,6 +3,10 @@ package io.wolftown.kaiku.data.local
 import app.cash.turbine.test
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -11,13 +15,17 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class AuthStateTest {
 
     private lateinit var authState: AuthState
 
     @Before
     fun setUp() {
-        authState = AuthState()
+        // UnconfinedTestDispatcher runs stateIn continuations synchronously on
+        // the calling thread, so `.value` reflects setLoggedIn/setLoggedOut
+        // immediately. See app/src/test/AGENTS.md ("inject the scope").
+        authState = AuthState(CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher()))
     }
 
     // ========================================================================

--- a/mobile/android/app/src/test/java/io/wolftown/kaiku/integration/AuthFlowTest.kt
+++ b/mobile/android/app/src/test/java/io/wolftown/kaiku/integration/AuthFlowTest.kt
@@ -9,7 +9,10 @@ import io.wolftown.kaiku.data.ws.ConnectionState
 import io.wolftown.kaiku.data.ws.KaikuWebSocket
 import io.wolftown.kaiku.domain.model.AuthResponse
 import io.wolftown.kaiku.domain.model.User
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
@@ -47,7 +50,10 @@ class AuthFlowTest {
     fun setUp() {
         authApi = mockk()
         tokenStorage = mockk(relaxed = true)
-        authState = AuthState()
+        // UnconfinedTestDispatcher drives AuthState's stateIn synchronously so
+        // `.isLoggedIn.value` / `.currentUserId.value` reflect setLoggedIn and
+        // setLoggedOut immediately. See app/src/test/AGENTS.md.
+        authState = AuthState(CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher()))
         webSocket = mockk(relaxed = true)
 
         authRepository = AuthRepository(authApi, tokenStorage, authState)
@@ -60,24 +66,16 @@ class AuthFlowTest {
     @Test
     fun `login stores tokens and sets auth state to logged in`() = runTest {
         coEvery { authApi.login("testuser", "pass", null) } returns testAuthResponse
-        coEvery { authApi.getMe() } returns testUser
+        coEvery { authApi.authenticatedGetMe(any()) } returns testUser
 
         val result = authRepository.login("testuser", "pass")
 
         assertTrue(result.isSuccess)
         assertEquals(testUser, result.getOrNull())
 
-        // Verify tokens were saved (twice: once before getMe, once after with userId)
-        verify(exactly = 2) {
-            tokenStorage.saveTokens(
-                accessToken = "access-token-abc",
-                refreshToken = "refresh-token-xyz",
-                expiresIn = 900,
-                userId = any()
-            )
-        }
-        // Second call should have the correct userId
-        verify {
+        // Since #525, tokens are persisted exactly once — after authenticatedGetMe
+        // succeeds — with the real userId. No placeholder empty-userId write.
+        verify(exactly = 1) {
             tokenStorage.saveTokens(
                 accessToken = "access-token-abc",
                 refreshToken = "refresh-token-xyz",
@@ -115,7 +113,7 @@ class AuthFlowTest {
         coEvery {
             authApi.register("newuser", "pass", null, null)
         } returns testAuthResponse
-        coEvery { authApi.getMe() } throws RuntimeException("Network error")
+        coEvery { authApi.authenticatedGetMe(any()) } throws RuntimeException("Network error")
 
         val result = authRepository.register("newuser", "pass", null, null)
 
@@ -131,7 +129,7 @@ class AuthFlowTest {
     fun `logout clears tokens and sets auth state to logged out`() = runTest {
         // First login
         coEvery { authApi.login("testuser", "pass", null) } returns testAuthResponse
-        coEvery { authApi.getMe() } returns testUser
+        coEvery { authApi.authenticatedGetMe(any()) } returns testUser
         coEvery { authApi.logout() } just Runs
         authRepository.login("testuser", "pass")
 
@@ -149,7 +147,7 @@ class AuthFlowTest {
     fun `logout succeeds even when server-side logout fails`() = runTest {
         // First login
         coEvery { authApi.login("testuser", "pass", null) } returns testAuthResponse
-        coEvery { authApi.getMe() } returns testUser
+        coEvery { authApi.authenticatedGetMe(any()) } returns testUser
         coEvery { authApi.logout() } throws Exception("Network error")
         authRepository.login("testuser", "pass")
 
@@ -210,7 +208,7 @@ class AuthFlowTest {
     @Test
     fun `WebSocket can connect after login stores token`() = runTest {
         coEvery { authApi.login("testuser", "pass", null) } returns testAuthResponse
-        coEvery { authApi.getMe() } returns testUser
+        coEvery { authApi.authenticatedGetMe(any()) } returns testUser
         every { tokenStorage.getAccessToken() } returns "access-token-abc"
         every { tokenStorage.getServerUrl() } returns "https://kaiku.example.com"
 
@@ -228,7 +226,7 @@ class AuthFlowTest {
 
     @Test
     fun `OIDC login stores tokens and sets auth state`() = runTest {
-        coEvery { authApi.getMe() } returns testUser
+        coEvery { authApi.authenticatedGetMe(any()) } returns testUser
 
         val result = authRepository.completeOidcLogin(
             accessToken = "oidc-access-token",

--- a/mobile/android/app/src/test/java/io/wolftown/kaiku/integration/QrLoginFlowTest.kt
+++ b/mobile/android/app/src/test/java/io/wolftown/kaiku/integration/QrLoginFlowTest.kt
@@ -7,7 +7,10 @@ import io.wolftown.kaiku.data.local.TokenStorage
 import io.wolftown.kaiku.data.repository.AuthRepository
 import io.wolftown.kaiku.domain.model.AuthResponse
 import io.wolftown.kaiku.domain.model.User
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
@@ -47,7 +50,10 @@ class QrLoginFlowTest {
     fun setUp() {
         authApi = mockk()
         tokenStorage = mockk(relaxed = true)
-        authState = AuthState()
+        // UnconfinedTestDispatcher drives AuthState's stateIn synchronously so
+        // `.isLoggedIn.value` / `.currentUserId.value` reflect setLoggedIn and
+        // setLoggedOut immediately. See app/src/test/AGENTS.md.
+        authState = AuthState(CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher()))
 
         authRepository = AuthRepository(authApi, tokenStorage, authState)
     }
@@ -59,32 +65,28 @@ class QrLoginFlowTest {
     @Test
     fun `QR redeem stores server URL, tokens, and sets auth state to logged in`() = runTest {
         coEvery { authApi.redeemQrToken(testServerUrl, testToken) } returns testAuthResponse
-        coEvery { authApi.getMe() } returns testUser
+        coEvery { authApi.authenticatedGetMe(any()) } returns testUser
 
         val result = authRepository.redeemQrToken(testServerUrl, testToken)
 
         assertTrue(result.isSuccess)
         assertEquals(testUser, result.getOrNull())
 
-        // Verify tokens were saved (twice: once before getMe, once after with userId)
-        verify(exactly = 2) {
+        // Since #525, tokens are persisted exactly once — after authenticatedGetMe
+        // succeeds — with the real userId. No placeholder empty-userId write.
+        verify(exactly = 1) {
             tokenStorage.saveTokens(
                 accessToken = "qr-access-token-abc",
                 refreshToken = "qr-refresh-token-xyz",
                 expiresIn = 900,
-                userId = any()
+                userId = "user-42"
             )
         }
 
-        // Server URL must be saved BEFORE getMe (KaikuHttpClient needs it for the base URL)
+        // Server URL must be saved BEFORE saveTokens (KaikuHttpClient needs the
+        // base URL for the authenticatedGetMe call that precedes saveTokens).
         verifyOrder {
             tokenStorage.saveServerUrl(testServerUrl)
-            tokenStorage.saveTokens(
-                accessToken = "qr-access-token-abc",
-                refreshToken = "qr-refresh-token-xyz",
-                expiresIn = 900,
-                userId = ""
-            )
             tokenStorage.saveTokens(
                 accessToken = "qr-access-token-abc",
                 refreshToken = "qr-refresh-token-xyz",
@@ -105,7 +107,7 @@ class QrLoginFlowTest {
     @Test
     fun `QR redeem cleans up when getMe fails after successful redeem`() = runTest {
         coEvery { authApi.redeemQrToken(testServerUrl, testToken) } returns testAuthResponse
-        coEvery { authApi.getMe() } throws RuntimeException("getMe failed")
+        coEvery { authApi.authenticatedGetMe(any()) } throws RuntimeException("getMe failed")
 
         val result = authRepository.redeemQrToken(testServerUrl, testToken)
 


### PR DESCRIPTION
## Summary

Resolves Cluster A (8 failing tests) from the [2026-04-16 Android test
triage](../blob/main/docs/developer-guide/testing/2026-04-16-android-test-failure-triage.md)
by mirroring the `@VoiceCoroutineScope` pattern from #538 onto
`AuthState`.

`AuthState` previously owned an inline
`CoroutineScope(SupervisorJob() + Dispatchers.Default)` used to back
two `stateIn`-derived flows (`isLoggedIn`, `currentUserId`). That scope
is unreachable from `TestCoroutineScheduler`, so tests reading
`.value` immediately after `setLoggedIn()` / `setLoggedOut()` saw
stale state.

This PR introduces `@AuthCoroutineScope` (qualifier +
`SingletonComponent`-installed `@Provides` module) and injects it into
`AuthState`. Tests pass a
`CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())` so
stateIn continuations run synchronously on the calling thread.

While touching these tests, also fixes two stale expectations that
pre-dated #525's deferred-token-persistence refactor:

- Stubs: login/register/redeem paths now stub `authenticatedGetMe`
  (which takes an access token) instead of `getMe`. The old stubs
  never matched, so the repository's catch block swallowed a
  `MockKException` and the failure masqueraded as StateFlow staleness.
- `saveTokens` verification: asserted exactly once with the real
  userId, matching current production — the pre-#525 two-call pattern
  (placeholder empty-userId, then real-userId) no longer exists.

Production behavior preserved: `Dispatchers.Default` kept (AuthState's
work is a cheap `.map`, not I/O); `close()` retained but no longer
cancels — Hilt's `SingletonComponent` now owns the scope
(same rationale as `WebRtcManager.dispose()` after #538).

## Resolved tests (Cluster A)

### `io.wolftown.kaiku.data.local.AuthStateTest` (2)
- `initialize with valid tokens sets logged in state`
- `initialize with expired token but valid refresh token stays logged in`

### `io.wolftown.kaiku.integration.AuthFlowTest` (5)
- `login stores tokens and sets auth state to logged in`
- `logout clears tokens and sets auth state to logged out`
- `initialize restores auth state from valid stored tokens`
- `initialize stays logged in with expired token but valid refresh token`
- `OIDC login stores tokens and sets auth state`

### `io.wolftown.kaiku.integration.QrLoginFlowTest` (1)
- `QR redeem stores server URL, tokens, and sets auth state to logged in`

## Remaining failures

- 5 `MessageFlowTest` failures remain — these are Cluster B
  (`ChatRepository` owns an analogous self-scoped collector) and will
  be addressed in a separate follow-up PR. This PR deliberately does
  not touch `ChatRepository`.

## Context

- Triage doc: `docs/developer-guide/testing/2026-04-16-android-test-failure-triage.md`
- Template PR (pattern mirrored): #538 (`@VoiceCoroutineScope` for
  `WebRtcManager`)

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` — `BUILD SUCCESSFUL`
- [x] `./gradlew :app:testDebugUnitTest --tests 'io.wolftown.kaiku.data.local.AuthStateTest'` — pass
- [x] `./gradlew :app:testDebugUnitTest --tests 'io.wolftown.kaiku.integration.AuthFlowTest'` — pass
- [x] `./gradlew :app:testDebugUnitTest --tests 'io.wolftown.kaiku.integration.QrLoginFlowTest'` — pass
- [x] Full suite: 174 tests, 5 failures (all `MessageFlowTest`, unchanged from baseline)