### PR TITLE
docs: sqlx::test integration migration — spec + 5 phase plans

### DIFF
--- a/docs/superpowers/plans/2026-04-18-phase1-testapp-api-plus-pilot.md
+++ b/docs/superpowers/plans/2026-04-18-phase1-testapp-api-plus-pilot.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add pool-injecting factories to `TestApp` (backward-compatible with existing no-arg forms), then migrate 3 pilot integration test files (`blocking.rs`, `e2ee_settings.rs`, `pages.rs`) to `#[sqlx::test]` to validate the template-DB + migrations pipeline in CI before bulk migration.
+**Goal:** Add pool-injecting factories to `TestApp` (backward-compatible with existing no-arg forms), then migrate 3 pilot integration test files (`blocking.rs`, `dm_http.rs`, `favorites.rs`) to `#[sqlx::test]` to validate the template-DB + migrations pipeline in CI before bulk migration.
 
 **Architecture:** The existing no-arg factories (`TestApp::new`, `TestApp::with_screen_share_limiter`, `fresh_test_app_with_s3`) are preserved and retrofitted to delegate to new pool-injecting forms (`TestApp::with_pool`, `TestApp::with_pool_and_screen_share_limiter`, `fresh_test_app_with_s3_and_pool`). The 3 pilot tests switch to `#[sqlx::test]` + new factories; all other tests remain on the old pattern until Phases 2–4.
 
@@ -62,8 +62,8 @@ Working branch: `feat/sqlx-test-phase1`. Working directory for every task below:
 |------|--------|------|
 | `server/tests/integration/helpers/mod.rs` | Modify (add new factories, rewire old as delegates) | 1, 2 |
 | `server/tests/integration/blocking.rs` | Modify (pilot migrate) | 3 |
-| `server/tests/integration/e2ee_settings.rs` | Modify (pilot migrate) | 4 |
-| `server/tests/integration/pages.rs` | Modify (pilot migrate) | 5 |
+| `server/tests/integration/dm_http.rs` | Modify (pilot migrate) | 4 |
+| `server/tests/integration/favorites.rs` | Modify (pilot migrate) | 5 |
 
 ---
 
@@ -211,6 +211,7 @@ Observe: (a) the existing use statements — likely `use crate::integration::hel
 
 For **every** test function in the file, do:
 
+0. **If the attribute has arguments** (e.g., `#[tokio::test(flavor = "current_thread", start_paused = true)]`) — STOP. Do not convert this test. `#[sqlx::test]` has a different argument surface and the semantics don't translate. File should be treated as a carve-out and removed from its batch. Examples in this repo: `voice_rate_limit.rs` uses `start_paused = true` and has no DB at all — it stays on `#[tokio::test]`.
 1. Change the attribute: `#[tokio::test]` → `#[sqlx::test]`
 2. Add a `pool: PgPool` parameter: `async fn test_xxx() {` → `async fn test_xxx(pool: PgPool) {`
 3. Replace factory calls:
@@ -218,8 +219,9 @@ For **every** test function in the file, do:
    - `TestApp::with_screen_share_limiter().await` → `TestApp::with_pool_and_screen_share_limiter(pool.clone()).await`
    - `fresh_test_app_with_s3().await` → `fresh_test_app_with_s3_and_pool(pool.clone()).await`
 4. Remove any `#[serial]` attribute on the function (and the `use serial_test::serial;` import at file top if no attribute remains).
-5. Remove `CleanupGuard` calls that only perform DB-row cleanup (e.g., `guard.delete_user(id)`). Keep non-DB cleanup. If the guard becomes empty, remove its declaration.
+5. Remove `CleanupGuard` calls that only perform DB-row cleanup (e.g., `guard.delete_user(id)`, `guard.restore_setup_complete(prev)`). Also remove stand-alone DB-cleanup helper calls at test end (e.g., `helpers::delete_user(&app.pool, user_id).await;`). Keep non-DB cleanup. If the guard becomes empty, remove its declaration.
 6. Add `use sqlx::PgPool;` at the top of the file if not already imported.
+7. Delete in-file DB helper functions that duplicate what `#[sqlx::test]` now provides. Example: if a file has a local `create_test_pool()` that reads `DATABASE_URL` directly, remove it — callers use the injected `pool` parameter instead.
 
 Refer to the spec's §"Phases 2–4 — bulk migration by batch" for the complete recipe.
 
@@ -254,10 +256,12 @@ git commit -m "test(infra): migrate blocking.rs to #[sqlx::test] (pilot)"
 
 ---
 
-## Task 4: Pilot migrate `e2ee_settings.rs`
+## Task 4: Pilot migrate `dm_http.rs`
 
 **Files:**
-- Modify: `server/tests/integration/e2ee_settings.rs`
+- Modify: `server/tests/integration/dm_http.rs`
+
+Rationale for choosing this pilot: 10 `TestApp::new()`/`#[tokio::test]` usages — exercises the full recipe (factory swap + function signature + attribute). Medium-sized file (~200 LOC).
 
 - [ ] **Step 1: Apply the same 6-point recipe from Task 3 Step 2 to every test in this file.**
 
@@ -269,11 +273,11 @@ SQLX_OFFLINE=true cargo check -p vc-server --tests 2>&1 | grep -E "^error" | hea
 
 Expected: no errors.
 
-- [ ] **Step 3: Run just `e2ee_settings.rs` tests (if local DB available)**
+- [ ] **Step 3: Run just `dm_http.rs` tests (if local DB available)**
 
 ```bash
 DATABASE_URL="postgres://voicechat:voicechat_dev@localhost:5433/voicechat" \
-cargo nextest run --test 'integration' e2ee_settings:: 2>&1 | tail -10
+cargo nextest run --test 'integration' dm_http:: 2>&1 | tail -10
 ```
 
 Expected: green.
@@ -281,16 +285,18 @@ Expected: green.
 - [ ] **Step 4: Commit**
 
 ```bash
-git add server/tests/integration/e2ee_settings.rs
-git commit -m "test(infra): migrate e2ee_settings.rs to #[sqlx::test] (pilot)"
+git add server/tests/integration/dm_http.rs
+git commit -m "test(infra): migrate dm_http.rs to #[sqlx::test] (pilot)"
 ```
 
 ---
 
-## Task 5: Pilot migrate `pages.rs`
+## Task 5: Pilot migrate `favorites.rs`
 
 **Files:**
-- Modify: `server/tests/integration/pages.rs`
+- Modify: `server/tests/integration/favorites.rs`
+
+Rationale: 6 `TestApp` usages, includes `CleanupGuard` patterns — exercises recipe step 7 (guard simplification/removal).
 
 - [ ] **Step 1: Apply the same 6-point recipe from Task 3 Step 2.**
 
@@ -300,7 +306,7 @@ git commit -m "test(infra): migrate e2ee_settings.rs to #[sqlx::test] (pilot)"
 SQLX_OFFLINE=true cargo check -p vc-server --tests 2>&1 | grep -E "^error" | head -5
 ```
 
-- [ ] **Step 3: Run just `pages.rs` tests (if local DB available)**
+- [ ] **Step 3: Run just `favorites.rs` tests (if local DB available)**
 
 ```bash
 DATABASE_URL="postgres://voicechat:voicechat_dev@localhost:5433/voicechat" \
@@ -310,8 +316,8 @@ cargo nextest run --test 'integration' pages:: 2>&1 | tail -10
 - [ ] **Step 4: Commit**
 
 ```bash
-git add server/tests/integration/pages.rs
-git commit -m "test(infra): migrate pages.rs to #[sqlx::test] (pilot)"
+git add server/tests/integration/favorites.rs
+git commit -m "test(infra): migrate favorites.rs to #[sqlx::test] (pilot)"
 ```
 
 ---
@@ -339,8 +345,8 @@ git log --oneline origin/main..HEAD
 Expected 4 commits:
 1. `test(infra): add TestApp::with_pool pool-injecting factories`
 2. `test(infra): migrate blocking.rs to #[sqlx::test] (pilot)`
-3. `test(infra): migrate e2ee_settings.rs to #[sqlx::test] (pilot)`
-4. `test(infra): migrate pages.rs to #[sqlx::test] (pilot)`
+3. `test(infra): migrate dm_http.rs to #[sqlx::test] (pilot)`
+4. `test(infra): migrate favorites.rs to #[sqlx::test] (pilot)`
 
 - [ ] **Step 3: Push + open PR**
 
@@ -355,7 +361,7 @@ Phase 1 of the integration-test migration to `#[sqlx::test]`'s per-test database
 
 - New factories: `TestApp::with_pool`, `TestApp::with_pool_and_screen_share_limiter`, `fresh_test_app_with_s3_and_pool`.
 - Existing factories (`TestApp::new`, `with_screen_share_limiter`, `fresh_test_app_with_s3`) kept, now delegating via the shared pool.
-- Pilot migrations: `blocking.rs`, `e2ee_settings.rs`, `pages.rs`.
+- Pilot migrations: `blocking.rs`, `dm_http.rs`, `favorites.rs`.
 
 Spec: `docs/superpowers/specs/2026-04-18-sqlx-test-integration-migration-design.md` — Phase 1.
 
@@ -402,7 +408,7 @@ git fetch origin --prune
 
 1. `TestApp::with_pool`, `TestApp::with_pool_and_screen_share_limiter`, and `fresh_test_app_with_s3_and_pool` exist on `main`.
 2. Existing `TestApp::new()`, `TestApp::with_screen_share_limiter()`, and `fresh_test_app_with_s3()` continue to work unchanged from a caller's perspective.
-3. `blocking.rs`, `e2ee_settings.rs`, `pages.rs` all run under `#[sqlx::test]` and pass CI.
+3. `blocking.rs`, `dm_http.rs`, `favorites.rs` all run under `#[sqlx::test]` and pass CI.
 4. No regression in the full integration test suite's green-test count.
 
 ## Notes for the implementer

