### PR TITLE
fix(chat): inject @ChatCoroutineScope into ChatRepository to resolve Cluster B failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Voice signaling events are rate-limited per peer to prevent flooding
 
 ### Fixed
+- Android: `ChatRepository`'s `CoroutineScope` is now DI-provided via `@ChatCoroutineScope`, resolving 5 failing unit tests (`MessageFlowTest`) that previously missed WebSocket events emitted off-scheduler
 - Android: voice-layer `CoroutineScope` is now DI-provided, making the full `WebRtcManager` test suite runnable under `TestCoroutineScheduler` and unblocking CI coverage for dual-PC ICE state transitions
 - Screen share slots are no longer leaked by duplicate stream IDs
 - Android: test infrastructure now injects EglBase via a provider so unit tests can be written without native EGL14 stubs; unblocks CI coverage for voice signaling

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/data/repository/ChatRepository.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/data/repository/ChatRepository.kt
@@ -4,11 +4,10 @@ import io.wolftown.kaiku.data.api.MessageApi
 import io.wolftown.kaiku.data.ws.ClientEvent
 import io.wolftown.kaiku.data.ws.KaikuWebSocket
 import io.wolftown.kaiku.data.ws.ServerEvent
+import io.wolftown.kaiku.di.ChatCoroutineScope
 import io.wolftown.kaiku.domain.model.Message
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -36,14 +35,13 @@ import javax.inject.Singleton
 class ChatRepository @Inject constructor(
     private val messageApi: MessageApi,
     private val webSocket: KaikuWebSocket,
-    private val json: Json
+    private val json: Json,
+    @ChatCoroutineScope private val scope: CoroutineScope,
 ) {
     companion object {
         private val logger = Logger.getLogger("ChatRepository")
         private const val TYPING_DEBOUNCE_MS = 3_000L
     }
-
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     /** Per-channel message lists. */
     private val channelMessages = ConcurrentHashMap<String, MutableStateFlow<List<Message>>>()

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/di/ChatCoroutineScope.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/di/ChatCoroutineScope.kt
@@ -1,0 +1,14 @@
+package io.wolftown.kaiku.di
+
+import javax.inject.Qualifier
+
+/**
+ * Qualifier for the [kotlinx.coroutines.CoroutineScope] used by chat-layer
+ * background work (e.g., [ChatRepository]'s WebSocket event collector).
+ *
+ * Tests inject a `TestScope` / `backgroundScope` via this qualifier so the
+ * `TestCoroutineScheduler` drives all emissions synchronously.
+ */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ChatCoroutineScope

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/di/ChatCoroutineScopeModule.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/di/ChatCoroutineScopeModule.kt
@@ -1,0 +1,32 @@
+package io.wolftown.kaiku.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import javax.inject.Singleton
+
+/**
+ * Provides the application-scoped [CoroutineScope] used by chat-layer
+ * background collectors (e.g., `ChatRepository`'s WebSocket event collector).
+ *
+ * Kept separate from [ChatModule] because that module is `abstract` for
+ * `@Binds` entries; Hilt requires `@Provides` to live in `object` or
+ * non-abstract modules.
+ *
+ * `SupervisorJob` ensures a child coroutine's failure does not cascade to
+ * siblings. `Dispatchers.IO` matches the prior (inline) behavior — the
+ * WebSocket event collector benefits from an I/O dispatcher.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object ChatCoroutineScopeModule {
+    @Provides
+    @Singleton
+    @ChatCoroutineScope
+    fun provideChatCoroutineScope(): CoroutineScope =
+        CoroutineScope(SupervisorJob() + Dispatchers.IO)
+}

--- a/mobile/android/app/src/test/AGENTS.md
+++ b/mobile/android/app/src/test/AGENTS.md
@@ -84,13 +84,13 @@ Same pattern applies to any `companion object` method that constructs
 - **Instrumented (`androidTest/`)**: for native WebRTC interactions, real
   `PeerConnectionFactory`, and full UI bindings. Requires emulator/device in CI.
 
-## `CoroutineScope(Dispatchers.IO)` + `StandardTestDispatcher` caveat
+## `CoroutineScope(Dispatchers.*)` + `StandardTestDispatcher` caveat
 
 Production code that wraps a flow in `stateIn(CoroutineScope(Dispatchers.IO), Eagerly, …)`
-or launches collectors on its own `Dispatchers.IO` scope cannot be driven by
-`TestCoroutineScheduler`. `runCurrent()` / `advanceUntilIdle()` only drain the
-test dispatcher, so synchronous assertions on `.value` right after mutating the
-source flow may read stale state.
+(or `Dispatchers.Default`, same problem) or launches collectors on its own
+privately-owned scope cannot be driven by `TestCoroutineScheduler`. `runCurrent()`
+/ `advanceUntilIdle()` only drain the test dispatcher, so synchronous assertions
+on `.value` right after mutating the source flow may read stale state.
 
 **Canonical fix: inject the scope via Hilt with a dedicated qualifier.**
 
@@ -117,8 +117,21 @@ class MyFeature @Inject constructor(
 }
 ```
 
-`WebRtcManager`'s `voiceIceConnected` uses this pattern via `@VoiceCoroutineScope`
-(`mobile/android/app/src/main/java/io/wolftown/kaiku/di/VoiceCoroutineScope.kt`).
+Existing examples in this codebase:
+
+- `@VoiceCoroutineScope` — drives `WebRtcManager.voiceIceConnected`
+  (`mobile/android/app/src/main/java/io/wolftown/kaiku/di/VoiceCoroutineScope.kt`,
+  module provides `Dispatchers.IO`).
+- `@AuthCoroutineScope` — drives `AuthState.isLoggedIn` and `currentUserId`
+  (`mobile/android/app/src/main/java/io/wolftown/kaiku/di/AuthCoroutineScope.kt`,
+  module provides `Dispatchers.Default` — the work is a cheap `.map`, not I/O).
+- `@ChatCoroutineScope` — drives `ChatRepository`'s WebSocket event collector
+  (`mobile/android/app/src/main/java/io/wolftown/kaiku/di/ChatCoroutineScope.kt`,
+  module provides `Dispatchers.IO` — WS decoding and state mutation).
+
+Apply the pattern anywhere production code wraps a flow in
+`stateIn(CoroutineScope(Dispatchers.*), Eagerly, …)` where tests need to assert
+on the derived `StateFlow.value` synchronously.
 
 **Fallbacks (avoid unless the injection path is genuinely blocked):**
 

--- a/mobile/android/app/src/test/java/io/wolftown/kaiku/integration/MessageFlowTest.kt
+++ b/mobile/android/app/src/test/java/io/wolftown/kaiku/integration/MessageFlowTest.kt
@@ -8,10 +8,13 @@ import io.wolftown.kaiku.data.ws.KaikuWebSocket
 import io.wolftown.kaiku.data.ws.ServerEvent
 import io.wolftown.kaiku.domain.model.Message
 import io.wolftown.kaiku.domain.model.User
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
@@ -66,7 +69,16 @@ class MessageFlowTest {
         webSocket = mockk(relaxed = true)
         every { webSocket.events } returns eventsFlow
 
-        chatRepository = ChatRepository(messageApi, webSocket, json)
+        // UnconfinedTestDispatcher runs the WebSocket event-collector
+        // continuations synchronously on the calling thread, so `.value`
+        // reflects emitted ServerEvents after `advanceUntilIdle()`. See
+        // app/src/test/AGENTS.md ("inject the scope").
+        chatRepository = ChatRepository(
+            messageApi,
+            webSocket,
+            json,
+            CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher()),
+        )
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary

Mirrors the `@VoiceCoroutineScope` pattern from #538 on `ChatRepository`, unblocking the 5 failing `MessageFlowTest` cases (Cluster B) from the [2026-04-16 Android test triage](../blob/main/docs/developer-guide/testing/2026-04-16-android-test-failure-triage.md).

Background:

- `ChatRepository` previously owned its own `CoroutineScope(SupervisorJob() + Dispatchers.IO)` that launched the WebSocket event collector. Under `runTest`, this scope was outside the `TestCoroutineScheduler`, so `eventsFlow.emit(...)` + `advanceUntilIdle()` didn't drain the collector and assertions on `.value` read stale state (2 msgs instead of 3, etc.).
- Production dispatcher is preserved (`Dispatchers.IO`), so runtime behavior is unchanged.
- Tests now pass `CoroutineScope(SupervisorJob() + UnconfinedTestDispatcher())` as the injected scope, matching the pattern Cluster A (#539, in flight) uses for `AuthState`.

## Resolved tests (MessageFlowTest, rows 9-13 of triage)

- `new WebSocket message appears in message list` (was: expected 3, was 2)
- `edit event updates message content in list` (was: ComparisonFailure on content)
- `delete event removes message from list` (was: expected 1, was 2)
- `typing start adds user to typing set`
- `typing stop removes user from typing set`

## Test results

- `MessageFlowTest`: 11 tests, 0 failed (was 5 failing).
- Full `:app:testDebugUnitTest`: 174 tests, 0 skipped, 8 failures — all 8 in `AuthStateTest` / `AuthFlowTest` / `QrLoginFlowTest`. These are exactly the Cluster A failures that #539 resolves; this PR does not touch those files.

## Related

- Template: #538 (`@VoiceCoroutineScope` for `WebRtcManager`).
- Sibling: #539 (`@AuthCoroutineScope` for `AuthState`) is still OPEN. AGENTS.md in this PR already references all three qualifiers (`@VoiceCoroutineScope`, `@AuthCoroutineScope`, `@ChatCoroutineScope`) so the textual conflict when either PR merges second is trivial.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin` (BUILD SUCCESSFUL)
- [x] `./gradlew :app:testDebugUnitTest --tests '*.MessageFlowTest'` (11/11 pass)
- [x] `./gradlew :app:testDebugUnitTest` (174 tests, 8 fails == known Cluster A set)