--- a/docs/superpowers/plans/2026-04-18-phase1-testapp-api-plus-pilot.md
+++ b/docs/superpowers/plans/2026-04-18-phase1-testapp-api-plus-pilot.md
@@ -1,0 +1,414 @@
+# Phase 1 — `TestApp::with_pool` API + Pilot Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add pool-injecting factories to `TestApp` (backward-compatible with existing no-arg forms), then migrate 3 pilot integration test files (`blocking.rs`, `e2ee_settings.rs`, `pages.rs`) to `#[sqlx::test]` to validate the template-DB + migrations pipeline in CI before bulk migration.
+
+**Architecture:** The existing no-arg factories (`TestApp::new`, `TestApp::with_screen_share_limiter`, `fresh_test_app_with_s3`) are preserved and retrofitted to delegate to new pool-injecting forms (`TestApp::with_pool`, `TestApp::with_pool_and_screen_share_limiter`, `fresh_test_app_with_s3_and_pool`). The 3 pilot tests switch to `#[sqlx::test]` + new factories; all other tests remain on the old pattern until Phases 2–4.
+
+**Tech Stack:** Rust stable, `sqlx` with the `postgres` + `migrate` + `test` features, `cargo-nextest`, `#[sqlx::test]` macro, PostgreSQL 16.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-sqlx-test-integration-migration-design.md` — Phase 1 section.
+
+**Parallelization safe:** No. Phase 1 is the prerequisite for Phases 2–5 and must merge first so the new factories and the proven pilot pattern exist on `main` before the bulk migration starts.
+
+---
+
+## Pre-flight Check (BLOCKING)
+
+- [ ] **Verify `sqlx` has the `test` feature enabled**
+
+```bash
+cd /home/detair/GIT/detair/kaiku
+grep -nE '^sqlx|^sqlx =' server/Cargo.toml
+```
+
+Expected: a line like `sqlx = { version = "0.8", features = [..., "postgres", "migrate", ...] }`. If `test` is not in the feature list, Phase 1 needs to add it. Examine the current line carefully — some sqlx versions auto-include test support when other features are present.
+
+- [ ] **Verify migrations live at the expected path**
+
+```bash
+ls server/migrations | wc -l
+```
+
+Expected: 54 migrations. The default `#[sqlx::test]` migrator path is `./migrations` relative to the crate root; since the integration tests live in the `server` crate, `server/migrations/` is the default and no override is needed. If that count differs materially, pause and verify the spec's factual baseline.
+
+- [ ] **Confirm `DATABASE_URL` is set on CI**
+
+```bash
+grep -nE 'DATABASE_URL' .github/workflows/ci.yml | head -5
+```
+
+Expected: `DATABASE_URL: postgres://postgres:postgres@localhost:5432/canis_test` at the `rust-test` job level. `#[sqlx::test]` reads `DATABASE_URL` and uses it to pick the base DB; per-test DBs are created on the same Postgres instance.
+
+---
+
+## Worktree Setup
+
+```bash
+cd /home/detair/GIT/detair/kaiku
+git fetch origin
+git worktree add .claude/worktrees/sqlx-test-phase1 -b feat/sqlx-test-phase1 origin/main
+cd .claude/worktrees/sqlx-test-phase1
+```
+
+Working branch: `feat/sqlx-test-phase1`. Working directory for every task below: `/home/detair/GIT/detair/kaiku/.claude/worktrees/sqlx-test-phase1`.
+
+---
+
+## File Map
+
+| Path | Action | Task |
+|------|--------|------|
+| `server/tests/integration/helpers/mod.rs` | Modify (add new factories, rewire old as delegates) | 1, 2 |
+| `server/tests/integration/blocking.rs` | Modify (pilot migrate) | 3 |
+| `server/tests/integration/e2ee_settings.rs` | Modify (pilot migrate) | 4 |
+| `server/tests/integration/pages.rs` | Modify (pilot migrate) | 5 |
+
+---
+
+## Task 1: Add `TestApp::with_pool` and variants
+
+**Files:**
+- Modify: `server/tests/integration/helpers/mod.rs` — add new pool-injecting factories below the existing `TestApp` impl block.
+
+- [ ] **Step 1: Read the current `TestApp::new` implementation**
+
+```bash
+grep -n 'pub struct TestApp\|impl TestApp\|pub async fn new\|pub async fn with_screen_share_limiter\|pub async fn fresh_test_app_with_s3' server/tests/integration/helpers/mod.rs
+```
+
+Expected: roughly the layout from the spec — `pub struct TestApp { router, pool, config }`, `impl TestApp { pub async fn new() … pub async fn with_screen_share_limiter() … }`, and the free function `pub async fn fresh_test_app_with_s3() -> (TestApp, String)`.
+
+- [ ] **Step 2: Extract the body of `TestApp::new()` into a new `with_pool(pool: PgPool)` method**
+
+Current body (conceptual):
+```rust
+pub async fn new() -> Self {
+    let pool = shared_pool().await.clone();
+    let config = shared_config().await.clone();
+    let redis = db::create_redis_client(&config.redis_url).await.expect("…");
+    let sfu = SfuServer::new(Arc::new(config.clone()), None).expect("…");
+    let state = AppState::new(AppStateConfig { db: pool.clone(), redis, config: config.clone(), /* … */ });
+    let router = create_router(state);
+    Self { router, pool, config: Arc::new(config) }
+}
+```
+
+Split into:
+```rust
+/// Canonical pool-injecting constructor for integration tests.
+///
+/// Pass a pool from `#[sqlx::test]`'s fixture. The returned `TestApp` owns
+/// `pool` for the duration of the test.
+pub async fn with_pool(pool: PgPool) -> Self {
+    let config = shared_config().await.clone();
+    let redis = db::create_redis_client(&config.redis_url).await.expect("…");
+    let sfu = SfuServer::new(Arc::new(config.clone()), None).expect("…");
+    let state = AppState::new(AppStateConfig { db: pool.clone(), redis, config: config.clone(), /* … */ });
+    let router = create_router(state);
+    Self { router, pool, config: Arc::new(config) }
+}
+
+/// Legacy no-arg constructor — delegates to [`Self::with_pool`] using the
+/// shared process-global pool. Retained for tests not yet migrated to
+/// `#[sqlx::test]`. Removed in Phase 5.
+pub async fn new() -> Self {
+    Self::with_pool(shared_pool().await.clone()).await
+}
+```
+
+Copy the full body exactly (do not paraphrase the `AppStateConfig` fields — the spec's sample elided some). Move every line from `let config = ...` through the final `Self { ... }` into `with_pool`.
+
+- [ ] **Step 3: Apply the same split to `with_screen_share_limiter()`**
+
+```rust
+pub async fn with_pool_and_screen_share_limiter(pool: PgPool) -> Self {
+    /* body: move current `with_screen_share_limiter` body here, replacing the
+       `let pool = shared_pool().await.clone();` with use of the argument */
+}
+
+pub async fn with_screen_share_limiter() -> Self {
+    Self::with_pool_and_screen_share_limiter(shared_pool().await.clone()).await
+}
+```
+
+- [ ] **Step 4: Apply the same split to `fresh_test_app_with_s3()`**
+
+```rust
+pub async fn fresh_test_app_with_s3_and_pool(pool: PgPool) -> (TestApp, String) {
+    /* body: move current `fresh_test_app_with_s3` body here, replacing the
+       first `let pool = shared_pool().await.clone();` with use of the argument */
+}
+
+pub async fn fresh_test_app_with_s3() -> (TestApp, String) {
+    fresh_test_app_with_s3_and_pool(shared_pool().await.clone()).await
+}
+```
+
+- [ ] **Step 5: If `TestApp` has any other factory variants**, apply the same pattern
+
+```bash
+grep -nE '^    pub async fn ' server/tests/integration/helpers/mod.rs | grep -v 'with_pool\|cleanup_guard' | head -20
+```
+
+Expected: returns any other `impl TestApp { pub async fn … }` methods that currently read `shared_pool()` / `shared_config()` implicitly. For each, add a pool-injecting twin using the `with_pool_<variant>` naming convention and retrofit the original as a delegate.
+
+- [ ] **Step 6: Compile check**
+
+```bash
+SQLX_OFFLINE=true cargo check -p vc-server --tests 2>&1 | tail -10
+```
+
+Expected: clean compile. The test binaries should still build because all existing call sites use the unchanged no-arg forms, which now delegate internally.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/tests/integration/helpers/mod.rs
+git commit -m "test(infra): add TestApp::with_pool pool-injecting factories"
+```
+
+---
+
+## Task 2: Verify no-op behavior for existing tests
+
+**Files:**
+- No code changes. Confirmation step.
+
+- [ ] **Step 1: Run the full integration test suite against the retrofitted helpers**
+
+```bash
+cd mobile  # no — wrong repo; skip and do the next line
+# from the worktree root:
+SQLX_OFFLINE=true cargo nextest run --all-features --workspace --exclude vc-client 2>&1 | tail -10
+```
+
+(If `SQLX_OFFLINE=true` is not set, sqlx may attempt to connect to the local dev DB during compile. Keep it set.)
+
+Expected: the tests that pass on current `main` continue to pass. The retrofit is pure refactoring — no test output should change.
+
+**Note on the libspa dev-host issue (carried over from Workstream A):** running `cargo nextest` locally may fail due to libspa/pipewire bindings on some Linux dev machines. If that happens, the actual validation happens on CI when the PR is pushed. For local dev, use `cargo check -p vc-server --tests` (already done in Task 1 Step 6) as a compile-only gate.
+
+- [ ] **Step 2: No commit** — this is a verification step only.
+
+---
+
+## Task 3: Pilot migrate `blocking.rs`
+
+**Files:**
+- Modify: `server/tests/integration/blocking.rs`
+
+- [ ] **Step 1: Read the current file**
+
+```bash
+cat server/tests/integration/blocking.rs | head -60
+```
+
+Observe: (a) the existing use statements — likely `use crate::integration::helpers::*;` or similar; (b) the test function signatures — each is `#[tokio::test] async fn test_xxx() { … }`; (c) whether there are any `#[serial]` attributes.
+
+- [ ] **Step 2: Apply the migration recipe**
+
+For **every** test function in the file, do:
+
+1. Change the attribute: `#[tokio::test]` → `#[sqlx::test]`
+2. Add a `pool: PgPool` parameter: `async fn test_xxx() {` → `async fn test_xxx(pool: PgPool) {`
+3. Replace factory calls:
+   - `TestApp::new().await` → `TestApp::with_pool(pool.clone()).await`
+   - `TestApp::with_screen_share_limiter().await` → `TestApp::with_pool_and_screen_share_limiter(pool.clone()).await`
+   - `fresh_test_app_with_s3().await` → `fresh_test_app_with_s3_and_pool(pool.clone()).await`
+4. Remove any `#[serial]` attribute on the function (and the `use serial_test::serial;` import at file top if no attribute remains).
+5. Remove `CleanupGuard` calls that only perform DB-row cleanup (e.g., `guard.delete_user(id)`). Keep non-DB cleanup. If the guard becomes empty, remove its declaration.
+6. Add `use sqlx::PgPool;` at the top of the file if not already imported.
+
+Refer to the spec's §"Phases 2–4 — bulk migration by batch" for the complete recipe.
+
+- [ ] **Step 3: Compile the modified file**
+
+```bash
+SQLX_OFFLINE=true cargo check -p vc-server --tests 2>&1 | grep -E "^error|^warning: unused" | head -10
+```
+
+Expected: no new errors. A couple of `unused imports` warnings are acceptable if the pilot file had helpers that are now redundant; fix those by removing the imports (lint-clean the file).
+
+- [ ] **Step 4: Run just `blocking.rs` tests against a live DB (local or CI)**
+
+Local (if dev DB is up):
+```bash
+DATABASE_URL="postgres://voicechat:voicechat_dev@localhost:5433/voicechat" \
+SQLX_OFFLINE=false \
+cargo nextest run --all-features --workspace --exclude vc-client \
+  --test 'integration' blocking:: 2>&1 | tail -10
+```
+
+Expected: every test in `blocking.rs` passes. Each test gets its own fresh DB cloned from the template; the 54 migrations run once on first use, then per-test DB creation is ~50–100 ms.
+
+If the local run fails because of the libspa compile issue, skip to CI verification after pushing the PR.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/tests/integration/blocking.rs
+git commit -m "test(infra): migrate blocking.rs to #[sqlx::test] (pilot)"
+```
+
+---
+
+## Task 4: Pilot migrate `e2ee_settings.rs`
+
+**Files:**
+- Modify: `server/tests/integration/e2ee_settings.rs`
+
+- [ ] **Step 1: Apply the same 6-point recipe from Task 3 Step 2 to every test in this file.**
+
+- [ ] **Step 2: Compile check**
+
+```bash
+SQLX_OFFLINE=true cargo check -p vc-server --tests 2>&1 | grep -E "^error" | head -5
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Run just `e2ee_settings.rs` tests (if local DB available)**
+
+```bash
+DATABASE_URL="postgres://voicechat:voicechat_dev@localhost:5433/voicechat" \
+cargo nextest run --test 'integration' e2ee_settings:: 2>&1 | tail -10
+```
+
+Expected: green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/tests/integration/e2ee_settings.rs
+git commit -m "test(infra): migrate e2ee_settings.rs to #[sqlx::test] (pilot)"
+```
+
+---
+
+## Task 5: Pilot migrate `pages.rs`
+
+**Files:**
+- Modify: `server/tests/integration/pages.rs`
+
+- [ ] **Step 1: Apply the same 6-point recipe from Task 3 Step 2.**
+
+- [ ] **Step 2: Compile check**
+
+```bash
+SQLX_OFFLINE=true cargo check -p vc-server --tests 2>&1 | grep -E "^error" | head -5
+```
+
+- [ ] **Step 3: Run just `pages.rs` tests (if local DB available)**
+
+```bash
+DATABASE_URL="postgres://voicechat:voicechat_dev@localhost:5433/voicechat" \
+cargo nextest run --test 'integration' pages:: 2>&1 | tail -10
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/tests/integration/pages.rs
+git commit -m "test(infra): migrate pages.rs to #[sqlx::test] (pilot)"
+```
+
+---
+
+## Task 6: Verify + PR
+
+- [ ] **Step 1: Full compile + full suite (local)**
+
+```bash
+SQLX_OFFLINE=true cargo check -p vc-server --tests 2>&1 | tail -3
+SQLX_OFFLINE=true cargo +nightly fmt --all -- --check && echo "fmt OK"
+SQLX_OFFLINE=true cargo clippy --all-features --workspace --exclude vc-client -- -D warnings 2>&1 | tail -3
+SQLX_OFFLINE=true cargo deny check advisories 2>&1 | tail -3
+SQLX_OFFLINE=true cargo deny check licenses 2>&1 | tail -3
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Review commit log**
+
+```bash
+git log --oneline origin/main..HEAD
+```
+
+Expected 4 commits:
+1. `test(infra): add TestApp::with_pool pool-injecting factories`
+2. `test(infra): migrate blocking.rs to #[sqlx::test] (pilot)`
+3. `test(infra): migrate e2ee_settings.rs to #[sqlx::test] (pilot)`
+4. `test(infra): migrate pages.rs to #[sqlx::test] (pilot)`
+
+- [ ] **Step 3: Push + open PR**
+
+```bash
+git push -u origin feat/sqlx-test-phase1
+gh pr create --base main --head feat/sqlx-test-phase1 \
+  --title "test(infra): sqlx::test migration Phase 1 — TestApp::with_pool + 3-file pilot" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Phase 1 of the integration-test migration to `#[sqlx::test]`'s per-test database isolation. Introduces pool-injecting `TestApp` factories (backward-compatible: existing no-arg forms delegate to them) and migrates 3 pilot files to validate the template-DB + migrations pipeline on CI before bulk migration.
+
+- New factories: `TestApp::with_pool`, `TestApp::with_pool_and_screen_share_limiter`, `fresh_test_app_with_s3_and_pool`.
+- Existing factories (`TestApp::new`, `with_screen_share_limiter`, `fresh_test_app_with_s3`) kept, now delegating via the shared pool.
+- Pilot migrations: `blocking.rs`, `e2ee_settings.rs`, `pages.rs`.
+
+Spec: `docs/superpowers/specs/2026-04-18-sqlx-test-integration-migration-design.md` — Phase 1.
+
+## Test plan
+
+- [x] `cargo check -p vc-server --tests` — green
+- [x] `cargo +nightly fmt --all -- --check` — green
+- [x] `cargo clippy --all-features --workspace --exclude vc-client` — green
+- [x] `cargo deny check advisories` / `licenses` — green
+- [x] Existing tests continue to pass (backward-compat preserved via delegate `new()`)
+- [x] Pilot tests run under `#[sqlx::test]` (verified in CI)
+
+## Follow-ups
+
+Phases 2–4 migrate the remaining 42 files in 3 batches; Phase 5 deletes the legacy `shared_pool` path and removes `[test-groups]` serialization + `#[serial]` attributes.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Wait for CI to pass**
+
+Expected: all checks green, including the `Rust Tests` job that actually runs the pilot tests under `#[sqlx::test]`. If `Rust Tests` fails because template-DB migrations exceed the 2-minute nextest slow-test timeout, that is **critical feedback** — pause, investigate migration squash vs `#[sqlx::test(migrator = …)]` caching, and revise the spec before proceeding to Phase 2.
+
+- [ ] **Step 5: Squash-merge (no `--admin`)**
+
+```bash
+gh pr merge <PR_NUMBER> --squash
+```
+
+- [ ] **Step 6: Post-merge cleanup**
+
+```bash
+cd /home/detair/GIT/detair/kaiku
+git worktree remove .claude/worktrees/sqlx-test-phase1
+git branch -D feat/sqlx-test-phase1
+git fetch origin --prune
+```
+
+---
+
+## Success criteria
+
+1. `TestApp::with_pool`, `TestApp::with_pool_and_screen_share_limiter`, and `fresh_test_app_with_s3_and_pool` exist on `main`.
+2. Existing `TestApp::new()`, `TestApp::with_screen_share_limiter()`, and `fresh_test_app_with_s3()` continue to work unchanged from a caller's perspective.
+3. `blocking.rs`, `e2ee_settings.rs`, `pages.rs` all run under `#[sqlx::test]` and pass CI.
+4. No regression in the full integration test suite's green-test count.
+
+## Notes for the implementer
+
+- **libspa-on-Linux caveat**: local `cargo test`/`nextest run` can fail to build due to pipewire bindings mismatch on some Linux dev hosts. CI is authoritative. If local runs fail with `libspa` errors, verify via `cargo check -p vc-server --tests` and rely on CI for final green signal.
+- **Template-DB first-run cost**: on CI's first test run with `#[sqlx::test]`, the template DB is provisioned (~1–2 s for 54 migrations). Subsequent tests within the same binary share the template and provision per-test DBs in ~50–100 ms. This is documented in the spec's §CI posture; if reality differs materially, escalate.
+- **DO NOT migrate a 4th pilot file.** The 3-file scope is deliberate — tighter diff for review, enough signal to validate the approach.
+- **DO NOT touch tests outside the 3 pilot files in Phase 1.** Batch migration is Phases 2–4.
+- **DO NOT delete `shared_pool`/`SHARED_POOL` in Phase 1.** Deletion is Phase 5 after all migrations complete.

--- a/docs/superpowers/plans/2026-04-18-phase2-batch-a-voice-chat-media.md
+++ b/docs/superpowers/plans/2026-04-18-phase2-batch-a-voice-chat-media.md
@@ -1,0 +1,242 @@
+# Phase 2 — Batch A: Voice/Chat/Media Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate 14 voice/chat/media integration test files to `#[sqlx::test]` using the Phase-1-established `TestApp::with_pool` API.
+
+**Architecture:** Mechanical per-file rewrite applying the Phase 1 migration recipe. Each file is converted in isolation; test count per file ranges from a few to a few dozen. All files in this batch share the same transformation — no per-file custom logic.
+
+**Tech Stack:** Same as Phase 1.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-sqlx-test-integration-migration-design.md` — Phases 2–4 section.
+**Recipe source:** `docs/superpowers/plans/2026-04-18-phase1-testapp-api-plus-pilot.md` Task 3 Step 2 — the 6-point mechanical rewrite. **Read that first.**
+
+**Parallelization safe:** Phase 2 depends only on Phase 1 landing on `main`. Phases 3 and 4 can open in parallel with Phase 2 once Phase 1 merges (different files, no conflicts) — but sequential serialization is recommended to keep review load bounded per reviewer.
+
+---
+
+## Pre-flight Check (BLOCKING)
+
+- [ ] **Verify Phase 1 has merged to `main`**
+
+```bash
+cd /home/detair/GIT/detair/kaiku
+git fetch origin
+git log origin/main --oneline | grep 'sqlx-test.*Phase 1\|TestApp::with_pool\|pilot' | head -3
+```
+
+Expected: at least one commit mentioning Phase 1 / `TestApp::with_pool` / pilot. If absent, **STOP** and land Phase 1 first.
+
+- [ ] **Verify the new factories exist on `main`**
+
+```bash
+git show origin/main:server/tests/integration/helpers/mod.rs | grep -nE 'with_pool|fresh_test_app_with_s3_and_pool' | head -5
+```
+
+Expected: matches for `with_pool` and `with_pool_and_screen_share_limiter` (plus `fresh_test_app_with_s3_and_pool`). If none, Phase 1 did not land the factories correctly — escalate.
+
+---
+
+## Worktree Setup
+
+```bash
+cd /home/detair/GIT/detair/kaiku
+git worktree add .claude/worktrees/sqlx-test-phase2 -b feat/sqlx-test-phase2 origin/main
+cd .claude/worktrees/sqlx-test-phase2
+```
+
+---
+
+## File Map
+
+14 files, each receiving the Phase 1 recipe. One task per file keeps review granular and per-file failures isolated:
+
+| Task | File |
+|------|------|
+| 1 | `server/tests/integration/voice_sfu.rs` |
+| 2 | `server/tests/integration/voice_mute_enforcement.rs` |
+| 3 | `server/tests/integration/voice_rate_limit.rs` |
+| 4 | `server/tests/integration/channels_http.rs` |
+| 5 | `server/tests/integration/channel_pins.rs` |
+| 6 | `server/tests/integration/messages_http.rs` |
+| 7 | `server/tests/integration/threads.rs` |
+| 8 | `server/tests/integration/dm_http.rs` |
+| 9 | `server/tests/integration/media_processing.rs` |
+| 10 | `server/tests/integration/upload_limits.rs` |
+| 11 | `server/tests/integration/uploads_http.rs` |
+| 12 | `server/tests/integration/screenshare.rs` |
+| 13 | `server/tests/integration/favorites.rs` |
+| 14 | `server/tests/integration/custom_status.rs` |
+
+---
+
+## Migration Recipe (per file, applied in Tasks 1–14)
+
+**For every test function in the target file:**
+
+1. `#[tokio::test]` → `#[sqlx::test]`
+2. `async fn test_xxx()` → `async fn test_xxx(pool: PgPool)`
+3. `TestApp::new().await` → `TestApp::with_pool(pool.clone()).await`
+4. `TestApp::with_screen_share_limiter().await` → `TestApp::with_pool_and_screen_share_limiter(pool.clone()).await`
+5. `fresh_test_app_with_s3().await` → `fresh_test_app_with_s3_and_pool(pool.clone()).await`
+6. Remove `#[serial]` attributes and `use serial_test::…;` if no other function in the file uses it.
+7. `CleanupGuard`: drop DB-row cleanup calls (`guard.delete_user(id)`, `guard.restore_setup_complete(prev)`, etc.). Keep non-DB cleanup (S3 bucket teardown — only relevant for `uploads_http.rs` if it uses S3). If the guard has no remaining actions, delete its declaration.
+8. Add `use sqlx::PgPool;` at the top of the file if missing.
+
+---
+
+## Task N: Migrate `<filename>` (applies to Tasks 1–14)
+
+**Files:**
+- Modify: `server/tests/integration/<filename>`
+
+- [ ] **Step 1: Read the file and identify every test function**
+
+```bash
+grep -nE '#\[(tokio|sqlx)::test|^async fn test_|#\[serial' server/tests/integration/<filename>
+```
+
+Record: number of tests, whether `#[serial]` is used, whether the file already has any `#[sqlx::test]` (shouldn't — but verify).
+
+- [ ] **Step 2: Apply the migration recipe (above) to every test**
+
+Use the Edit tool, `sed`, or your editor. For each test, apply steps 1–8 mechanically. Do NOT change test body logic — only the attribute, signature, and factory calls.
+
+- [ ] **Step 3: Remove unused `CleanupGuard` state + shared_pool references**
+
+```bash
+grep -n 'shared_pool\|CleanupGuard\|cleanup_guard\|delete_user(' server/tests/integration/<filename>
+```
+
+For each match: if it's a DB-row cleanup call (e.g., `guard.delete_user(id)`), delete it (sqlx::test drops the DB). If it's S3 or otherwise non-DB, keep it. If the file declared a guard only to delete rows, remove the `let mut guard = …;` line.
+
+- [ ] **Step 4: Compile check**
+
+```bash
+SQLX_OFFLINE=true cargo check -p vc-server --tests 2>&1 | grep -E "^error|^warning: unused" | head -10
+```
+
+Expected: no new errors. Fix any "unused import" warning by deleting the unused import from the file.
+
+- [ ] **Step 5: (Optional) Run just this file's tests against a live DB**
+
+If a local DB is available:
+```bash
+DATABASE_URL="postgres://voicechat:voicechat_dev@localhost:5433/voicechat" \
+cargo nextest run --test 'integration' <module_prefix>:: 2>&1 | tail -10
+```
+
+Expected: every test in the file passes. If the local run is blocked by libspa, defer to CI verification after push.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/tests/integration/<filename>
+git commit -m "test(infra): migrate <filename> to #[sqlx::test]"
+```
+
+**Repeat Steps 1–6 for every file in the Task N table above.**
+
+---
+
+## Final Verification (before opening PR)
+
+- [ ] **Full compile + lint + deny + fmt**
+
+```bash
+SQLX_OFFLINE=true cargo check -p vc-server --tests 2>&1 | tail -3
+SQLX_OFFLINE=true cargo +nightly fmt --all -- --check && echo "fmt OK"
+SQLX_OFFLINE=true cargo clippy --all-features --workspace --exclude vc-client -- -D warnings 2>&1 | tail -3
+SQLX_OFFLINE=true cargo deny check advisories 2>&1 | tail -3
+SQLX_OFFLINE=true cargo deny check licenses 2>&1 | tail -3
+```
+
+Expected: all green.
+
+- [ ] **Grep sweep for remaining `#[tokio::test]` in this batch**
+
+```bash
+for f in voice_sfu voice_mute_enforcement voice_rate_limit channels_http channel_pins messages_http threads dm_http media_processing upload_limits uploads_http screenshare favorites custom_status; do
+    c=$(grep -c '#\[tokio::test' "server/tests/integration/$f.rs" 2>/dev/null || echo 0)
+    [ "$c" -gt 0 ] && echo "  $f.rs: $c remaining #[tokio::test] — FIX BEFORE PR"
+done
+```
+
+Expected: no output (every `#[tokio::test]` in these 14 files has been converted). Any output is a MUST-FIX before opening the PR.
+
+- [ ] **Commit log sanity**
+
+```bash
+git log --oneline origin/main..HEAD
+```
+
+Expected: 14 commits, each matching `test(infra): migrate <filename> to #[sqlx::test]`.
+
+- [ ] **Push + open PR**
+
+```bash
+git push -u origin feat/sqlx-test-phase2
+gh pr create --base main --head feat/sqlx-test-phase2 \
+  --title "test(infra): sqlx::test migration Phase 2 — batch A (voice/chat/media)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Phase 2 of the integration-test migration to `#[sqlx::test]`. Converts 14 voice/chat/media test files from the shared-pool pattern to per-test database isolation.
+
+Spec: `docs/superpowers/specs/2026-04-18-sqlx-test-integration-migration-design.md` — Phases 2–4.
+Phase 1: established `TestApp::with_pool` API and pilot-validated the approach on 3 files.
+
+Files migrated:
+- voice: `voice_sfu.rs`, `voice_mute_enforcement.rs`, `voice_rate_limit.rs`
+- chat: `channels_http.rs`, `channel_pins.rs`, `messages_http.rs`, `threads.rs`, `dm_http.rs`
+- media: `media_processing.rs`, `upload_limits.rs`, `uploads_http.rs`, `screenshare.rs`
+- misc: `favorites.rs`, `custom_status.rs`
+
+## Test plan
+
+- [x] `cargo check -p vc-server --tests` — green
+- [x] `cargo +nightly fmt --all -- --check` — green
+- [x] `cargo clippy --all-features --workspace --exclude vc-client` — green
+- [x] `cargo deny check advisories` / `licenses` — green
+- [x] No `#[tokio::test]` remaining in these 14 files (verified via grep)
+- [x] Full suite passes on CI with no regressions
+
+## Follow-ups
+
+Phases 3 (batch B: auth/admin/governance, 14 files) and 4 (batch C: social/search/misc, 14 files) still to ship. Phase 5 will delete `shared_pool`, remove `[test-groups]`, and prune `#[serial]` attributes after all tests migrate.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Wait for CI green and squash-merge (no `--admin`)**
+
+```bash
+gh pr checks <PR_NUMBER> --watch
+gh pr merge <PR_NUMBER> --squash
+```
+
+- [ ] **Post-merge cleanup**
+
+```bash
+cd /home/detair/GIT/detair/kaiku
+git worktree remove .claude/worktrees/sqlx-test-phase2
+git branch -D feat/sqlx-test-phase2
+git fetch origin --prune
+```
+
+---
+
+## Success criteria
+
+1. All 14 files in this batch use `#[sqlx::test]` exclusively; zero `#[tokio::test]` remaining in them.
+2. All tests in these files pass on CI under `-j 4` parallelism.
+3. Overall integration-test failure count is strictly non-increasing vs. pre-Phase-2 baseline.
+4. No new `#[serial]` or `use serial_test` additions anywhere in the migrated files.
+
+## Notes for the implementer
+
+- **If any test in a migrated file fails for a reason that isn't the mechanical conversion** (e.g., it depended on cross-test state that per-test DB isolation now exposes), STOP and carve that file out into its own PR with an explicit diagnosis. Don't block the rest of the batch.
+- **No cross-file changes** in this phase. `TestApp` helpers stay exactly as Phase 1 left them. If you feel the urge to tweak a helper, resist — that's Phase 5.
+- **Commit per-file**, not per-test. Test-level commits bloat history; file-level commits give the right granularity for review and for bisect.

--- a/docs/superpowers/plans/2026-04-18-phase2-batch-a-voice-chat-media.md
+++ b/docs/superpowers/plans/2026-04-18-phase2-batch-a-voice-chat-media.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Migrate 14 voice/chat/media integration test files to `#[sqlx::test]` using the Phase-1-established `TestApp::with_pool` API.
+**Goal:** Migrate 11 voice/chat/media integration test files to `#[sqlx::test]` using the Phase-1-established `TestApp::with_pool` API. (Down from an initial 14: `dm_http.rs` and `favorites.rs` moved to Phase 1's pilot trio; `voice_rate_limit.rs` is a pure in-memory rate-limiter test with no DB and no migration needed — it stays on `#[tokio::test(start_paused = true)]`.)
 
 **Architecture:** Mechanical per-file rewrite applying the Phase 1 migration recipe. Each file is converted in isolation; test count per file ranges from a few to a few dozen. All files in this batch share the same transformation — no per-file custom logic.
 
@@ -49,24 +49,27 @@ cd .claude/worktrees/sqlx-test-phase2
 
 ## File Map
 
-14 files, each receiving the Phase 1 recipe. One task per file keeps review granular and per-file failures isolated:
+11 files, each receiving the Phase 1 recipe. One task per file keeps review granular and per-file failures isolated:
 
 | Task | File |
 |------|------|
 | 1 | `server/tests/integration/voice_sfu.rs` |
 | 2 | `server/tests/integration/voice_mute_enforcement.rs` |
-| 3 | `server/tests/integration/voice_rate_limit.rs` |
-| 4 | `server/tests/integration/channels_http.rs` |
-| 5 | `server/tests/integration/channel_pins.rs` |
-| 6 | `server/tests/integration/messages_http.rs` |
-| 7 | `server/tests/integration/threads.rs` |
-| 8 | `server/tests/integration/dm_http.rs` |
-| 9 | `server/tests/integration/media_processing.rs` |
-| 10 | `server/tests/integration/upload_limits.rs` |
-| 11 | `server/tests/integration/uploads_http.rs` |
-| 12 | `server/tests/integration/screenshare.rs` |
-| 13 | `server/tests/integration/favorites.rs` |
-| 14 | `server/tests/integration/custom_status.rs` |
+| 3 | `server/tests/integration/channels_http.rs` |
+| 4 | `server/tests/integration/channel_pins.rs` |
+| 5 | `server/tests/integration/messages_http.rs` |
+| 6 | `server/tests/integration/threads.rs` |
+| 7 | `server/tests/integration/media_processing.rs` |
+| 8 | `server/tests/integration/upload_limits.rs` |
+| 9 | `server/tests/integration/uploads_http.rs` |
+| 10 | `server/tests/integration/screenshare.rs` |
+| 11 | `server/tests/integration/custom_status.rs` |
+
+**Carve-outs (not in this batch, not in any batch):**
+- `voice_rate_limit.rs` — `#[tokio::test(start_paused = true)]`, pure in-memory `VoiceRateLimiter`, no DB. Stays on `#[tokio::test]`.
+- `dm_http.rs`, `favorites.rs` — migrated in Phase 1 as pilots.
+
+**Per-file sanity check before applying the recipe**: run `grep -c '#\[tokio::test(' <file>` — if it returns > 0, the file has attribute arguments (e.g., `start_paused`). STOP, carve-out per the Phase 1 recipe's Step 0, and do not migrate.
 
 ---
 
@@ -156,11 +159,13 @@ Expected: all green.
 - [ ] **Grep sweep for remaining `#[tokio::test]` in this batch**
 
 ```bash
-for f in voice_sfu voice_mute_enforcement voice_rate_limit channels_http channel_pins messages_http threads dm_http media_processing upload_limits uploads_http screenshare favorites custom_status; do
+for f in voice_sfu voice_mute_enforcement channels_http channel_pins messages_http threads media_processing upload_limits uploads_http screenshare custom_status; do
     c=$(grep -c '#\[tokio::test' "server/tests/integration/$f.rs" 2>/dev/null || echo 0)
     [ "$c" -gt 0 ] && echo "  $f.rs: $c remaining #[tokio::test] — FIX BEFORE PR"
 done
 ```
+
+Note: `voice_rate_limit.rs` retains `#[tokio::test(start_paused = true)]` — it's a documented carve-out, not a bug.
 
 Expected: no output (every `#[tokio::test]` in these 14 files has been converted). Any output is a MUST-FIX before opening the PR.
 
@@ -170,7 +175,7 @@ Expected: no output (every `#[tokio::test]` in these 14 files has been converted
 git log --oneline origin/main..HEAD
 ```
 
-Expected: 14 commits, each matching `test(infra): migrate <filename> to #[sqlx::test]`.
+Expected: 11 commits, each matching `test(infra): migrate <filename> to #[sqlx::test]`.
 
 - [ ] **Push + open PR**
 

--- a/docs/superpowers/plans/2026-04-18-phase3-batch-b-auth-admin-governance.md
+++ b/docs/superpowers/plans/2026-04-18-phase3-batch-b-auth-admin-governance.md
@@ -1,0 +1,112 @@
+# Phase 3 — Batch B: Auth/Admin/Governance Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Migrate 14 auth/admin/governance integration test files to `#[sqlx::test]`. Structurally identical to Phase 2; different file set.
+
+**Architecture:** Same mechanical per-file rewrite as Phase 2, applying the recipe from Phase 1's plan. Tests in this batch include the `setup*` files that currently require cross-process serialization via nextest `[test-groups].setup-state` — per-test DB isolation obsoletes that serialization, but the `setup-state` entry stays in `nextest.toml` until Phase 5 (because un-migrated Batch A/C files may still reference `setup-state` if they're executed in the same run).
+
+**Tech Stack:** Same as Phase 1/2.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-sqlx-test-integration-migration-design.md` — Phases 2–4.
+**Recipe source:** `docs/superpowers/plans/2026-04-18-phase1-testapp-api-plus-pilot.md` Task 3 Step 2 — the 6-point mechanical rewrite.
+**Worked example:** `docs/superpowers/plans/2026-04-18-phase2-batch-a-voice-chat-media.md` — same pattern, Batch A file set.
+
+**Parallelization safe:** Phase 3 depends on Phase 1. It's independent of Phase 2's file set, so could theoretically open in parallel, but sequential is recommended.
+
+---
+
+## Pre-flight Check (BLOCKING)
+
+- [ ] **Verify Phase 1 has merged** (same check as Phase 2's pre-flight).
+
+Phase 2 need not have merged yet for Phase 3 to start; however, if Phase 2 is open, coordinate branches to avoid accidentally converting the same file twice (this plan's file set is disjoint from Phase 2's, so conflict risk is low).
+
+---
+
+## Worktree Setup
+
+```bash
+cd /home/detair/GIT/detair/kaiku
+git worktree add .claude/worktrees/sqlx-test-phase3 -b feat/sqlx-test-phase3 origin/main
+cd .claude/worktrees/sqlx-test-phase3
+```
+
+---
+
+## File Map
+
+| Task | File | Notes |
+|------|------|-------|
+| 1 | `server/tests/integration/admin_elevation.rs` | |
+| 2 | `server/tests/integration/admin_reports.rs` | |
+| 3 | `server/tests/integration/auth.rs` | |
+| 4 | `server/tests/integration/oidc.rs` | |
+| 5 | `server/tests/integration/ratelimit.rs` | |
+| 6 | `server/tests/integration/ratelimit_http.rs` | |
+| 7 | `server/tests/integration/reports.rs` | |
+| 8 | `server/tests/integration/roles_security.rs` | |
+| 9 | `server/tests/integration/setup.rs` | |
+| 10 | `server/tests/integration/setup_integration.rs` | |
+| 11 | `server/tests/integration/setup_http.rs` | Currently in `setup-state` test-group — serialization obsoleted by per-test DB, but leave the nextest entry for Phase 5 |
+| 12 | `server/tests/integration/setup_concurrent_http.rs` | Same as above |
+| 13 | `server/tests/integration/governance.rs` | |
+| 14 | `server/tests/integration/channel_permissions.rs` | |
+
+---
+
+## Migration Recipe
+
+Follow the 6-point recipe from `2026-04-18-phase1-testapp-api-plus-pilot.md` Task 3 Step 2. Summary:
+
+1. `#[tokio::test]` → `#[sqlx::test]`
+2. `async fn test_xxx()` → `async fn test_xxx(pool: PgPool)`
+3. `TestApp::new().await` → `TestApp::with_pool(pool.clone()).await` (and equivalents for other factory variants).
+4. Remove `#[serial]` + unused `serial_test` import.
+5. Drop `CleanupGuard` DB-row cleanup calls; keep non-DB cleanup.
+6. Ensure `use sqlx::PgPool;` is present.
+
+**Setup-specific caveat:** `setup_http.rs` and `setup_concurrent_http.rs` test the singleton `server_config.setup_complete` row. Under `#[sqlx::test]`, each test gets a fresh DB where `setup_complete` is whatever the migration default initializes it to (typically `false`). Tests should read that as expected behavior. If a test assumes a previous test's mutation persists, it was relying on shared-DB state — carve it out into its own remediation PR per the spec's Risk #2.
+
+---
+
+## Task N: Migrate `<filename>` (applies to Tasks 1–14)
+
+Same 6-step shape as Phase 2's Task template. Repeat per file.
+
+---
+
+## Final Verification
+
+Same as Phase 2's final verification section, with the grep loop updated for this batch's file set:
+
+```bash
+for f in admin_elevation admin_reports auth oidc ratelimit ratelimit_http reports roles_security setup setup_integration setup_http setup_concurrent_http governance channel_permissions; do
+    c=$(grep -c '#\[tokio::test' "server/tests/integration/$f.rs" 2>/dev/null || echo 0)
+    [ "$c" -gt 0 ] && echo "  $f.rs: $c remaining #[tokio::test] — FIX BEFORE PR"
+done
+```
+
+Expected: no output.
+
+---
+
+## PR
+
+- Title: `test(infra): sqlx::test migration Phase 3 — batch B (auth/admin/governance)`
+- Body template: same shape as Phase 2's, swap the file list. Mention the `setup_http`/`setup_concurrent_http` entries still sit under `[test-groups].setup-state` — removal is Phase 5.
+- Merge with `gh pr merge <N> --squash` (no `--admin`).
+- Post-merge: remove worktree, delete branch, prune.
+
+---
+
+## Success criteria
+
+1. All 14 files in Batch B use `#[sqlx::test]` exclusively.
+2. `setup*` tests pass under `#[sqlx::test]` per-test DB isolation without relying on singleton DB state.
+3. Overall integration-test failure count strictly non-increasing vs. pre-Phase-3 baseline.
+
+## Notes for the implementer
+
+- **Setup-test fragility**: the setup tests have the strongest dependency on mutable DB state (they're the only ones that mutate the `server_config` singleton). If any setup test breaks under `#[sqlx::test]` because it assumed cross-test state, the fix is either (a) set the expected state explicitly in the test's `@Before`, or (b) carve that test into a separate PR with an explicit `#[sqlx::test(fixtures = …)]` fixture that sets the initial row. Do NOT add retry logic or put it back on `serial_test`.
+- **`[test-groups].setup-state` stays in nextest.toml** until Phase 5. Even after these files' tests migrate, the nextest filter `test(setup_http::) + test(setup_concurrent_http::)` is harmless — it just assigns matching tests to a 1-thread group, which is a no-op when each test has its own DB. Phase 5 cleans this up.

--- a/docs/superpowers/plans/2026-04-18-phase4-batch-c-social-search-misc.md
+++ b/docs/superpowers/plans/2026-04-18-phase4-batch-c-social-search-misc.md
@@ -1,0 +1,106 @@
+# Phase 4 — Batch C: Social/Search/Misc Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Migrate 14 social/search/misc integration test files to `#[sqlx::test]`. Last batch before Phase 5's legacy-path deletion.
+
+**Architecture:** Same mechanical per-file rewrite as Phases 2 and 3.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-sqlx-test-integration-migration-design.md` — Phases 2–4.
+**Recipe source:** `docs/superpowers/plans/2026-04-18-phase1-testapp-api-plus-pilot.md` Task 3 Step 2.
+**Worked examples:** Phase 2 and Phase 3 plans — same pattern, different file sets.
+
+**Parallelization safe:** Same as Phase 3 — depends only on Phase 1. Sequential after Phases 2 and 3 is recommended to keep review load bounded.
+
+---
+
+## Pre-flight Check (BLOCKING)
+
+- [ ] **Verify Phase 1 has merged** (same check as Phases 2/3).
+
+---
+
+## Worktree Setup
+
+```bash
+cd /home/detair/GIT/detair/kaiku
+git worktree add .claude/worktrees/sqlx-test-phase4 -b feat/sqlx-test-phase4 origin/main
+cd .claude/worktrees/sqlx-test-phase4
+```
+
+---
+
+## File Map
+
+| Task | File |
+|------|------|
+| 1 | `server/tests/integration/bot_ecosystem.rs` |
+| 2 | `server/tests/integration/bot_intents.rs` |
+| 3 | `server/tests/integration/guild_invite.rs` |
+| 4 | `server/tests/integration/guild_limits.rs` |
+| 5 | `server/tests/integration/mention_permission.rs` |
+| 6 | `server/tests/integration/search.rs` |
+| 7 | `server/tests/integration/search_http.rs` |
+| 8 | `server/tests/integration/global_search_http.rs` |
+| 9 | `server/tests/integration/e2ee_keys.rs` |
+| 10 | `server/tests/integration/filters_http.rs` |
+| 11 | `server/tests/integration/webhooks.rs` |
+| 12 | `server/tests/integration/websocket_integration.rs` |
+| 13 | `server/tests/integration/workspaces.rs` |
+| 14 | `server/tests/integration/connectivity_http.rs` |
+
+---
+
+## Migration Recipe
+
+Same 6-point recipe as Phases 2 and 3. See `2026-04-18-phase1-testapp-api-plus-pilot.md` Task 3 Step 2.
+
+---
+
+## Task N: Migrate `<filename>` (applies to Tasks 1–14)
+
+Same 6-step shape as Phases 2/3. Repeat per file.
+
+---
+
+## Final Verification
+
+```bash
+for f in bot_ecosystem bot_intents guild_invite guild_limits mention_permission search search_http global_search_http e2ee_keys filters_http webhooks websocket_integration workspaces connectivity_http; do
+    c=$(grep -c '#\[tokio::test' "server/tests/integration/$f.rs" 2>/dev/null || echo 0)
+    [ "$c" -gt 0 ] && echo "  $f.rs: $c remaining #[tokio::test] — FIX BEFORE PR"
+done
+```
+
+Plus the standard `cargo check -p vc-server --tests`, `fmt --check`, `clippy`, `cargo deny` sweeps.
+
+**Post-Phase-4 invariant check:**
+
+```bash
+grep -rl '#\[tokio::test' server/tests/integration/ 2>&1 | head -5
+```
+
+Expected: **no output**. After Phase 4 merges, every integration test function in the repo should use `#[sqlx::test]`. Any remaining `#[tokio::test]` is a bug — either a missed file in a batch or a test added after the migration started. Either way, must be resolved before Phase 5 opens.
+
+---
+
+## PR
+
+- Title: `test(infra): sqlx::test migration Phase 4 — batch C (social/search/misc)`
+- Body template: same as Phase 2's, swap file list; mention that this is the final migration batch and Phase 5 deletes the legacy path next.
+- Merge with `gh pr merge <N> --squash` (no `--admin`).
+- Post-merge: remove worktree, delete branch, prune.
+
+---
+
+## Success criteria
+
+1. All 14 files in Batch C use `#[sqlx::test]` exclusively.
+2. **Invariant**: zero `#[tokio::test]` remains anywhere under `server/tests/integration/` after Phase 4 merges. Verified by the grep above.
+3. Overall integration-test failure count strictly non-increasing vs. pre-Phase-4 baseline.
+
+## Notes for the implementer
+
+- **Phase 4 is the "no more `#[tokio::test]`" milestone.** The grep in Final Verification is load-bearing — if it returns anything, fix it before PR.
+- **Do not touch `shared_pool` / `SHARED_POOL` / `[test-groups]` in this phase.** Those are Phase 5's job. A test file migrated in Phase 4 will no longer CALL `shared_pool` (because its `TestApp::new()` calls now use `pool.clone()`), but the helper function itself remains on `main` until Phase 5 deletes it.
+- **Watch for `use serial_test::…` imports without any matching `#[serial]` attribute** (left-over dead code in files from Phases 2 or 3 where this batch didn't delete them). If you find any while grepping, clean them up opportunistically — it's the only "tidy-up" allowed in Phase 4.

--- a/docs/superpowers/plans/2026-04-18-phase5-legacy-deletion.md
+++ b/docs/superpowers/plans/2026-04-18-phase5-legacy-deletion.md
@@ -1,0 +1,461 @@
+# Phase 5 — Legacy Path Deletion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Delete the shared-pool legacy path now that every integration test uses `#[sqlx::test]`. Removes `SHARED_POOL`/`shared_pool`/`SHARED_CONFIG`/`shared_config`, the legacy `TestApp` no-arg factories, the `[test-groups].setup-state` nextest entry, all remaining `#[serial]` attributes and `serial_test` imports under `server/tests/`, and `CleanupGuard`'s DB-row cleanup methods. Updates contributor-facing docs. Ships one CHANGELOG `### Changed` entry.
+
+**Architecture:** Pure deletion + documentation refresh. No functional change to what tests assert — only infrastructure that is now provably unused.
+
+**Tech Stack:** Same as Phases 1–4.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-sqlx-test-integration-migration-design.md` — Phase 5 section.
+
+**Parallelization safe:** No. Phase 5 requires Phases 1–4 all merged, verified by a grep invariant below.
+
+---
+
+## Pre-flight Check (BLOCKING)
+
+- [ ] **Verify zero `#[tokio::test]` remains in integration tests**
+
+```bash
+cd /home/detair/GIT/detair/kaiku
+git fetch origin
+git show origin/main --stat | head -1  # just to confirm we're on latest origin/main
+grep -rln '#\[tokio::test' server/tests/integration/ 2>&1 | head -5
+```
+
+Expected: no output from the grep. If any file still has `#[tokio::test]`, **STOP** — a previous batch did not complete. Identify the file, open a remediation PR to migrate it, then proceed.
+
+- [ ] **Verify the Phase 1 new factories exist on `main`** (sanity check — should always be true at this point)
+
+```bash
+git show origin/main:server/tests/integration/helpers/mod.rs | grep -c 'with_pool'
+```
+
+Expected: ≥ 3 matches (from Phase 1's additions).
+
+- [ ] **Verify no non-test code depends on the helpers' legacy factories**
+
+```bash
+grep -rnE 'shared_pool|shared_config|TestApp::new\(' server/src/ 2>&1 | head -5
+grep -rnE 'shared_pool|shared_config|TestApp::new\(' server/benches/ 2>&1 | head -5
+```
+
+Expected: no matches (helpers are test-only; nothing outside `tests/` should reference them). If anything turns up, escalate — Phase 5 must not break a non-test caller.
+
+---
+
+## Worktree Setup
+
+```bash
+cd /home/detair/GIT/detair/kaiku
+git worktree add .claude/worktrees/sqlx-test-phase5 -b chore/sqlx-test-phase5-cleanup origin/main
+cd .claude/worktrees/sqlx-test-phase5
+```
+
+---
+
+## File Map
+
+| Path | Action | Task |
+|------|--------|------|
+| `server/tests/integration/helpers/mod.rs` | Delete `SHARED_POOL`, `shared_pool`, `SHARED_CONFIG`, `shared_config`, legacy no-arg factories, `CleanupGuard` DB-row methods | 1, 2 |
+| `.config/nextest.toml` | Delete `[test-groups]` block + its `[[profile.default.overrides]]` | 3 |
+| Any file importing `serial_test` under `server/tests/` | Remove imports + any stray `#[serial]` | 4 |
+| `docs/developer-guide/testing/*.md` (if exists) | Update to document `#[sqlx::test]` as canonical | 5 |
+| `server/AGENTS.md`, `server/tests/AGENTS.md` (if exists) | Same | 5 |
+| `CHANGELOG.md` | Add `### Changed` entry under `[Unreleased]` | 6 |
+
+---
+
+## Task 1: Delete `SHARED_POOL`, `SHARED_CONFIG`, and related helpers
+
+**Files:**
+- Modify: `server/tests/integration/helpers/mod.rs`
+
+- [ ] **Step 1: Locate the targets**
+
+```bash
+grep -nE 'SHARED_POOL|SHARED_CONFIG|shared_pool\(\)|shared_config\(\)|pub async fn new\(\)|pub async fn with_screen_share_limiter\(\)|pub async fn fresh_test_app_with_s3\(\)' server/tests/integration/helpers/mod.rs
+```
+
+Expected: matches for:
+- `static SHARED_POOL: OnceCell<PgPool> = OnceCell::const_new();`
+- `static SHARED_CONFIG: OnceCell<Config> = OnceCell::const_new();`
+- `pub async fn shared_pool() -> &'static PgPool { … }`
+- `pub async fn shared_config() -> &'static Config { … }`
+- `pub async fn new() -> Self { Self::with_pool(shared_pool().await.clone()).await }` (under `impl TestApp`)
+- `pub async fn with_screen_share_limiter() -> Self { … }` (the legacy no-arg delegate)
+- `pub async fn fresh_test_app_with_s3() -> (TestApp, String) { … }` (the legacy no-arg delegate)
+
+- [ ] **Step 2: Delete them**
+
+Remove each of the items listed in Step 1. Also remove any `use` statements that are now unused (commonly `use tokio::sync::OnceCell;` if nothing else in the file uses it).
+
+Keep:
+- `with_pool`, `with_pool_and_screen_share_limiter`, `fresh_test_app_with_s3_and_pool`
+- All test-fixture builder helpers (`create_test_user`, `create_guild`, `insert_message`, …)
+- `CleanupGuard` struct itself (DB-row methods are removed in Task 2)
+
+- [ ] **Step 3: Compile check**
+
+```bash
+SQLX_OFFLINE=true cargo check -p vc-server --tests 2>&1 | grep -E "^error" | head -10
+```
+
+Expected: no errors. Every test in the integration crate should now use the new `with_pool` factories — confirming the deletion is safe.
+
+If errors appear like "cannot find function `shared_pool` in this scope" in some test file, that file was not properly migrated in Phases 2–4. STOP, migrate that file per the recipe, then retry.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/tests/integration/helpers/mod.rs
+git commit -m "test(infra): delete SHARED_POOL + legacy no-arg TestApp factories"
+```
+
+---
+
+## Task 2: Prune `CleanupGuard` DB-row cleanup methods
+
+**Files:**
+- Modify: `server/tests/integration/helpers/mod.rs`
+
+- [ ] **Step 1: Audit `CleanupGuard`'s methods**
+
+```bash
+awk '/^impl CleanupGuard \{/,/^\}/' server/tests/integration/helpers/mod.rs | grep -E '^\s*pub fn [a-z]'
+```
+
+Expected: a list of method signatures — `delete_user`, `delete_guild`, `delete_dm_channel`, `delete_connection_data`, `restore_setup_complete`, and possibly others. Also any non-DB methods (e.g., S3 bucket cleanup).
+
+- [ ] **Step 2: Classify each method as "DB-row" or "non-DB"**
+
+DB-row methods (example list — verify against actual code):
+- `delete_user` — row deletion, now redundant (sqlx::test drops DB)
+- `delete_guild` — row deletion, redundant
+- `delete_dm_channel` — row deletion, redundant
+- `delete_connection_data` — row deletion, redundant
+- `restore_setup_complete` — singleton row mutation, redundant
+
+Non-DB methods (keep):
+- Any method that operates on S3 buckets, Redis keys, or external resources.
+
+If `CleanupGuard` has zero non-DB methods after audit, delete the struct entirely along with the `type CleanupAction = …;` typedef and the `impl Drop for CleanupGuard` block.
+
+- [ ] **Step 3: Delete DB-row methods (and the generic `add_action` / `register` if it's only reachable via DB-row helpers)**
+
+Keep only what non-DB methods need.
+
+- [ ] **Step 4: If `CleanupGuard` becomes empty, delete it fully**
+
+```bash
+grep -n 'CleanupGuard\|cleanup_guard' server/tests/integration/
+```
+
+Expected after full deletion: no matches outside of the deletion itself. If any test file still references `cleanup_guard()` or `CleanupGuard::new(...)` (carried over from Phase 2–4 batches), remove those calls — they were orphans the batches missed.
+
+- [ ] **Step 5: Compile check**
+
+```bash
+SQLX_OFFLINE=true cargo check -p vc-server --tests 2>&1 | grep -E "^error" | head -5
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/tests/integration/helpers/mod.rs
+git add server/tests/integration/  # catch any orphan CleanupGuard calls in test files
+git commit -m "test(infra): prune CleanupGuard DB-row cleanup methods"
+```
+
+---
+
+## Task 3: Remove `[test-groups].setup-state` from nextest config
+
+**Files:**
+- Modify: `.config/nextest.toml`
+
+- [ ] **Step 1: Read the current config**
+
+```bash
+cat .config/nextest.toml
+```
+
+Expected: a `[test-groups] setup-state = { max-threads = 1 }` block and a `[[profile.default.overrides]]` that filters `setup_http::` and `setup_concurrent_http::` into that group.
+
+- [ ] **Step 2: Delete the `[test-groups]` block and the related override**
+
+Keep `[profile.default]` (with `slow-timeout`, `fail-fast`). Remove:
+- The `[test-groups]` section and any members under it.
+- The `[[profile.default.overrides]]` that assigns tests to `setup-state`.
+
+If, after the deletion, no override remains, the file reduces to only `[profile.default]` plus its settings — that's correct.
+
+- [ ] **Step 3: Sanity check nextest still parses the file**
+
+```bash
+cargo nextest list --help 2>&1 | head -1
+cargo nextest list 2>&1 | head -5
+```
+
+Expected: nextest lists tests without a parse error on `.config/nextest.toml`. If it errors on the file, the deletion was over-zealous — restore `[profile.default]` as needed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .config/nextest.toml
+git commit -m "chore(infra): remove [test-groups].setup-state nextest entry"
+```
+
+---
+
+## Task 4: Remove remaining `serial_test` imports and `#[serial]` attrs
+
+**Files:**
+- Modify: any file under `server/tests/` that still imports `serial_test` or applies `#[serial]`.
+
+- [ ] **Step 1: Find stragglers**
+
+```bash
+grep -rnE 'use serial_test|#\[serial' server/tests/ 2>&1 | head -20
+```
+
+Expected: this should mostly be empty (each phase's recipe removes `#[serial]` on migrated tests). Any remaining hits are (a) files where the import was left as dead code after the attribute was removed, or (b) tests that the batches somehow missed.
+
+- [ ] **Step 2: Delete each straggler**
+
+For a dead `use serial_test::…;`: delete the line.
+For any residual `#[serial]` attribute: delete it.
+
+- [ ] **Step 3: Check that `serial_test` is no longer needed as a dev-dependency**
+
+```bash
+grep -nE 'serial_test|serial-test' server/Cargo.toml server/Cargo.toml.orig 2>/dev/null
+grep -rnE 'use serial_test' server/ 2>&1 | head -5
+```
+
+Expected: no matches in `server/src/` or `server/tests/`. If `server/Cargo.toml` declares `serial_test` as a dev-dep, remove that declaration too.
+
+- [ ] **Step 4: Compile check**
+
+```bash
+SQLX_OFFLINE=true cargo check -p vc-server --tests 2>&1 | grep -E "^error" | head -5
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A server/tests/ server/Cargo.toml
+git commit -m "chore(infra): remove serial_test dep and residual #[serial] attributes"
+```
+
+---
+
+## Task 5: Update contributor docs
+
+**Files:**
+- Modify: `docs/developer-guide/testing/*.md` (any file documenting integration test patterns)
+- Modify: `server/AGENTS.md` and `server/tests/AGENTS.md` if they exist
+- Possibly modify: `server/src/AGENTS.md` if it references the integration-test pattern
+
+- [ ] **Step 1: Locate doc references to the old pattern**
+
+```bash
+grep -rn 'shared_pool\|SHARED_POOL\|shared_config\|TestApp::new()\|CleanupGuard\|\[test-groups\]\|setup-state\|#\[serial\]' docs/ server/AGENTS.md server/tests/ 2>/dev/null | grep '\.md:' | head -20
+```
+
+Expected: a handful of matches in developer-guide docs and AGENTS files.
+
+- [ ] **Step 2: Update each doc to point at `#[sqlx::test]`**
+
+Concretely, change sentences like:
+- "Integration tests use `TestApp::new()` with a shared pool." → "Integration tests use `#[sqlx::test]`; each test receives a fresh `PgPool` via `TestApp::with_pool(pool)`."
+- "Use `CleanupGuard` to delete rows at test end." → (delete the sentence if DB-row cleanup was the only use case; otherwise narrow it to non-DB cleanup).
+- "Setup-state tests are serialized via nextest `[test-groups]`." → (delete the sentence; per-test DB makes serialization unnecessary).
+
+- [ ] **Step 3: Add a short "Integration test patterns" section to `server/tests/AGENTS.md`** (create the file if it doesn't exist) describing the canonical pattern:
+
+```markdown
+## Integration test pattern
+
+Each integration test gets its own isolated PostgreSQL database via `#[sqlx::test]`:
+
+```rust
+#[sqlx::test]
+async fn test_something(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
+    // … test body
+}
+```
+
+The pool is freshly created from a template DB that has all migrations applied; the test's DB is dropped automatically after the test returns. There is no shared state between tests.
+
+For tests that need S3, use `fresh_test_app_with_s3_and_pool(pool)` — it returns a `TestApp` plus a unique bucket name, with the bucket's teardown deferred to a `CleanupGuard`.
+
+Do NOT use `#[tokio::test]` for integration tests. Do NOT use `#[serial]` — per-test DB isolation is absolute.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/ server/AGENTS.md server/tests/ 2>/dev/null  # commit whatever paths exist
+git commit -m "docs(infra): document #[sqlx::test] as canonical integration-test pattern"
+```
+
+---
+
+## Task 6: CHANGELOG entry
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Locate the `[Unreleased]` → `### Changed` section**
+
+```bash
+grep -nE '^## \[Unreleased\]|^### Changed' CHANGELOG.md | head -5
+```
+
+- [ ] **Step 2: Add the entry**
+
+Append (or prepend, matching the repo's convention) under the topmost `### Changed` block within `[Unreleased]`:
+
+```markdown
+- Integration tests now use `#[sqlx::test]`'s per-test database isolation; the shared-pool model that produced sporadic Postgres deadlocks in CI is retired. Contributor-facing documentation is in `docs/developer-guide/testing/` and `server/tests/AGENTS.md`.
+```
+
+If `[Unreleased]` has no `### Changed` subsection yet, add one (alphabetical with the other `### …` headings per Keep-a-Changelog).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(infra): CHANGELOG entry for sqlx::test integration-test migration"
+```
+
+---
+
+## Final Verification (before opening PR)
+
+- [ ] **Invariant greps**
+
+```bash
+grep -rn 'shared_pool\|SHARED_POOL\|shared_config\|SHARED_CONFIG' server/tests/ 2>&1 | head -5
+grep -rn '#\[serial\]\|use serial_test' server/tests/ 2>&1 | head -5
+grep -c '\[test-groups\]' .config/nextest.toml
+```
+
+Expected:
+- First grep: no output.
+- Second grep: no output.
+- Third grep: `0`.
+
+- [ ] **Full check-fmt-clippy-deny sweep**
+
+```bash
+SQLX_OFFLINE=true cargo check -p vc-server --tests 2>&1 | tail -3
+cargo +nightly fmt --all -- --check && echo "fmt OK"
+SQLX_OFFLINE=true cargo clippy --all-features --workspace --exclude vc-client -- -D warnings 2>&1 | tail -3
+cargo deny check advisories 2>&1 | tail -3
+cargo deny check licenses 2>&1 | tail -3
+```
+
+Expected: all green.
+
+- [ ] **Commit log**
+
+```bash
+git log --oneline origin/main..HEAD
+```
+
+Expected 6 commits:
+1. `test(infra): delete SHARED_POOL + legacy no-arg TestApp factories`
+2. `test(infra): prune CleanupGuard DB-row cleanup methods`
+3. `chore(infra): remove [test-groups].setup-state nextest entry`
+4. `chore(infra): remove serial_test dep and residual #[serial] attributes`
+5. `docs(infra): document #[sqlx::test] as canonical integration-test pattern`
+6. `docs(infra): CHANGELOG entry for sqlx::test integration-test migration`
+
+- [ ] **Push + open PR**
+
+```bash
+git push -u origin chore/sqlx-test-phase5-cleanup
+gh pr create --base main --head chore/sqlx-test-phase5-cleanup \
+  --title "chore(infra): sqlx::test migration Phase 5 — delete legacy path + update docs" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Final phase of the integration-test migration to `#[sqlx::test]`. Deletes the shared-pool legacy path now that every integration test uses per-test DB isolation.
+
+Changes:
+- Delete `SHARED_POOL`/`shared_pool`, `SHARED_CONFIG`/`shared_config`, legacy `TestApp::new()`/`with_screen_share_limiter()`/`fresh_test_app_with_s3()` no-arg wrappers.
+- Prune `CleanupGuard` DB-row cleanup methods; keep only non-DB cleanup (e.g., S3).
+- Remove `[test-groups].setup-state` from `.config/nextest.toml` — per-test DB obsoletes cross-process serialization.
+- Drop `serial_test` dev-dep + any residual `#[serial]` attributes / imports under `server/tests/`.
+- Document `#[sqlx::test]` as the canonical integration-test pattern in `server/tests/AGENTS.md` and `docs/developer-guide/testing/`.
+- CHANGELOG `### Changed` entry.
+
+Spec: `docs/superpowers/specs/2026-04-18-sqlx-test-integration-migration-design.md` — Phase 5.
+
+## Test plan
+
+- [x] `grep -rn 'shared_pool\|SHARED_POOL\|shared_config\|SHARED_CONFIG' server/tests/` returns empty
+- [x] `grep -rn '#\[serial\]\|use serial_test' server/tests/` returns empty
+- [x] `.config/nextest.toml` no longer has `[test-groups]`
+- [x] Full integration test suite passes on CI under `-j 4` parallelism
+- [x] fmt / clippy / deny sweep green
+
+## Expected post-merge outcome
+
+- The 3 observed deadlock-flake test functions (`test_first_user_detection_works`, `test_guild_search_xss_content_returned_verbatim`, `test_upload_requires_auth`) run cleanly under `-j 4`.
+- Zero `40P01` (deadlock_detected) occurrences in `main` CI logs going forward. Verified against 10 consecutive runs before declaring the workstream complete.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Wait for CI green and squash-merge (no `--admin`)**
+
+```bash
+gh pr checks <PR_NUMBER> --watch
+gh pr merge <PR_NUMBER> --squash
+```
+
+- [ ] **Post-merge cleanup**
+
+```bash
+cd /home/detair/GIT/detair/kaiku
+git worktree remove .claude/worktrees/sqlx-test-phase5
+git branch -D chore/sqlx-test-phase5-cleanup
+git fetch origin --prune
+```
+
+---
+
+## Success criteria
+
+1. `grep -rn 'shared_pool\|SHARED_POOL\|shared_config\|SHARED_CONFIG' server/tests/` returns empty.
+2. `grep -rn '#\[serial\]\|use serial_test' server/tests/` returns empty.
+3. `.config/nextest.toml` no longer contains `[test-groups]`.
+4. `server/tests/AGENTS.md` documents `#[sqlx::test]` as canonical with a copy-pasteable example.
+5. `CHANGELOG.md` `### Changed` has the Phase 5 entry under `[Unreleased]`.
+6. Full integration test suite passes on CI under `-j 4` for the PR.
+
+## Post-merge workstream validation (tracked separately from this PR)
+
+- [ ] Observe `main` CI for 1 week post-merge.
+- [ ] Zero `40P01` deadlock failures in that window.
+- [ ] The 3 flagged test functions run cleanly under `-j 4` across 10 consecutive `main` runs.
+
+If any of those validations fail, open a remediation issue — do NOT revert this PR. The structural fix should be correct; any residual flake indicates a different root cause (e.g., a different shared resource like Redis) that was latent under the old shared-pool pattern.
+
+## Notes for the implementer
+
+- **Phase 5 is a deletion PR.** If you find yourself writing a new helper or adding new behavior, you've wandered out of scope. Undo and ask.
+- **Don't leave `CleanupGuard` alive if it has no non-DB users.** If the audit in Task 2 Step 2 finds zero non-DB methods, delete the entire struct. YAGNI.
+- **Don't split this into smaller PRs.** The 6 commits tell a coherent deletion story; splitting fragments reviewer context.
+- **If CI goes red on deletion**, the most likely cause is an orphaned reference from a batch that "migrated" a test but left a helper call behind. Grep for the specific symbol (`shared_pool`, `CleanupGuard::new`, etc.), fix in-place, commit as an amendment to Task 1 or 2 rather than a new commit.

--- a/docs/superpowers/specs/2026-04-18-sqlx-test-integration-migration-design.md
+++ b/docs/superpowers/specs/2026-04-18-sqlx-test-integration-migration-design.md
@@ -28,7 +28,7 @@ Each fix addresses only the test class that flaked most recently; the underlying
 
 ## Scope
 
-Target: 45 integration test files and ~406 test functions under `server/tests/integration/`. In scope: the `TestApp` constructor API, the `SHARED_POOL`/`SHARED_CONFIG` `OnceCell`s, the `[test-groups]` nextest entries, the `#[serial]` attributes on test functions, and the `CleanupGuard` DB-cleanup methods. Out of scope (deliberate):
+Target: 45 integration test files (plus `helpers/mod.rs`) and ~406 test functions under `server/tests/integration/`. Three files are carved out as not requiring migration (they have no DB/`TestApp` dependency, so they neither cause nor suffer the cross-process deadlock): `e2ee_settings.rs` (pure parsing tests, 0 `TestApp` usages), `pages.rs` (all `#[ignore]`'d, uses its own `DATABASE_URL` helper), `voice_rate_limit.rs` (`#[tokio::test(start_paused = true)]` exercising a pure in-memory rate limiter). Effective migration scope: **42 files**. In scope: the `TestApp` constructor API, the `SHARED_POOL`/`SHARED_CONFIG` `OnceCell`s, the `[test-groups]` nextest entries, the `#[serial]` attributes on test functions, and the `CleanupGuard` DB-cleanup methods. Out of scope (deliberate):
 
 - **Unit tests under `server/src/`** — already use `#[sqlx::test]`; nothing to migrate.
 - **Tauri / Android / client-side tests** — unrelated subsystem; their own concurrency story.

--- a/docs/superpowers/specs/2026-04-18-sqlx-test-integration-migration-design.md
+++ b/docs/superpowers/specs/2026-04-18-sqlx-test-integration-migration-design.md
@@ -1,0 +1,179 @@
+# `#[sqlx::test]` Migration for Integration Tests
+
+**Date:** 2026-04-18
+**Status:** Draft
+**Goal:** Migrate all ~406 `#[tokio::test]` integration tests under `server/tests/integration/` to `#[sqlx::test]`'s per-test isolated-database pattern, eliminating the cross-process Postgres deadlock flakes that have plagued CI for 2+ years under the shared-pool + `CleanupGuard` model.
+
+## Context
+
+Integration tests currently share a single `canis_test` database through a static `SHARED_POOL` (`server/tests/integration/helpers/mod.rs:58`). `cargo nextest run -j 4` runs four test processes concurrently against that one DB. Tests insert/delete rows in `users`, `guild_members`, `channels`, `messages`, etc.; Postgres's implicit `FOR KEY SHARE` foreign-key-check locks are taken in inconsistent order by concurrent processes, producing sporadic `40P01` deadlocks during fixture setup.
+
+Four distinct deadlock failures observed in the current working week alone, across four unrelated PRs:
+- `setup::test_first_user_detection_works` — deadlock on `guild_members` tuple (PR #531)
+- `search_http::test_guild_search_xss_content_returned_verbatim` — deadlock on `users` `FOR KEY SHARE` (PRs #540, #539 twice)
+- `uploads_http::test_upload_requires_auth` — TIMEOUT, likely related (PR #529)
+
+The team has responded with point fixes for 2+ years:
+- `#193` serialized bot ecosystem tests
+- `#194` serialized channel permissions tests
+- `#280` serialized guild joins in production code
+- `#508` unblocked a flaky test
+- `#509/#511` added nextest `[test-groups].setup-state` for cross-process serialization of setup-state tests
+- `#515` migrated to explicit `CleanupGuard` cleanup
+- `a21506a` marked one specific concurrent-setup race test as ignored
+
+Each fix addresses only the test class that flaked most recently; the underlying shared-DB concurrency model is untouched. New flakes keep appearing in new test classes. This spec is a root-cause rewrite: replace the shared-DB model with per-test isolation via sqlx's `#[sqlx::test]` macro.
+
+`#[sqlx::test]` is already used extensively in unit tests under `server/src/` (e.g., `server/src/chat/messages.rs` has 6 examples). This spec extends the pattern to integration tests.
+
+## Scope
+
+Target: 45 integration test files and ~406 test functions under `server/tests/integration/`. In scope: the `TestApp` constructor API, the `SHARED_POOL`/`SHARED_CONFIG` `OnceCell`s, the `[test-groups]` nextest entries, the `#[serial]` attributes on test functions, and the `CleanupGuard` DB-cleanup methods. Out of scope (deliberate):
+
+- **Unit tests under `server/src/`** — already use `#[sqlx::test]`; nothing to migrate.
+- **Tauri / Android / client-side tests** — unrelated subsystem; their own concurrency story.
+- **Production code changes** — the deadlocks are an artefact of test concurrency, not a production bug. Production traffic serialises through single connections per request; it does not hit the interleavings this spec fixes. No production-side audit is warranted by this workstream.
+- **Retry-on-deadlock config** in nextest — the structural fix obsoletes retry as a flake-mitigation strategy; no point adding it.
+
+## Approach
+
+Phased across 5 PRs. Each PR lands independently with CI green; no `--admin` overrides. Backward compatibility preserved within the migration window: existing `TestApp::new()` callers keep working until Phase 5 deletes them.
+
+### Phase 1 — new `TestApp` API + pilot migration (1 PR)
+
+Add pool-injecting factories alongside the existing ones:
+
+```rust
+impl TestApp {
+    /// New canonical constructor: accepts an externally-provided pool
+    /// (typically from `#[sqlx::test]`'s fixture). All fresh integration
+    /// tests should use this form.
+    pub async fn with_pool(pool: PgPool) -> Self { /* move TestApp::new body here */ }
+
+    /// Screen-share-enabled variant, pool-injecting form.
+    pub async fn with_pool_and_screen_share_limiter(pool: PgPool) -> Self { /* … */ }
+
+    // Existing no-arg wrappers kept as convenience during migration:
+    pub async fn new() -> Self {
+        Self::with_pool(shared_pool().await.clone()).await
+    }
+    pub async fn with_screen_share_limiter() -> Self {
+        Self::with_pool_and_screen_share_limiter(shared_pool().await.clone()).await
+    }
+}
+
+/// S3 variant, pool-injecting form.
+pub async fn fresh_test_app_with_s3_and_pool(pool: PgPool) -> (TestApp, String) { /* … */ }
+// `fresh_test_app_with_s3()` (no-arg) kept as convenience during migration.
+```
+
+Pilot migration: 3 low-risk files — `blocking.rs`, `e2ee_settings.rs`, `pages.rs` — are converted to `#[sqlx::test]` form as part of Phase 1 to validate the template-DB + migrations pipeline end-to-end in CI before committing to bulk migration.
+
+**Phase 1 success criteria:**
+- New factories exist and compile.
+- Old factories still exist and delegate to the new ones.
+- The 3 pilot files pass under `#[sqlx::test]` in CI.
+- Template DB creation + migrations execute within a reasonable bound on CI (verified: cold startup < 10s, per-test overhead < 200ms).
+
+### Phases 2–4 — bulk migration by batch (3 PRs)
+
+Remaining 42 files split into 3 batches of approximately 14 each, grouped by domain coherence so reviewers see related tests together:
+
+- **Batch A — voice/chat/media**: `voice_sfu.rs`, `channels_http.rs`, `messages_http.rs`, `media_processing.rs`, `screenshare.rs`, `threads.rs`, `upload_limits.rs`, `uploads_http.rs`, plus any others in the same domain.
+- **Batch B — auth/admin/governance**: `admin_elevation.rs`, `admin_reports.rs`, `oidc.rs`, `ratelimit.rs`, `reports.rs`, `roles_security.rs`, `setup.rs`, `setup_integration.rs`, plus related.
+- **Batch C — social/search/misc**: `bot_ecosystem.rs`, `channel_permissions.rs`, `guild_invite.rs`, `mention_permission.rs`, `search.rs`, `search_http.rs`, plus remaining.
+
+Per-batch mechanical rewrite per test function:
+
+1. `#[tokio::test]` → `#[sqlx::test]`
+2. Function signature gains `pool: PgPool` parameter
+3. Any `TestApp::new().await` → `TestApp::with_pool(pool.clone()).await`
+4. Any `TestApp::with_screen_share_limiter().await` → `TestApp::with_pool_and_screen_share_limiter(pool.clone()).await`
+5. Any `fresh_test_app_with_s3().await` → `fresh_test_app_with_s3_and_pool(pool.clone()).await`
+6. `CleanupGuard`: drop DB-row cleanup calls that become redundant under per-test DB isolation (e.g., `guard.delete_user(id)`); keep S3-bucket cleanup and any future non-DB cleanup methods. For tests that use `CleanupGuard` solely for DB rows, delete the guard entirely.
+7. `#[serial(setup)]` (or any `#[serial]`) attributes: remove unconditionally. Cross-test DB isolation is now absolute.
+
+Each batch PR is small enough for a subagent to execute end-to-end with spec-compliance + code-quality review between phases.
+
+**Batch success criteria:**
+- All migrated tests green under `cargo nextest run -j 4`.
+- Full-suite failure count strictly monotonically non-increasing across the series of PRs.
+- No previously-passing test regresses.
+
+### Phase 5 — delete the legacy path (1 PR)
+
+After Batches A, B, C merge, Phase 5 removes the old patterns:
+
+1. Delete `SHARED_POOL` (`OnceCell<PgPool>`), `shared_pool()`, `SHARED_CONFIG`, `shared_config()`, and the no-arg `TestApp::new()` / `with_screen_share_limiter()` / `fresh_test_app_with_s3()` wrappers.
+2. Remove the `[test-groups]` `setup-state` entry from `.config/nextest.toml`. Remove the `[[profile.default.overrides]]` that assigns tests to it.
+3. Grep remaining `#[serial]` attributes and `use serial_test` imports across `server/tests/`; delete them.
+4. `CleanupGuard` audit: delete DB-row cleanup methods (`delete_user`, `restore_setup_complete`, `delete_dm_channel`, `delete_guild`, `delete_connection_data`). Keep the type and any non-DB cleanup methods (S3 bucket cleanup, etc.). If no non-DB uses remain, delete the type entirely.
+5. Update `docs/developer-guide/testing/` (and any `AGENTS.md` under `server/`) to name `#[sqlx::test]` as the canonical integration-test setup and remove references to `shared_pool`, `SHARED_POOL`, `[test-groups]`, etc.
+6. `CHANGELOG.md` `### Changed` entry: *"Integration tests now use `#[sqlx::test]`'s per-test database isolation; contributor-facing documentation of the new pattern is in `docs/developer-guide/testing/`."*
+
+**Phase 5 success criteria:**
+- `grep -rn 'shared_pool\|SHARED_POOL\|shared_config\|SHARED_CONFIG' server/tests/` returns empty.
+- `grep -rn '#\[serial\]\|use serial_test' server/tests/` returns empty.
+- `.config/nextest.toml` no longer contains `[test-groups]`.
+- All 4 observed deadlock-flake test functions run cleanly under `-j 4` across 10 consecutive CI runs on `main`.
+- Zero deadlock flakes on `main` CI for 1 week post-merge.
+
+## File map
+
+**Modified (Phase 1):**
+- `server/tests/integration/helpers/mod.rs` — add `with_pool`, `with_pool_and_screen_share_limiter`, `fresh_test_app_with_s3_and_pool`; refactor existing no-arg forms to delegate.
+- `server/tests/integration/blocking.rs`, `e2ee_settings.rs`, `pages.rs` — pilot migration.
+
+**Modified (Phases 2–4):** 39 files under `server/tests/integration/`, one batch per phase.
+
+**Modified (Phase 5):**
+- `server/tests/integration/helpers/mod.rs` — delete `SHARED_POOL`, `shared_pool`, `SHARED_CONFIG`, `shared_config`, legacy no-arg `TestApp` factories, and DB-cleanup methods on `CleanupGuard`.
+- `.config/nextest.toml` — remove `[test-groups]` block and its override.
+- `docs/developer-guide/testing/*.md` — document `#[sqlx::test]` as canonical.
+- `server/AGENTS.md`, `server/tests/AGENTS.md` (if it exists) — update test-infra guidance.
+- `CHANGELOG.md` — `### Changed` entry.
+- Any file currently importing `serial_test` — drop the import + attributes.
+
+**Total LOC estimate:** ~500–800 lines touched across all phases (mostly mechanical per-test edits of ~1–2 lines each plus the helper refactor and Phase 5 deletions).
+
+## CI posture
+
+- sqlx::test uses a template-database optimization: on first use per binary, it creates `canis_test_template`, runs the 54 migrations, and subsequently per-test database creation is `CREATE DATABASE ... TEMPLATE canis_test_template` (~50–100 ms). Initial migration cost amortises across the whole test run.
+- Rough CI wall-time impact: +1–2 s cold start for template + 406 × ~100 ms per-test = ~40 s extra per integration test binary. Offset against eliminated deadlock reruns (each currently costs ~10–30 min of human+machine time), CI throughput improves on a moderate timescale.
+- `-j 4` parallelism is preserved. `[test-groups]` serialization is removed (no longer needed).
+
+## Risks
+
+| # | Risk | Probability | Mitigation |
+|---|------|-------------|-----------|
+| 1 | Template DB + 54 migrations exceeds sqlx::test's startup budget and CI stalls | Low | Validate in Phase 1's pilot before committing to bulk. If slow, investigate migration squash or `sqlx::migrate!` caching. |
+| 2 | A test silently depends on cross-test state (e.g., data from test A leaks to test B) | Medium | Per-test DB isolation will surface this as a failure; roll the specific test into its own carve-out PR with an explicit `#[sqlx::test(fixtures = …)]` fixture. Do not block the batch on it. |
+| 3 | `CleanupGuard`'s S3 bucket cleanup pattern doesn't cleanly combine with `#[sqlx::test]`'s per-test DB | Low | S3 cleanup is orthogonal to DB — `CleanupGuard` continues to work. Phase 5 audits that the guard's type survives with only non-DB methods. |
+| 4 | A subagent batch produces a large hard-to-review diff | Medium | Batch size caps at ~13 files. If review burden exceeds tolerance, split the batch. |
+| 5 | During Phase 2–4, a test flakes for unrelated reasons (e.g., CI runner infra) | Low | Retry the job per the existing workflow. If a specific test flakes repeatedly, escalate as a separate concern; do not lump it into this workstream. |
+| 6 | A production test (e.g., `setup_integration`) depends on the singleton `server_config.setup_complete` row — `#[sqlx::test]` per-test DB resets that row between tests, breaking the test's premise | Medium | These tests already tolerated isolation under `setup-state` nextest group serialization; per-test DB should be a strict improvement. Verify during Batch B (where `setup*` lives). |
+
+## Success criteria (workstream-level)
+
+1. All 406 integration test functions run under `#[sqlx::test]`.
+2. `shared_pool`, `SHARED_POOL`, `shared_config`, `SHARED_CONFIG`, and all no-arg `TestApp` factories are deleted from `server/tests/integration/helpers/mod.rs`.
+3. `.config/nextest.toml` no longer contains `[test-groups]`.
+4. No `#[serial]` attribute or `use serial_test` import remains under `server/tests/`.
+5. The 3 observed deadlock-flake test functions (`test_first_user_detection_works`, `test_guild_search_xss_content_returned_verbatim`, `test_upload_requires_auth`) run cleanly under `cargo nextest run -j 4` for 10 consecutive CI runs on `main`.
+6. Zero `40P01` (deadlock_detected) occurrences in `main` CI logs for 1 week after Phase 5 merges.
+
+## Out of scope
+
+- **Production code changes.** The deadlocks are artefacts of test-only concurrency; production traffic serialises per-request and does not hit these interleavings.
+- **Retry-on-deadlock configuration.** Obsoleted by the structural fix.
+- **Unit tests under `server/src/`.** Already use `#[sqlx::test]`.
+- **Android, Tauri, or frontend tests.** Different subsystems.
+- **Redis / Valkey fixture isolation.** Integration tests share one Redis via `config.redis_url`. Out of scope here; Redis contention has not been observed as a source of flakes. If it becomes one, treat as a separate workstream.
+- **S3 / RustFS bucket-per-test isolation.** Only 2 files use S3 and they already create unique bucket names. Current CleanupGuard-based S3 teardown is retained.
+
+## CHANGELOG entries
+
+- **Phase 5 only** (the earlier phases are refactoring with no user-visible change; per CLAUDE.md, CHANGELOG is updated only for user-visible changes. This one gets an entry because the new integration-test pattern is a contributor-facing convention worth noting):
+
+  Under `### Changed`:
+  > Integration tests now use `#[sqlx::test]`'s per-test database isolation; the shared-pool model that produced sporadic Postgres deadlocks in CI is retired. Contributor-facing documentation is in `docs/developer-guide/testing/`.


### PR DESCRIPTION
## Summary

Ships the design spec and five implementation plans for migrating `server/tests/integration/` to `#[sqlx::test]` per-test DB isolation. No code changes — docs only.

- `docs/superpowers/specs/2026-04-18-sqlx-test-integration-migration-design.md` — design (motivation: 2+ year history of cross-process Postgres deadlock flakes caused by 42+ integration tests sharing `canis_test` under nextest `-j 4`; mitigation: per-test DB via `#[sqlx::test]`)
- `docs/superpowers/plans/2026-04-18-phase1-testapp-api-plus-pilot.md` — Phase 1: `TestApp::with_pool` factories + 3-file pilot (blocking, dm_http, favorites); go/no-go gate on template-DB + 54-migration cold start (<10s budget)
- `docs/superpowers/plans/2026-04-18-phase2-batch-a-voice-chat-media.md` — Phase 2: 11 voice/chat/media files; `voice_rate_limit.rs` carved out (pure in-memory `#[tokio::test(start_paused=true)]`)
- `docs/superpowers/plans/2026-04-18-phase3-batch-b-auth-admin-governance.md` — Phase 3: 14 auth/admin/governance files
- `docs/superpowers/plans/2026-04-18-phase4-batch-c-social-search-misc.md` — Phase 4: 14 social/search/misc files; includes the "zero `#[tokio::test]` in `server/tests/integration/`" invariant check that is load-bearing for Phase 5
- `docs/superpowers/plans/2026-04-18-phase5-legacy-deletion.md` — Phase 5: delete `CleanupGuard` (100% of its methods are DB-cleanup per review), remove `.config/nextest.toml` `setup-state` block, drop `serial_test` dev-dep, refresh docs, add `CHANGELOG` `### Changed` entry

Brainstormed + spec-reviewed + plan-reviewed via the superpowers skill pipeline. Each phase lands as its own implementation PR; the spec/plans live on `main` first so those PRs can reference them by path.

## Execution sequence

- **Phase 1** is the foundation — it establishes the migration recipe and pilots it on 3 files. Must land and bake before anything else; it is the CI go/no-go on template-DB startup cost.
- **Phases 2–4** migrate the remaining 39 files in three sequential batches (voice/chat/media → auth/admin/governance → social/search/misc), each following the Phase 1 recipe.
- **Phase 5** is pure cleanup, gated on Phase 4's invariant check passing.

## Expected CI

Docs-only PR, zero code delta — should inherit `main`'s current green state. Non-admin merge per the workflow restored in #536.

🤖 Generated with [Claude Code](https://claude.com/claude-code)