### PR TITLE
test(infra): sqlx::test migration Phase 4 — batch C (social/search/misc)

### DIFF
--- a/server/tests/integration/bot_ecosystem.rs
+++ b/server/tests/integration/bot_ecosystem.rs
@@ -40,7 +40,6 @@ async fn test_create_bot_application(pool: PgPool) {
     assert_eq!(app_response["name"], "Test Bot");
     assert_eq!(app_response["description"], "A test bot application");
     assert!(app_response["id"].is_string());
-
 }
 
 /// Test creating application with invalid name.
@@ -64,7 +63,6 @@ async fn test_create_bot_application_invalid_name(pool: PgPool) {
 
     let response = app.oneshot(request).await;
     assert_eq!(response.status(), 400);
-
 }
 
 /// Test listing bot applications.
@@ -105,7 +103,6 @@ async fn test_list_bot_applications(pool: PgPool) {
     assert_eq!(apps.len(), 2);
     assert_eq!(apps[0]["name"], "Bot 2"); // Ordered by created_at DESC
     assert_eq!(apps[1]["name"], "Bot 1");
-
 }
 
 /// Test creating a bot user for an application.
@@ -161,7 +158,6 @@ async fn test_create_bot_user(pool: PgPool) {
 
     assert!(bot_user.is_bot);
     assert_eq!(bot_user.bot_owner_id, Some(user_id));
-
 }
 
 /// Test that creating bot user twice fails.
@@ -203,7 +199,6 @@ async fn test_create_bot_user_twice_fails(pool: PgPool) {
         .unwrap();
     let bot_resp2 = app.oneshot(bot_req2).await;
     assert_eq!(bot_resp2.status(), 409); // Conflict
-
 }
 
 /// Test resetting bot token.
@@ -256,7 +251,6 @@ async fn test_reset_bot_token(pool: PgPool) {
     let new_token = new_data["token"].as_str().unwrap();
 
     assert_ne!(original_token, new_token);
-
 }
 
 /// Test deleting a bot application.
@@ -303,7 +297,6 @@ async fn test_delete_bot_application(pool: PgPool) {
     let apps: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
 
     assert_eq!(apps.len(), 0);
-
 }
 
 /// Test registering slash commands.
@@ -368,7 +361,6 @@ async fn test_register_slash_commands(pool: PgPool) {
     assert_eq!(commands.len(), 2);
     assert_eq!(commands[0]["name"], "hello");
     assert_eq!(commands[1]["name"], "ping");
-
 }
 
 /// Test command name validation.
@@ -416,7 +408,6 @@ async fn test_register_command_invalid_name(pool: PgPool) {
 
     let register_resp = app.oneshot(register_req).await;
     assert_eq!(register_resp.status(), 400);
-
 }
 
 /// Test listing slash commands.
@@ -477,7 +468,6 @@ async fn test_list_slash_commands(pool: PgPool) {
 
     assert_eq!(commands.len(), 1);
     assert_eq!(commands[0]["name"], "test");
-
 }
 
 /// Test guild-scoped command operations stay isolated per application.
@@ -614,7 +604,6 @@ async fn test_guild_scoped_commands_are_isolated_per_application(pool: PgPool) {
     let commands_b: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
     assert_eq!(commands_b.len(), 1);
     assert_eq!(commands_b[0]["name"], "beta");
-
 }
 
 /// Test deleting a slash command.
@@ -692,7 +681,6 @@ async fn test_delete_slash_command(pool: PgPool) {
     let commands: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
 
     assert_eq!(commands.len(), 0);
-
 }
 
 /// Test that non-owners cannot access applications.
@@ -1365,7 +1353,6 @@ async fn test_register_commands_rejects_batch_duplicates(pool: PgPool) {
         409,
         "Expected 409 Conflict for duplicate command names in batch"
     );
-
 }
 
 /// Test that listing guild commands shows entries from all installed bots (no deduplication)

--- a/server/tests/integration/bot_ecosystem.rs
+++ b/server/tests/integration/bot_ecosystem.rs
@@ -7,14 +7,15 @@ use axum::http::Method;
 use fred::interfaces::{ClientLike, EventInterface, KeysInterface, PubsubInterface};
 use http_body_util::BodyExt;
 use serde_json::json;
+use sqlx::PgPool;
 use vc_server::db;
 
-use super::helpers::{create_test_user, delete_user, generate_access_token, TestApp};
+use super::helpers::{create_test_user, generate_access_token, TestApp};
 
 /// Test creating a bot application.
-#[tokio::test]
-async fn test_create_bot_application() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_create_bot_application(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -40,13 +41,12 @@ async fn test_create_bot_application() {
     assert_eq!(app_response["description"], "A test bot application");
     assert!(app_response["id"].is_string());
 
-    delete_user(&app.pool, user_id).await;
 }
 
 /// Test creating application with invalid name.
-#[tokio::test]
-async fn test_create_bot_application_invalid_name() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_create_bot_application_invalid_name(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -65,13 +65,12 @@ async fn test_create_bot_application_invalid_name() {
     let response = app.oneshot(request).await;
     assert_eq!(response.status(), 400);
 
-    delete_user(&app.pool, user_id).await;
 }
 
 /// Test listing bot applications.
-#[tokio::test]
-async fn test_list_bot_applications() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_list_bot_applications(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -107,13 +106,12 @@ async fn test_list_bot_applications() {
     assert_eq!(apps[0]["name"], "Bot 2"); // Ordered by created_at DESC
     assert_eq!(apps[1]["name"], "Bot 1");
 
-    delete_user(&app.pool, user_id).await;
 }
 
 /// Test creating a bot user for an application.
-#[tokio::test]
-async fn test_create_bot_user() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_create_bot_user(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -164,13 +162,12 @@ async fn test_create_bot_user() {
     assert!(bot_user.is_bot);
     assert_eq!(bot_user.bot_owner_id, Some(user_id));
 
-    delete_user(&app.pool, user_id).await;
 }
 
 /// Test that creating bot user twice fails.
-#[tokio::test]
-async fn test_create_bot_user_twice_fails() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_create_bot_user_twice_fails(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -207,13 +204,12 @@ async fn test_create_bot_user_twice_fails() {
     let bot_resp2 = app.oneshot(bot_req2).await;
     assert_eq!(bot_resp2.status(), 409); // Conflict
 
-    delete_user(&app.pool, user_id).await;
 }
 
 /// Test resetting bot token.
-#[tokio::test]
-async fn test_reset_bot_token() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_reset_bot_token(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -261,13 +257,12 @@ async fn test_reset_bot_token() {
 
     assert_ne!(original_token, new_token);
 
-    delete_user(&app.pool, user_id).await;
 }
 
 /// Test deleting a bot application.
-#[tokio::test]
-async fn test_delete_bot_application() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_delete_bot_application(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -309,13 +304,12 @@ async fn test_delete_bot_application() {
 
     assert_eq!(apps.len(), 0);
 
-    delete_user(&app.pool, user_id).await;
 }
 
 /// Test registering slash commands.
-#[tokio::test]
-async fn test_register_slash_commands() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_register_slash_commands(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -375,13 +369,12 @@ async fn test_register_slash_commands() {
     assert_eq!(commands[0]["name"], "hello");
     assert_eq!(commands[1]["name"], "ping");
 
-    delete_user(&app.pool, user_id).await;
 }
 
 /// Test command name validation.
-#[tokio::test]
-async fn test_register_command_invalid_name() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_register_command_invalid_name(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -424,13 +417,12 @@ async fn test_register_command_invalid_name() {
     let register_resp = app.oneshot(register_req).await;
     assert_eq!(register_resp.status(), 400);
 
-    delete_user(&app.pool, user_id).await;
 }
 
 /// Test listing slash commands.
-#[tokio::test]
-async fn test_list_slash_commands() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_list_slash_commands(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -486,13 +478,12 @@ async fn test_list_slash_commands() {
     assert_eq!(commands.len(), 1);
     assert_eq!(commands[0]["name"], "test");
 
-    delete_user(&app.pool, user_id).await;
 }
 
 /// Test guild-scoped command operations stay isolated per application.
-#[tokio::test]
-async fn test_guild_scoped_commands_are_isolated_per_application() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_guild_scoped_commands_are_isolated_per_application(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -624,13 +615,12 @@ async fn test_guild_scoped_commands_are_isolated_per_application() {
     assert_eq!(commands_b.len(), 1);
     assert_eq!(commands_b[0]["name"], "beta");
 
-    delete_user(&app.pool, user_id).await;
 }
 
 /// Test deleting a slash command.
-#[tokio::test]
-async fn test_delete_slash_command() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_delete_slash_command(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -703,13 +693,12 @@ async fn test_delete_slash_command() {
 
     assert_eq!(commands.len(), 0);
 
-    delete_user(&app.pool, user_id).await;
 }
 
 /// Test that non-owners cannot access applications.
-#[tokio::test]
-async fn test_application_ownership() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_application_ownership(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (owner_id, _) = create_test_user(&app.pool).await;
     let (other_id, _) = create_test_user(&app.pool).await;
     let owner_token = generate_access_token(&app.config, owner_id);
@@ -740,15 +729,12 @@ async fn test_application_ownership() {
 
     let get_resp = app.oneshot(get_req).await;
     assert_eq!(get_resp.status(), 403); // Forbidden
-
-    delete_user(&app.pool, owner_id).await;
-    delete_user(&app.pool, other_id).await;
 }
 
 /// Test guild bot install endpoint requires guild management permissions.
-#[tokio::test]
-async fn test_add_bot_to_guild() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_add_bot_to_guild(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (owner_id, _) = create_test_user(&app.pool).await;
     let owner_token = generate_access_token(&app.config, owner_id);
 
@@ -883,14 +869,12 @@ async fn test_add_bot_to_guild() {
     .execute(&app.pool)
     .await
     .unwrap();
-    delete_user(&app.pool, owner_id).await;
-    delete_user(&app.pool, other_user_id).await;
 }
 
 /// Test slash command routing publishes invocation to bot gateway channel.
-#[tokio::test]
-async fn test_slash_command_invocation_publishes_to_bot_channel() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_slash_command_invocation_publishes_to_bot_channel(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -1083,16 +1067,15 @@ async fn test_slash_command_invocation_publishes_to_bot_channel() {
         .execute(&app.pool)
         .await
         .unwrap();
-    delete_user(&app.pool, user_id).await;
 }
 
 /// Test that a duplicate command response is rejected (SET NX prevents overwrite).
 ///
 /// Verifies the single-response semantic: once `interaction:{id}:response` is set,
 /// a second SET NX returns false and the original response is preserved.
-#[tokio::test]
-async fn test_duplicate_command_response_rejected() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_duplicate_command_response_rejected(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
 
     let redis = db::create_redis_client(&app.config.redis_url)
         .await
@@ -1162,9 +1145,9 @@ async fn test_duplicate_command_response_rejected() {
 }
 
 /// Test slash command fails when multiple bots provide same command in same scope.
-#[tokio::test]
-async fn test_slash_command_invocation_ambiguous() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_slash_command_invocation_ambiguous(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -1329,13 +1312,12 @@ async fn test_slash_command_invocation_ambiguous() {
         .execute(&app.pool)
         .await
         .unwrap();
-    delete_user(&app.pool, user_id).await;
 }
 
 /// Test that registering commands with duplicate names in a single batch returns 409 Conflict.
-#[tokio::test]
-async fn test_register_commands_rejects_batch_duplicates() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_register_commands_rejects_batch_duplicates(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -1384,14 +1366,13 @@ async fn test_register_commands_rejects_batch_duplicates() {
         "Expected 409 Conflict for duplicate command names in batch"
     );
 
-    delete_user(&app.pool, user_id).await;
 }
 
 /// Test that listing guild commands shows entries from all installed bots (no deduplication)
 /// and marks ambiguous commands with `is_ambiguous: true`.
-#[tokio::test]
-async fn test_list_guild_commands_shows_all_providers() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_list_guild_commands_shows_all_providers(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -1516,13 +1497,12 @@ async fn test_list_guild_commands_shows_all_providers() {
         .execute(&app.pool)
         .await
         .unwrap();
-    delete_user(&app.pool, user_id).await;
 }
 
 /// Test that invoking an ambiguous command returns a 400 error containing the bot names.
-#[tokio::test]
-async fn test_ambiguity_error_includes_bot_names() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_ambiguity_error_includes_bot_names(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -1666,13 +1646,12 @@ async fn test_ambiguity_error_includes_bot_names() {
         .execute(&app.pool)
         .await
         .unwrap();
-    delete_user(&app.pool, user_id).await;
 }
 
 /// Test that the built-in /ping command returns a 200 OK with "Pong!" in the content.
-#[tokio::test]
-async fn test_builtin_ping_returns_pong() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_builtin_ping_returns_pong(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -1767,5 +1746,4 @@ async fn test_builtin_ping_returns_pong() {
         .execute(&app.pool)
         .await
         .unwrap();
-    delete_user(&app.pool, user_id).await;
 }

--- a/server/tests/integration/bot_intents.rs
+++ b/server/tests/integration/bot_intents.rs
@@ -3,20 +3,20 @@
 use axum::body::Body;
 use axum::http::{Method, StatusCode};
 
+use sqlx::PgPool;
+
 use super::helpers::*;
 
 // ============================================================================
 // Intent Persistence Tests
 // ============================================================================
 
-#[tokio::test]
-async fn update_intents_persists() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn update_intents_persists(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let (app_id, _, _) = create_bot_application(&app.pool, user_id).await;
     let token = generate_access_token(&app.config, user_id);
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     let body = serde_json::json!({
         "intents": ["messages", "members", "commands"],
@@ -37,17 +37,14 @@ async fn update_intents_persists() {
     assert!(intents.iter().any(|v| v == "messages"));
     assert!(intents.iter().any(|v| v == "members"));
     assert!(intents.iter().any(|v| v == "commands"));
-    guard.cleanup().await;
 }
 
-#[tokio::test]
-async fn update_intents_reflects_in_get() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn update_intents_reflects_in_get(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let (app_id, _, _) = create_bot_application(&app.pool, user_id).await;
     let token = generate_access_token(&app.config, user_id);
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     // Update intents
     let body = serde_json::json!({ "intents": ["messages", "members"] });
@@ -74,21 +71,18 @@ async fn update_intents_reflects_in_get() {
     assert_eq!(intents.len(), 2);
     assert!(intents.iter().any(|v| v == "messages"));
     assert!(intents.iter().any(|v| v == "members"));
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // Intent Validation Tests
 // ============================================================================
 
-#[tokio::test]
-async fn invalid_intent_name_rejected() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn invalid_intent_name_rejected(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let (app_id, _, _) = create_bot_application(&app.pool, user_id).await;
     let token = generate_access_token(&app.config, user_id);
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     let body = serde_json::json!({
         "intents": ["messages", "invalid_intent"],
@@ -102,17 +96,14 @@ async fn invalid_intent_name_rejected() {
 
     let resp = app.oneshot(req).await;
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-    guard.cleanup().await;
 }
 
-#[tokio::test]
-async fn empty_intents_allowed() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn empty_intents_allowed(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let (app_id, _, _) = create_bot_application(&app.pool, user_id).await;
     let token = generate_access_token(&app.config, user_id);
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     let body = serde_json::json!({ "intents": [] });
 
@@ -128,23 +119,19 @@ async fn empty_intents_allowed() {
     let json = body_to_json(resp).await;
     let intents = json["gateway_intents"].as_array().unwrap();
     assert!(intents.is_empty());
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // Ownership Tests
 // ============================================================================
 
-#[tokio::test]
-async fn non_owner_cannot_update_intents() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn non_owner_cannot_update_intents(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (owner_id, _) = create_test_user(&app.pool).await;
     let (other_id, _) = create_test_user(&app.pool).await;
     let (app_id, _, _) = create_bot_application(&app.pool, owner_id).await;
     let other_token = generate_access_token(&app.config, other_id);
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(owner_id);
-    guard.delete_user(other_id);
 
     let body = serde_json::json!({ "intents": ["messages"] });
 
@@ -156,20 +143,17 @@ async fn non_owner_cannot_update_intents() {
 
     let resp = app.oneshot(req).await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // Default Intent Behavior Tests
 // ============================================================================
 
-#[tokio::test]
-async fn new_application_has_default_intents() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn new_application_has_default_intents(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     // Create application via API
     let body = serde_json::json!({
@@ -190,15 +174,14 @@ async fn new_application_has_default_intents() {
     // New applications should have empty gateway_intents by default (from DB default)
     let intents = json["gateway_intents"].as_array().unwrap();
     assert!(intents.is_empty());
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // Intent Logic Unit Tests (via shared events module)
 // ============================================================================
 
-#[tokio::test]
-async fn intents_permit_event_messages() {
+#[sqlx::test]
+async fn intents_permit_event_messages(_pool: PgPool) {
     use vc_server::webhooks::events::{BotEventType, GatewayIntent};
 
     let intents = vec!["messages".to_string()];
@@ -221,8 +204,8 @@ async fn intents_permit_event_messages() {
     ));
 }
 
-#[tokio::test]
-async fn intents_permit_event_members() {
+#[sqlx::test]
+async fn intents_permit_event_members(_pool: PgPool) {
     use vc_server::webhooks::events::{BotEventType, GatewayIntent};
 
     let intents = vec!["members".to_string()];
@@ -244,8 +227,8 @@ async fn intents_permit_event_members() {
     ));
 }
 
-#[tokio::test]
-async fn intents_permit_event_combined() {
+#[sqlx::test]
+async fn intents_permit_event_combined(_pool: PgPool) {
     use vc_server::webhooks::events::{BotEventType, GatewayIntent};
 
     let intents = vec!["messages".to_string(), "members".to_string()];
@@ -267,8 +250,8 @@ async fn intents_permit_event_combined() {
     ));
 }
 
-#[tokio::test]
-async fn no_intents_still_permits_commands() {
+#[sqlx::test]
+async fn no_intents_still_permits_commands(_pool: PgPool) {
     use vc_server::webhooks::events::{BotEventType, GatewayIntent};
 
     let intents: Vec<String> = vec![];

--- a/server/tests/integration/bot_intents.rs
+++ b/server/tests/integration/bot_intents.rs
@@ -2,7 +2,6 @@
 
 use axum::body::Body;
 use axum::http::{Method, StatusCode};
-
 use sqlx::PgPool;
 
 use super::helpers::*;

--- a/server/tests/integration/connectivity_http.rs
+++ b/server/tests/integration/connectivity_http.rs
@@ -116,9 +116,7 @@ async fn test_summary_with_data(pool: PgPool) {
         .await
         .unwrap();
 
-    let session_id = insert_test_session(&app.pool, user_id, channel_id, Some(guild_id), 3).await;
-
-    let _sid = session_id;
+    let _session_id = insert_test_session(&app.pool, user_id, channel_id, Some(guild_id), 3).await;
 
     let req = TestApp::request(Method::GET, "/api/me/connection/summary")
         .header("Authorization", format!("Bearer {token}"))
@@ -179,8 +177,6 @@ async fn test_sessions_with_data(pool: PgPool) {
     let channel_id = super::helpers::create_channel(&app.pool, guild_id, "voice-sess").await;
 
     let session_id = insert_test_session(&app.pool, user_id, channel_id, Some(guild_id), 0).await;
-
-    let _sid = session_id;
 
     let req = TestApp::request(Method::GET, "/api/me/connection/sessions")
         .header("Authorization", format!("Bearer {token}"))
@@ -258,8 +254,6 @@ async fn test_session_detail(pool: PgPool) {
     // Insert session with 5 metrics (< 200, so no downsampling)
     let session_id = insert_test_session(&app.pool, user_id, channel_id, Some(guild_id), 5).await;
 
-    let _sid = session_id;
-
     let url = format!("/api/me/connection/sessions/{session_id}");
     let req = TestApp::request(Method::GET, &url)
         .header("Authorization", format!("Bearer {token}"))
@@ -317,9 +311,7 @@ async fn test_session_rls_isolation(pool: PgPool) {
     let channel_id = super::helpers::create_channel(&app.pool, guild_id, "voice-rls").await;
 
     // Insert a session for user A
-    let session_a = insert_test_session(&app.pool, user_a, channel_id, Some(guild_id), 0).await;
-
-    let _sa = session_a;
+    let _session_a = insert_test_session(&app.pool, user_a, channel_id, Some(guild_id), 0).await;
 
     // User B should not see user A's sessions
     let req = TestApp::request(Method::GET, "/api/me/connection/sessions")

--- a/server/tests/integration/connectivity_http.rs
+++ b/server/tests/integration/connectivity_http.rs
@@ -79,7 +79,6 @@ async fn test_summary_empty(pool: PgPool) {
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-
     let req = TestApp::request(Method::GET, "/api/me/connection/summary")
         .header("Authorization", format!("Bearer {token}"))
         .body(Body::empty())
@@ -158,7 +157,6 @@ async fn test_sessions_empty(pool: PgPool) {
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-
     let req = TestApp::request(Method::GET, "/api/me/connection/sessions")
         .header("Authorization", format!("Bearer {token}"))
         .body(Body::empty())
@@ -212,7 +210,6 @@ async fn test_sessions_pagination(pool: PgPool) {
     let _s1 = insert_test_session(&app.pool, user_id, channel_id, Some(guild_id), 0).await;
     let _s2 = insert_test_session(&app.pool, user_id, channel_id, Some(guild_id), 0).await;
     let _s3 = insert_test_session(&app.pool, user_id, channel_id, Some(guild_id), 0).await;
-
 
     // Request page: limit=1, offset=1
     let req = TestApp::request(Method::GET, "/api/me/connection/sessions?limit=1&offset=1")
@@ -291,7 +288,6 @@ async fn test_session_detail_not_found(pool: PgPool) {
     let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
-
 
     let random_id = Uuid::new_v4();
     let url = format!("/api/me/connection/sessions/{random_id}");

--- a/server/tests/integration/connectivity_http.rs
+++ b/server/tests/integration/connectivity_http.rs
@@ -73,14 +73,12 @@ async fn insert_test_session(
 // GET /api/me/connection/summary
 // ============================================================================
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_summary_empty() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_summary_empty(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     let req = TestApp::request(Method::GET, "/api/me/connection/summary")
         .header("Authorization", format!("Bearer {token}"))
@@ -99,12 +97,11 @@ async fn test_summary_empty() {
     assert_eq!(json["total_sessions"], 0);
     assert_eq!(json["total_duration_secs"], 0);
     assert!(json["daily_stats"].as_array().unwrap().is_empty());
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_summary_with_data() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_summary_with_data(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
     let channel_id = super::helpers::create_channel(
@@ -122,15 +119,7 @@ async fn test_summary_with_data() {
 
     let session_id = insert_test_session(&app.pool, user_id, channel_id, Some(guild_id), 3).await;
 
-    let mut guard = app.cleanup_guard();
-    let sid = session_id;
-    guard.add(move |pool| async move {
-        super::helpers::delete_connection_data(&pool, sid).await;
-    });
-    guard.add(move |pool| async move {
-        super::helpers::delete_guild(&pool, guild_id).await;
-    });
-    guard.delete_user(user_id);
+    let _sid = session_id;
 
     let req = TestApp::request(Method::GET, "/api/me/connection/summary")
         .header("Authorization", format!("Bearer {token}"))
@@ -145,12 +134,11 @@ async fn test_summary_with_data() {
     assert!(json["total_duration_secs"].as_i64().unwrap() > 0);
     assert!(json["avg_latency"].is_number());
     assert!(!json["daily_stats"].as_array().unwrap().is_empty());
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_summary_unauthenticated() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_summary_unauthenticated(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
 
     let req = TestApp::request(Method::GET, "/api/me/connection/summary")
         .body(Body::empty())
@@ -164,14 +152,12 @@ async fn test_summary_unauthenticated() {
 // GET /api/me/connection/sessions
 // ============================================================================
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_sessions_empty() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_sessions_empty(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     let req = TestApp::request(Method::GET, "/api/me/connection/sessions")
         .header("Authorization", format!("Bearer {token}"))
@@ -184,12 +170,11 @@ async fn test_sessions_empty() {
     let json = body_to_json(resp).await;
     assert_eq!(json["total"], 0);
     assert!(json["sessions"].as_array().unwrap().is_empty());
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_sessions_with_data() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_sessions_with_data(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
     let guild_id = super::helpers::create_guild(&app.pool, user_id).await;
@@ -197,15 +182,7 @@ async fn test_sessions_with_data() {
 
     let session_id = insert_test_session(&app.pool, user_id, channel_id, Some(guild_id), 0).await;
 
-    let mut guard = app.cleanup_guard();
-    let sid = session_id;
-    guard.add(move |pool| async move {
-        super::helpers::delete_connection_data(&pool, sid).await;
-    });
-    guard.add(move |pool| async move {
-        super::helpers::delete_guild(&pool, guild_id).await;
-    });
-    guard.delete_user(user_id);
+    let _sid = session_id;
 
     let req = TestApp::request(Method::GET, "/api/me/connection/sessions")
         .header("Authorization", format!("Bearer {token}"))
@@ -222,31 +199,20 @@ async fn test_sessions_with_data() {
     assert_eq!(sessions[0]["id"], session_id.to_string());
     assert_eq!(sessions[0]["channel_name"], "voice-sess");
     assert!(sessions[0]["guild_name"].is_string());
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_sessions_pagination() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_sessions_pagination(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
     let guild_id = super::helpers::create_guild(&app.pool, user_id).await;
     let channel_id = super::helpers::create_channel(&app.pool, guild_id, "voice-page").await;
 
-    let s1 = insert_test_session(&app.pool, user_id, channel_id, Some(guild_id), 0).await;
-    let s2 = insert_test_session(&app.pool, user_id, channel_id, Some(guild_id), 0).await;
-    let s3 = insert_test_session(&app.pool, user_id, channel_id, Some(guild_id), 0).await;
+    let _s1 = insert_test_session(&app.pool, user_id, channel_id, Some(guild_id), 0).await;
+    let _s2 = insert_test_session(&app.pool, user_id, channel_id, Some(guild_id), 0).await;
+    let _s3 = insert_test_session(&app.pool, user_id, channel_id, Some(guild_id), 0).await;
 
-    let mut guard = app.cleanup_guard();
-    guard.add(move |pool| async move {
-        super::helpers::delete_connection_data(&pool, s1).await;
-        super::helpers::delete_connection_data(&pool, s2).await;
-        super::helpers::delete_connection_data(&pool, s3).await;
-    });
-    guard.add(move |pool| async move {
-        super::helpers::delete_guild(&pool, guild_id).await;
-    });
-    guard.delete_user(user_id);
 
     // Request page: limit=1, offset=1
     let req = TestApp::request(Method::GET, "/api/me/connection/sessions?limit=1&offset=1")
@@ -266,12 +232,11 @@ async fn test_sessions_pagination() {
         1,
         "Should return exactly 1 session"
     );
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_sessions_unauthenticated() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_sessions_unauthenticated(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
 
     let req = TestApp::request(Method::GET, "/api/me/connection/sessions")
         .body(Body::empty())
@@ -285,9 +250,9 @@ async fn test_sessions_unauthenticated() {
 // GET /api/me/connection/sessions/:id
 // ============================================================================
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_session_detail() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_session_detail(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
     let guild_id = super::helpers::create_guild(&app.pool, user_id).await;
@@ -296,15 +261,7 @@ async fn test_session_detail() {
     // Insert session with 5 metrics (< 200, so no downsampling)
     let session_id = insert_test_session(&app.pool, user_id, channel_id, Some(guild_id), 5).await;
 
-    let mut guard = app.cleanup_guard();
-    let sid = session_id;
-    guard.add(move |pool| async move {
-        super::helpers::delete_connection_data(&pool, sid).await;
-    });
-    guard.add(move |pool| async move {
-        super::helpers::delete_guild(&pool, guild_id).await;
-    });
-    guard.delete_user(user_id);
+    let _sid = session_id;
 
     let url = format!("/api/me/connection/sessions/{session_id}");
     let req = TestApp::request(Method::GET, &url)
@@ -327,17 +284,14 @@ async fn test_session_detail() {
     assert!(metrics[0]["packet_loss"].is_number());
     assert!(metrics[0]["jitter_ms"].is_number());
     assert!(metrics[0]["quality"].is_number());
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_session_detail_not_found() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_session_detail_not_found(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     let random_id = Uuid::new_v4();
     let url = format!("/api/me/connection/sessions/{random_id}");
@@ -348,16 +302,15 @@ async fn test_session_detail_not_found() {
 
     let resp = app.oneshot(req).await;
     assert_eq!(resp.status(), 404, "Non-existent session should return 404");
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // RLS Isolation
 // ============================================================================
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_session_rls_isolation() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_session_rls_isolation(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
 
     // Create two users
     let (user_a, _) = create_test_user(&app.pool).await;
@@ -370,16 +323,7 @@ async fn test_session_rls_isolation() {
     // Insert a session for user A
     let session_a = insert_test_session(&app.pool, user_a, channel_id, Some(guild_id), 0).await;
 
-    let mut guard = app.cleanup_guard();
-    let sa = session_a;
-    guard.add(move |pool| async move {
-        super::helpers::delete_connection_data(&pool, sa).await;
-    });
-    guard.add(move |pool| async move {
-        super::helpers::delete_guild(&pool, guild_id).await;
-    });
-    guard.delete_user(user_a);
-    guard.delete_user(user_b);
+    let _sa = session_a;
 
     // User B should not see user A's sessions
     let req = TestApp::request(Method::GET, "/api/me/connection/sessions")
@@ -393,5 +337,4 @@ async fn test_session_rls_isolation() {
     let json = body_to_json(resp).await;
     assert_eq!(json["total"], 0, "User B should not see User A's sessions");
     assert!(json["sessions"].as_array().unwrap().is_empty());
-    guard.cleanup().await;
 }

--- a/server/tests/integration/e2ee_keys.rs
+++ b/server/tests/integration/e2ee_keys.rs
@@ -11,6 +11,7 @@
 
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
+use sqlx::PgPool;
 use uuid::Uuid;
 
 // ============================================================================
@@ -142,17 +143,6 @@ fn test_claimed_prekey_fields() {
 // Integration Tests (require database - marked as #[ignore])
 // ============================================================================
 
-/// Helper to create a test database pool.
-#[allow(dead_code)]
-async fn create_test_pool() -> sqlx::PgPool {
-    let database_url =
-        std::env::var("DATABASE_URL").unwrap_or_else(|_| "postgres://localhost/vc_test".into());
-
-    sqlx::PgPool::connect(&database_url)
-        .await
-        .expect("Failed to connect to test database")
-}
-
 /// Test user struct for cleanup.
 #[allow(dead_code)]
 struct TestUser {
@@ -181,30 +171,6 @@ async fn create_test_user(pool: &sqlx::PgPool, username: &str) -> TestUser {
         id: user_id,
         username: username.to_string(),
     }
-}
-
-/// Helper to cleanup test data.
-#[allow(dead_code)]
-async fn cleanup_test_user(pool: &sqlx::PgPool, user_id: Uuid) {
-    // Delete in correct order due to foreign key constraints
-    let _ = sqlx::query(
-        "DELETE FROM prekeys WHERE device_id IN (SELECT id FROM user_devices WHERE user_id = $1)",
-    )
-    .bind(user_id)
-    .execute(pool)
-    .await;
-    let _ = sqlx::query("DELETE FROM user_devices WHERE user_id = $1")
-        .bind(user_id)
-        .execute(pool)
-        .await;
-    let _ = sqlx::query("DELETE FROM key_backups WHERE user_id = $1")
-        .bind(user_id)
-        .execute(pool)
-        .await;
-    let _ = sqlx::query("DELETE FROM users WHERE id = $1")
-        .bind(user_id)
-        .execute(pool)
-        .await;
 }
 
 /// Helper to generate mock identity keys.
@@ -247,10 +213,8 @@ fn generate_mock_prekeys(count: usize) -> Vec<(String, String)> {
         .collect()
 }
 
-#[tokio::test]
-#[ignore] // Requires PostgreSQL
-async fn test_device_registration() {
-    let pool = create_test_pool().await;
+#[sqlx::test]
+async fn test_device_registration(pool: PgPool) {
 
     // Create test user
     let username = format!("test_device_{}", &Uuid::new_v4().to_string()[..8]);
@@ -283,14 +247,10 @@ async fn test_device_registration() {
 
     assert!(device_exists.is_some(), "Device should exist");
 
-    // Cleanup
-    cleanup_test_user(&pool, user.id).await;
 }
 
-#[tokio::test]
-#[ignore] // Requires PostgreSQL
-async fn test_device_upsert_on_same_identity_key() {
-    let pool = create_test_pool().await;
+#[sqlx::test]
+async fn test_device_upsert_on_same_identity_key(pool: PgPool) {
 
     // Create test user
     let username = format!("test_upsert_{}", &Uuid::new_v4().to_string()[..8]);
@@ -350,14 +310,10 @@ async fn test_device_upsert_on_same_identity_key() {
         "Should only have one device after upsert"
     );
 
-    // Cleanup
-    cleanup_test_user(&pool, user.id).await;
 }
 
-#[tokio::test]
-#[ignore] // Requires PostgreSQL
-async fn test_prekey_upload() {
-    let pool = create_test_pool().await;
+#[sqlx::test]
+async fn test_prekey_upload(pool: PgPool) {
 
     // Create test user and device
     let username = format!("test_prekey_{}", &Uuid::new_v4().to_string()[..8]);
@@ -410,14 +366,10 @@ async fn test_prekey_upload() {
 
     assert_eq!(prekey_count.0, 10, "Should have 10 prekeys");
 
-    // Cleanup
-    cleanup_test_user(&pool, user.id).await;
 }
 
-#[tokio::test]
-#[ignore] // Requires PostgreSQL
-async fn test_prekey_claim_single() {
-    let pool = create_test_pool().await;
+#[sqlx::test]
+async fn test_prekey_claim_single(pool: PgPool) {
 
     // Create owner and claimer users
     let owner_username = format!("test_owner_{}", &Uuid::new_v4().to_string()[..8]);
@@ -490,15 +442,10 @@ async fn test_prekey_claim_single() {
 
     assert_eq!(unclaimed_count.0, 4, "Should have 4 unclaimed prekeys left");
 
-    // Cleanup
-    cleanup_test_user(&pool, owner.id).await;
-    cleanup_test_user(&pool, claimer.id).await;
 }
 
-#[tokio::test]
-#[ignore] // Requires PostgreSQL
-async fn test_prekey_claim_when_exhausted() {
-    let pool = create_test_pool().await;
+#[sqlx::test]
+async fn test_prekey_claim_when_exhausted(pool: PgPool) {
 
     // Create owner and claimer
     let owner_username = format!("test_exhausted_{}", &Uuid::new_v4().to_string()[..8]);
@@ -546,15 +493,10 @@ async fn test_prekey_claim_when_exhausted() {
         "Should return None when no prekeys available"
     );
 
-    // Cleanup
-    cleanup_test_user(&pool, owner.id).await;
-    cleanup_test_user(&pool, claimer.id).await;
 }
 
-#[tokio::test]
-#[ignore] // Requires PostgreSQL
-async fn test_prekey_duplicate_upload_ignored() {
-    let pool = create_test_pool().await;
+#[sqlx::test]
+async fn test_prekey_duplicate_upload_ignored(pool: PgPool) {
 
     // Create test user and device
     let username = format!("test_dup_prekey_{}", &Uuid::new_v4().to_string()[..8]);
@@ -621,14 +563,10 @@ async fn test_prekey_duplicate_upload_ignored() {
 
     assert_eq!(count.0, 1, "Should only have 1 prekey");
 
-    // Cleanup
-    cleanup_test_user(&pool, user.id).await;
 }
 
-#[tokio::test]
-#[ignore] // Requires PostgreSQL
-async fn test_key_backup_upload_and_retrieve() {
-    let pool = create_test_pool().await;
+#[sqlx::test]
+async fn test_key_backup_upload_and_retrieve(pool: PgPool) {
 
     // Create test user
     let username = format!("test_backup_{}", &Uuid::new_v4().to_string()[..8]);
@@ -676,14 +614,10 @@ async fn test_key_backup_upload_and_retrieve() {
     assert_eq!(retrieved_ciphertext, ciphertext.to_vec());
     assert_eq!(version, 1);
 
-    // Cleanup
-    cleanup_test_user(&pool, user.id).await;
 }
 
-#[tokio::test]
-#[ignore] // Requires PostgreSQL
-async fn test_key_backup_upsert() {
-    let pool = create_test_pool().await;
+#[sqlx::test]
+async fn test_key_backup_upsert(pool: PgPool) {
 
     // Create test user
     let username = format!("test_backup_upsert_{}", &Uuid::new_v4().to_string()[..8]);
@@ -748,14 +682,10 @@ async fn test_key_backup_upsert() {
 
     assert_eq!(backup.0, 2, "Backup should be version 2");
 
-    // Cleanup
-    cleanup_test_user(&pool, user.id).await;
 }
 
-#[tokio::test]
-#[ignore] // Requires PostgreSQL
-async fn test_backup_status_no_backup() {
-    let pool = create_test_pool().await;
+#[sqlx::test]
+async fn test_backup_status_no_backup(pool: PgPool) {
 
     // Create test user (no backup)
     let username = format!("test_no_backup_{}", &Uuid::new_v4().to_string()[..8]);
@@ -771,14 +701,10 @@ async fn test_backup_status_no_backup() {
 
     assert!(backup.is_none(), "Should have no backup");
 
-    // Cleanup
-    cleanup_test_user(&pool, user.id).await;
 }
 
-#[tokio::test]
-#[ignore] // Requires PostgreSQL
-async fn test_get_user_device_keys() {
-    let pool = create_test_pool().await;
+#[sqlx::test]
+async fn test_get_user_device_keys(pool: PgPool) {
 
     // Create test user with multiple devices
     let username = format!("test_multi_device_{}", &Uuid::new_v4().to_string()[..8]);
@@ -818,16 +744,12 @@ async fn test_get_user_device_keys() {
 
     assert_eq!(devices.len(), 3, "Should have 3 devices");
 
-    // Cleanup
-    cleanup_test_user(&pool, user.id).await;
 }
 
-#[tokio::test]
-#[ignore] // Requires PostgreSQL
-async fn test_concurrent_prekey_claims_unique() {
+#[sqlx::test]
+async fn test_concurrent_prekey_claims_unique(pool: PgPool) {
     use tokio::task::JoinSet;
 
-    let pool = create_test_pool().await;
 
     // Create owner
     let owner_username = format!("test_concurrent_{}", &Uuid::new_v4().to_string()[..8]);
@@ -926,10 +848,4 @@ async fn test_concurrent_prekey_claims_unique() {
             .expect("Query should succeed");
 
     assert_eq!(unclaimed_count.0, 0, "All prekeys should be claimed");
-
-    // Cleanup
-    cleanup_test_user(&pool, owner.id).await;
-    for claimer_id in &claimer_ids {
-        cleanup_test_user(&pool, *claimer_id).await;
-    }
 }

--- a/server/tests/integration/e2ee_keys.rs
+++ b/server/tests/integration/e2ee_keys.rs
@@ -215,7 +215,6 @@ fn generate_mock_prekeys(count: usize) -> Vec<(String, String)> {
 
 #[sqlx::test]
 async fn test_device_registration(pool: PgPool) {
-
     // Create test user
     let username = format!("test_device_{}", &Uuid::new_v4().to_string()[..8]);
     let user = create_test_user(&pool, &username).await;
@@ -246,12 +245,10 @@ async fn test_device_registration(pool: PgPool) {
             .expect("Query should succeed");
 
     assert!(device_exists.is_some(), "Device should exist");
-
 }
 
 #[sqlx::test]
 async fn test_device_upsert_on_same_identity_key(pool: PgPool) {
-
     // Create test user
     let username = format!("test_upsert_{}", &Uuid::new_v4().to_string()[..8]);
     let user = create_test_user(&pool, &username).await;
@@ -309,12 +306,10 @@ async fn test_device_upsert_on_same_identity_key(pool: PgPool) {
         device_count.0, 1,
         "Should only have one device after upsert"
     );
-
 }
 
 #[sqlx::test]
 async fn test_prekey_upload(pool: PgPool) {
-
     // Create test user and device
     let username = format!("test_prekey_{}", &Uuid::new_v4().to_string()[..8]);
     let user = create_test_user(&pool, &username).await;
@@ -365,12 +360,10 @@ async fn test_prekey_upload(pool: PgPool) {
         .expect("Query should succeed");
 
     assert_eq!(prekey_count.0, 10, "Should have 10 prekeys");
-
 }
 
 #[sqlx::test]
 async fn test_prekey_claim_single(pool: PgPool) {
-
     // Create owner and claimer users
     let owner_username = format!("test_owner_{}", &Uuid::new_v4().to_string()[..8]);
     let claimer_username = format!("test_claimer_{}", &Uuid::new_v4().to_string()[..8]);
@@ -441,12 +434,10 @@ async fn test_prekey_claim_single(pool: PgPool) {
             .expect("Query should succeed");
 
     assert_eq!(unclaimed_count.0, 4, "Should have 4 unclaimed prekeys left");
-
 }
 
 #[sqlx::test]
 async fn test_prekey_claim_when_exhausted(pool: PgPool) {
-
     // Create owner and claimer
     let owner_username = format!("test_exhausted_{}", &Uuid::new_v4().to_string()[..8]);
     let claimer_username = format!("test_claimer_ex_{}", &Uuid::new_v4().to_string()[..8]);
@@ -492,12 +483,10 @@ async fn test_prekey_claim_when_exhausted(pool: PgPool) {
         claimed.is_none(),
         "Should return None when no prekeys available"
     );
-
 }
 
 #[sqlx::test]
 async fn test_prekey_duplicate_upload_ignored(pool: PgPool) {
-
     // Create test user and device
     let username = format!("test_dup_prekey_{}", &Uuid::new_v4().to_string()[..8]);
     let user = create_test_user(&pool, &username).await;
@@ -562,12 +551,10 @@ async fn test_prekey_duplicate_upload_ignored(pool: PgPool) {
         .expect("Query should succeed");
 
     assert_eq!(count.0, 1, "Should only have 1 prekey");
-
 }
 
 #[sqlx::test]
 async fn test_key_backup_upload_and_retrieve(pool: PgPool) {
-
     // Create test user
     let username = format!("test_backup_{}", &Uuid::new_v4().to_string()[..8]);
     let user = create_test_user(&pool, &username).await;
@@ -613,12 +600,10 @@ async fn test_key_backup_upload_and_retrieve(pool: PgPool) {
     assert_eq!(retrieved_nonce, nonce.to_vec());
     assert_eq!(retrieved_ciphertext, ciphertext.to_vec());
     assert_eq!(version, 1);
-
 }
 
 #[sqlx::test]
 async fn test_key_backup_upsert(pool: PgPool) {
-
     // Create test user
     let username = format!("test_backup_upsert_{}", &Uuid::new_v4().to_string()[..8]);
     let user = create_test_user(&pool, &username).await;
@@ -681,12 +666,10 @@ async fn test_key_backup_upsert(pool: PgPool) {
         .expect("Query should succeed");
 
     assert_eq!(backup.0, 2, "Backup should be version 2");
-
 }
 
 #[sqlx::test]
 async fn test_backup_status_no_backup(pool: PgPool) {
-
     // Create test user (no backup)
     let username = format!("test_no_backup_{}", &Uuid::new_v4().to_string()[..8]);
     let user = create_test_user(&pool, &username).await;
@@ -700,12 +683,10 @@ async fn test_backup_status_no_backup(pool: PgPool) {
             .expect("Query should succeed");
 
     assert!(backup.is_none(), "Should have no backup");
-
 }
 
 #[sqlx::test]
 async fn test_get_user_device_keys(pool: PgPool) {
-
     // Create test user with multiple devices
     let username = format!("test_multi_device_{}", &Uuid::new_v4().to_string()[..8]);
     let user = create_test_user(&pool, &username).await;
@@ -743,13 +724,11 @@ async fn test_get_user_device_keys(pool: PgPool) {
     .expect("Query should succeed");
 
     assert_eq!(devices.len(), 3, "Should have 3 devices");
-
 }
 
 #[sqlx::test]
 async fn test_concurrent_prekey_claims_unique(pool: PgPool) {
     use tokio::task::JoinSet;
-
 
     // Create owner
     let owner_username = format!("test_concurrent_{}", &Uuid::new_v4().to_string()[..8]);

--- a/server/tests/integration/filters_http.rs
+++ b/server/tests/integration/filters_http.rs
@@ -6,6 +6,7 @@
 //! Run with: `cargo test --test integration filters_http -- --nocapture`
 
 use axum::body::Body;
+use sqlx::PgPool;
 use axum::http::Method;
 use uuid::Uuid;
 use vc_server::permissions::GuildPermissions;
@@ -147,14 +148,11 @@ async fn edit_message_raw(
 // Filter Config CRUD
 // ============================================================================
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_list_filter_configs_empty() {
-    let app = TestApp::new().await;
-    let (user_id, guild_id, _, token) = setup_guild_with_filters(&app).await;
+#[sqlx::test]
+async fn test_list_filter_configs_empty(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
+    let (_user_id, guild_id, _, token) = setup_guild_with_filters(&app).await;
 
-    let mut guard = app.cleanup_guard();
-    guard.add(move |pool| async move { super::helpers::delete_guild(&pool, guild_id).await });
-    guard.delete_user(user_id);
 
     let req = TestApp::request(Method::GET, &format!("/api/guilds/{guild_id}/filters"))
         .header("Authorization", format!("Bearer {token}"))
@@ -165,17 +163,13 @@ async fn test_list_filter_configs_empty() {
     assert_eq!(resp.status(), 200);
     let json = body_to_json(resp).await;
     assert!(json.as_array().unwrap().is_empty());
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_enable_and_list_filter_category() {
-    let app = TestApp::new().await;
-    let (user_id, guild_id, _, token) = setup_guild_with_filters(&app).await;
+#[sqlx::test]
+async fn test_enable_and_list_filter_category(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
+    let (_user_id, guild_id, _, token) = setup_guild_with_filters(&app).await;
 
-    let mut guard = app.cleanup_guard();
-    guard.add(move |pool| async move { super::helpers::delete_guild(&pool, guild_id).await });
-    guard.delete_user(user_id);
 
     enable_filter_category(&app, guild_id, &token, "spam", "block").await;
 
@@ -192,17 +186,13 @@ async fn test_enable_and_list_filter_category() {
     assert_eq!(configs[0]["category"], "spam");
     assert_eq!(configs[0]["enabled"], true);
     assert_eq!(configs[0]["action"], "block");
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_disable_filter_category() {
-    let app = TestApp::new().await;
-    let (user_id, guild_id, _, token) = setup_guild_with_filters(&app).await;
+#[sqlx::test]
+async fn test_disable_filter_category(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
+    let (_user_id, guild_id, _, token) = setup_guild_with_filters(&app).await;
 
-    let mut guard = app.cleanup_guard();
-    guard.add(move |pool| async move { super::helpers::delete_guild(&pool, guild_id).await });
-    guard.delete_user(user_id);
 
     // Enable then disable
     enable_filter_category(&app, guild_id, &token, "spam", "block").await;
@@ -220,51 +210,39 @@ async fn test_disable_filter_category() {
     assert_eq!(resp.status(), 200);
     let json = body_to_json(resp).await;
     assert_eq!(json[0]["enabled"], false);
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // Custom Patterns
 // ============================================================================
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_create_custom_keyword_pattern() {
-    let app = TestApp::new().await;
-    let (user_id, guild_id, _, token) = setup_guild_with_filters(&app).await;
+#[sqlx::test]
+async fn test_create_custom_keyword_pattern(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
+    let (_user_id, guild_id, _, token) = setup_guild_with_filters(&app).await;
 
-    let mut guard = app.cleanup_guard();
-    guard.add(move |pool| async move { super::helpers::delete_guild(&pool, guild_id).await });
-    guard.delete_user(user_id);
 
     let pattern = create_pattern(&app, guild_id, &token, "badword", false).await;
     assert_eq!(pattern["pattern"], "badword");
     assert_eq!(pattern["is_regex"], false);
     assert_eq!(pattern["enabled"], true);
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_create_custom_regex_pattern() {
-    let app = TestApp::new().await;
-    let (user_id, guild_id, _, token) = setup_guild_with_filters(&app).await;
+#[sqlx::test]
+async fn test_create_custom_regex_pattern(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
+    let (_user_id, guild_id, _, token) = setup_guild_with_filters(&app).await;
 
-    let mut guard = app.cleanup_guard();
-    guard.add(move |pool| async move { super::helpers::delete_guild(&pool, guild_id).await });
-    guard.delete_user(user_id);
 
     let pattern = create_pattern(&app, guild_id, &token, r"(?i)bad\s+word", true).await;
     assert_eq!(pattern["is_regex"], true);
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_invalid_regex_rejected() {
-    let app = TestApp::new().await;
-    let (user_id, guild_id, _, token) = setup_guild_with_filters(&app).await;
+#[sqlx::test]
+async fn test_invalid_regex_rejected(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
+    let (_user_id, guild_id, _, token) = setup_guild_with_filters(&app).await;
 
-    let mut guard = app.cleanup_guard();
-    guard.add(move |pool| async move { super::helpers::delete_guild(&pool, guild_id).await });
-    guard.delete_user(user_id);
 
     let body = serde_json::json!({
         "pattern": "[invalid",
@@ -281,17 +259,13 @@ async fn test_invalid_regex_rejected() {
 
     let resp = app.oneshot(req).await;
     assert_eq!(resp.status(), 400, "Invalid regex should be rejected");
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_delete_custom_pattern() {
-    let app = TestApp::new().await;
-    let (user_id, guild_id, _, token) = setup_guild_with_filters(&app).await;
+#[sqlx::test]
+async fn test_delete_custom_pattern(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
+    let (_user_id, guild_id, _, token) = setup_guild_with_filters(&app).await;
 
-    let mut guard = app.cleanup_guard();
-    guard.add(move |pool| async move { super::helpers::delete_guild(&pool, guild_id).await });
-    guard.delete_user(user_id);
 
     let pattern = create_pattern(&app, guild_id, &token, "deleteme", false).await;
     let pattern_id = pattern["id"].as_str().unwrap();
@@ -306,21 +280,17 @@ async fn test_delete_custom_pattern() {
 
     let resp = app.oneshot(req).await;
     assert_eq!(resp.status(), 204, "Expected 204 No Content for delete");
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // Message Blocking
 // ============================================================================
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_message_blocked_by_custom_keyword() {
-    let app = TestApp::new().await;
-    let (user_id, guild_id, channel_id, token) = setup_guild_with_filters(&app).await;
+#[sqlx::test]
+async fn test_message_blocked_by_custom_keyword(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
+    let (_user_id, guild_id, channel_id, token) = setup_guild_with_filters(&app).await;
 
-    let mut guard = app.cleanup_guard();
-    guard.add(move |pool| async move { super::helpers::delete_guild(&pool, guild_id).await });
-    guard.delete_user(user_id);
 
     // Add custom keyword
     create_pattern(&app, guild_id, &token, "forbidden", false).await;
@@ -330,17 +300,13 @@ async fn test_message_blocked_by_custom_keyword() {
         send_message_raw(&app, channel_id, &token, "this is forbidden content").await;
     assert_eq!(status, 403, "Blocked message should return 403");
     assert_eq!(json["error"], "CONTENT_FILTERED");
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_clean_message_allowed() {
-    let app = TestApp::new().await;
-    let (user_id, guild_id, channel_id, token) = setup_guild_with_filters(&app).await;
+#[sqlx::test]
+async fn test_clean_message_allowed(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
+    let (_user_id, guild_id, channel_id, token) = setup_guild_with_filters(&app).await;
 
-    let mut guard = app.cleanup_guard();
-    guard.add(move |pool| async move { super::helpers::delete_guild(&pool, guild_id).await });
-    guard.delete_user(user_id);
 
     // Add custom keyword
     create_pattern(&app, guild_id, &token, "forbidden", false).await;
@@ -348,17 +314,13 @@ async fn test_clean_message_allowed() {
     // Send clean message
     let (status, _) = send_message_raw(&app, channel_id, &token, "this is perfectly fine").await;
     assert_eq!(status, 201, "Clean message should be allowed");
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_edit_blocked_by_filter() {
-    let app = TestApp::new().await;
-    let (user_id, guild_id, channel_id, token) = setup_guild_with_filters(&app).await;
+#[sqlx::test]
+async fn test_edit_blocked_by_filter(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
+    let (_user_id, guild_id, channel_id, token) = setup_guild_with_filters(&app).await;
 
-    let mut guard = app.cleanup_guard();
-    guard.add(move |pool| async move { super::helpers::delete_guild(&pool, guild_id).await });
-    guard.delete_user(user_id);
 
     // Create clean message first
     let (status, msg) = send_message_raw(&app, channel_id, &token, "clean message").await;
@@ -375,21 +337,17 @@ async fn test_edit_blocked_by_filter() {
         "Edited message with blocked word should return 403"
     );
     assert_eq!(json["error"], "CONTENT_FILTERED");
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // Encrypted & DM Skip
 // ============================================================================
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_encrypted_message_not_filtered() {
-    let app = TestApp::new().await;
-    let (user_id, guild_id, channel_id, token) = setup_guild_with_filters(&app).await;
+#[sqlx::test]
+async fn test_encrypted_message_not_filtered(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
+    let (_user_id, guild_id, channel_id, token) = setup_guild_with_filters(&app).await;
 
-    let mut guard = app.cleanup_guard();
-    guard.add(move |pool| async move { super::helpers::delete_guild(&pool, guild_id).await });
-    guard.delete_user(user_id);
 
     // Add filter
     create_pattern(&app, guild_id, &token, "forbidden", false).await;
@@ -400,41 +358,30 @@ async fn test_encrypted_message_not_filtered() {
         status, 201,
         "Encrypted message should bypass content filter"
     );
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_dm_message_not_filtered() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_dm_message_not_filtered(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_a, _) = create_test_user(&app.pool).await;
     let (user_b, _) = create_test_user(&app.pool).await;
     let token_a = generate_access_token(&app.config, user_a);
     let dm_channel = super::helpers::create_dm_channel(&app.pool, user_a, user_b).await;
 
-    let mut guard = app.cleanup_guard();
-    guard
-        .add(move |pool| async move { super::helpers::delete_dm_channel(&pool, dm_channel).await });
-    guard.delete_user(user_a);
-    guard.delete_user(user_b);
-
     // DMs have no guild_id, so filters don't apply
     let (status, _) = send_message_raw(&app, dm_channel, &token_a, "anything goes in DMs").await;
     assert_eq!(status, 201, "DM messages should not be filtered");
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // Log Action (non-block)
 // ============================================================================
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_log_action_allows_message_but_creates_log() {
-    let app = TestApp::new().await;
-    let (user_id, guild_id, channel_id, token) = setup_guild_with_filters(&app).await;
+#[sqlx::test]
+async fn test_log_action_allows_message_but_creates_log(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
+    let (_user_id, guild_id, channel_id, token) = setup_guild_with_filters(&app).await;
 
-    let mut guard = app.cleanup_guard();
-    guard.add(move |pool| async move { super::helpers::delete_guild(&pool, guild_id).await });
-    guard.delete_user(user_id);
 
     // Enable spam category with "log" action
     enable_filter_category(&app, guild_id, &token, "spam", "log").await;
@@ -462,21 +409,17 @@ async fn test_log_action_allows_message_but_creates_log() {
         json["total"].as_i64().unwrap() > 0,
         "Moderation log should have entries from log action"
     );
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // Moderation Log
 // ============================================================================
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_moderation_log_pagination() {
-    let app = TestApp::new().await;
-    let (user_id, guild_id, channel_id, token) = setup_guild_with_filters(&app).await;
+#[sqlx::test]
+async fn test_moderation_log_pagination(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
+    let (_user_id, guild_id, channel_id, token) = setup_guild_with_filters(&app).await;
 
-    let mut guard = app.cleanup_guard();
-    guard.add(move |pool| async move { super::helpers::delete_guild(&pool, guild_id).await });
-    guard.delete_user(user_id);
 
     // Add filter and trigger some blocks
     create_pattern(&app, guild_id, &token, "forbidden", false).await;
@@ -497,16 +440,15 @@ async fn test_moderation_log_pagination() {
     let json = body_to_json(resp).await;
     assert_eq!(json["items"].as_array().unwrap().len(), 2);
     assert!(json["total"].as_i64().unwrap() >= 3);
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // Permission Checks
 // ============================================================================
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_non_admin_cannot_modify_filters() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_non_admin_cannot_modify_filters(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (owner_id, _) = create_test_user(&app.pool).await;
     let (member_id, _) = create_test_user(&app.pool).await;
     let member_token = generate_access_token(&app.config, member_id);
@@ -514,11 +456,6 @@ async fn test_non_admin_cannot_modify_filters() {
     let perms = GuildPermissions::VIEW_CHANNEL | GuildPermissions::SEND_MESSAGES;
     let guild_id = super::helpers::create_guild_with_default_role(&app.pool, owner_id, perms).await;
     super::helpers::add_guild_member(&app.pool, guild_id, member_id).await;
-
-    let mut guard = app.cleanup_guard();
-    guard.add(move |pool| async move { super::helpers::delete_guild(&pool, guild_id).await });
-    guard.delete_user(owner_id);
-    guard.delete_user(member_id);
 
     // Try to list configs as non-admin
     let req = TestApp::request(Method::GET, &format!("/api/guilds/{guild_id}/filters"))
@@ -528,21 +465,17 @@ async fn test_non_admin_cannot_modify_filters() {
 
     let resp = app.oneshot(req).await;
     assert_eq!(resp.status(), 403, "Non-admin should get 403");
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // Test Endpoint
 // ============================================================================
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_filter_dry_run() {
-    let app = TestApp::new().await;
-    let (user_id, guild_id, _, token) = setup_guild_with_filters(&app).await;
+#[sqlx::test]
+async fn test_filter_dry_run(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
+    let (_user_id, guild_id, _, token) = setup_guild_with_filters(&app).await;
 
-    let mut guard = app.cleanup_guard();
-    guard.add(move |pool| async move { super::helpers::delete_guild(&pool, guild_id).await });
-    guard.delete_user(user_id);
 
     // Add a keyword
     create_pattern(&app, guild_id, &token, "testblock", false).await;
@@ -580,21 +513,17 @@ async fn test_filter_dry_run() {
     let json = body_to_json(resp).await;
     assert_eq!(json["blocked"], false);
     assert!(json["matches"].as_array().unwrap().is_empty());
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // Cache Invalidation
 // ============================================================================
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_cache_invalidation_on_config_change() {
-    let app = TestApp::new().await;
-    let (user_id, guild_id, channel_id, token) = setup_guild_with_filters(&app).await;
+#[sqlx::test]
+async fn test_cache_invalidation_on_config_change(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
+    let (_user_id, guild_id, channel_id, token) = setup_guild_with_filters(&app).await;
 
-    let mut guard = app.cleanup_guard();
-    guard.add(move |pool| async move { super::helpers::delete_guild(&pool, guild_id).await });
-    guard.delete_user(user_id);
 
     // Message should pass with no filters
     let (status, _) = send_message_raw(&app, channel_id, &token, "forbidden content").await;
@@ -610,5 +539,4 @@ async fn test_cache_invalidation_on_config_change() {
         "After adding filter, message should be blocked"
     );
     assert_eq!(json["error"], "CONTENT_FILTERED");
-    guard.cleanup().await;
 }

--- a/server/tests/integration/filters_http.rs
+++ b/server/tests/integration/filters_http.rs
@@ -6,8 +6,8 @@
 //! Run with: `cargo test --test integration filters_http -- --nocapture`
 
 use axum::body::Body;
-use sqlx::PgPool;
 use axum::http::Method;
+use sqlx::PgPool;
 use uuid::Uuid;
 use vc_server::permissions::GuildPermissions;
 
@@ -153,7 +153,6 @@ async fn test_list_filter_configs_empty(pool: PgPool) {
     let app = TestApp::with_pool(pool.clone()).await;
     let (_user_id, guild_id, _, token) = setup_guild_with_filters(&app).await;
 
-
     let req = TestApp::request(Method::GET, &format!("/api/guilds/{guild_id}/filters"))
         .header("Authorization", format!("Bearer {token}"))
         .body(Body::empty())
@@ -169,7 +168,6 @@ async fn test_list_filter_configs_empty(pool: PgPool) {
 async fn test_enable_and_list_filter_category(pool: PgPool) {
     let app = TestApp::with_pool(pool.clone()).await;
     let (_user_id, guild_id, _, token) = setup_guild_with_filters(&app).await;
-
 
     enable_filter_category(&app, guild_id, &token, "spam", "block").await;
 
@@ -192,7 +190,6 @@ async fn test_enable_and_list_filter_category(pool: PgPool) {
 async fn test_disable_filter_category(pool: PgPool) {
     let app = TestApp::with_pool(pool.clone()).await;
     let (_user_id, guild_id, _, token) = setup_guild_with_filters(&app).await;
-
 
     // Enable then disable
     enable_filter_category(&app, guild_id, &token, "spam", "block").await;
@@ -221,7 +218,6 @@ async fn test_create_custom_keyword_pattern(pool: PgPool) {
     let app = TestApp::with_pool(pool.clone()).await;
     let (_user_id, guild_id, _, token) = setup_guild_with_filters(&app).await;
 
-
     let pattern = create_pattern(&app, guild_id, &token, "badword", false).await;
     assert_eq!(pattern["pattern"], "badword");
     assert_eq!(pattern["is_regex"], false);
@@ -233,7 +229,6 @@ async fn test_create_custom_regex_pattern(pool: PgPool) {
     let app = TestApp::with_pool(pool.clone()).await;
     let (_user_id, guild_id, _, token) = setup_guild_with_filters(&app).await;
 
-
     let pattern = create_pattern(&app, guild_id, &token, r"(?i)bad\s+word", true).await;
     assert_eq!(pattern["is_regex"], true);
 }
@@ -242,7 +237,6 @@ async fn test_create_custom_regex_pattern(pool: PgPool) {
 async fn test_invalid_regex_rejected(pool: PgPool) {
     let app = TestApp::with_pool(pool.clone()).await;
     let (_user_id, guild_id, _, token) = setup_guild_with_filters(&app).await;
-
 
     let body = serde_json::json!({
         "pattern": "[invalid",
@@ -265,7 +259,6 @@ async fn test_invalid_regex_rejected(pool: PgPool) {
 async fn test_delete_custom_pattern(pool: PgPool) {
     let app = TestApp::with_pool(pool.clone()).await;
     let (_user_id, guild_id, _, token) = setup_guild_with_filters(&app).await;
-
 
     let pattern = create_pattern(&app, guild_id, &token, "deleteme", false).await;
     let pattern_id = pattern["id"].as_str().unwrap();
@@ -291,7 +284,6 @@ async fn test_message_blocked_by_custom_keyword(pool: PgPool) {
     let app = TestApp::with_pool(pool.clone()).await;
     let (_user_id, guild_id, channel_id, token) = setup_guild_with_filters(&app).await;
 
-
     // Add custom keyword
     create_pattern(&app, guild_id, &token, "forbidden", false).await;
 
@@ -307,7 +299,6 @@ async fn test_clean_message_allowed(pool: PgPool) {
     let app = TestApp::with_pool(pool.clone()).await;
     let (_user_id, guild_id, channel_id, token) = setup_guild_with_filters(&app).await;
 
-
     // Add custom keyword
     create_pattern(&app, guild_id, &token, "forbidden", false).await;
 
@@ -320,7 +311,6 @@ async fn test_clean_message_allowed(pool: PgPool) {
 async fn test_edit_blocked_by_filter(pool: PgPool) {
     let app = TestApp::with_pool(pool.clone()).await;
     let (_user_id, guild_id, channel_id, token) = setup_guild_with_filters(&app).await;
-
 
     // Create clean message first
     let (status, msg) = send_message_raw(&app, channel_id, &token, "clean message").await;
@@ -347,7 +337,6 @@ async fn test_edit_blocked_by_filter(pool: PgPool) {
 async fn test_encrypted_message_not_filtered(pool: PgPool) {
     let app = TestApp::with_pool(pool.clone()).await;
     let (_user_id, guild_id, channel_id, token) = setup_guild_with_filters(&app).await;
-
 
     // Add filter
     create_pattern(&app, guild_id, &token, "forbidden", false).await;
@@ -381,7 +370,6 @@ async fn test_dm_message_not_filtered(pool: PgPool) {
 async fn test_log_action_allows_message_but_creates_log(pool: PgPool) {
     let app = TestApp::with_pool(pool.clone()).await;
     let (_user_id, guild_id, channel_id, token) = setup_guild_with_filters(&app).await;
-
 
     // Enable spam category with "log" action
     enable_filter_category(&app, guild_id, &token, "spam", "log").await;
@@ -419,7 +407,6 @@ async fn test_log_action_allows_message_but_creates_log(pool: PgPool) {
 async fn test_moderation_log_pagination(pool: PgPool) {
     let app = TestApp::with_pool(pool.clone()).await;
     let (_user_id, guild_id, channel_id, token) = setup_guild_with_filters(&app).await;
-
 
     // Add filter and trigger some blocks
     create_pattern(&app, guild_id, &token, "forbidden", false).await;
@@ -476,7 +463,6 @@ async fn test_filter_dry_run(pool: PgPool) {
     let app = TestApp::with_pool(pool.clone()).await;
     let (_user_id, guild_id, _, token) = setup_guild_with_filters(&app).await;
 
-
     // Add a keyword
     create_pattern(&app, guild_id, &token, "testblock", false).await;
 
@@ -523,7 +509,6 @@ async fn test_filter_dry_run(pool: PgPool) {
 async fn test_cache_invalidation_on_config_change(pool: PgPool) {
     let app = TestApp::with_pool(pool.clone()).await;
     let (_user_id, guild_id, channel_id, token) = setup_guild_with_filters(&app).await;
-
 
     // Message should pass with no filters
     let (status, _) = send_message_raw(&app, channel_id, &token, "forbidden content").await;

--- a/server/tests/integration/global_search_http.rs
+++ b/server/tests/integration/global_search_http.rs
@@ -7,10 +7,11 @@
 
 use axum::body::Body;
 use axum::http::Method;
+use sqlx::PgPool;
 
 use super::helpers::{
     add_guild_member, body_to_json, create_channel, create_dm_channel, create_guild,
-    create_test_user, delete_dm_channel, delete_guild, delete_user, generate_access_token,
+    create_test_user, generate_access_token,
     insert_attachment, insert_deleted_message, insert_encrypted_message, insert_message,
     insert_message_at, TestApp,
 };
@@ -31,9 +32,9 @@ fn global_search_request(query_string: &str, token: &str) -> axum::http::Request
 // Global Search — Auth
 // ============================================================================
 
-#[tokio::test]
-async fn test_global_search_requires_auth() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_global_search_requires_auth(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
 
     let req = TestApp::request(Method::GET, "/api/search?q=test")
         .body(Body::empty())
@@ -47,9 +48,9 @@ async fn test_global_search_requires_auth() {
 // Global Search — Basic
 // ============================================================================
 
-#[tokio::test]
-async fn test_global_search_basic() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_global_search_basic(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -105,17 +106,15 @@ async fn test_global_search_basic() {
     let rank = result["rank"].as_f64().unwrap();
     assert!(rank > 0.0, "rank should be positive, got: {rank}");
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // Global Search — Multi Guild
 // ============================================================================
 
-#[tokio::test]
-async fn test_global_search_multi_guild() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_global_search_multi_guild(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -148,18 +147,15 @@ async fn test_global_search_multi_guild() {
         "Should include result from guild B"
     );
 
-    delete_guild(&app.pool, guild_a).await;
-    delete_guild(&app.pool, guild_b).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // Global Search — Includes DMs
 // ============================================================================
 
-#[tokio::test]
-async fn test_global_search_includes_dms() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_global_search_includes_dms(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_a, _) = create_test_user(&app.pool).await;
     let (user_b, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_a);
@@ -189,19 +185,15 @@ async fn test_global_search_includes_dms() {
     );
     assert!(source_types.contains(&"dm"), "Should have a dm source");
 
-    delete_dm_channel(&app.pool, dm_id).await;
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_a).await;
-    delete_user(&app.pool, user_b).await;
 }
 
 // ============================================================================
 // Global Search — Source Guild
 // ============================================================================
 
-#[tokio::test]
-async fn test_global_search_source_guild() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_global_search_source_guild(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -230,17 +222,15 @@ async fn test_global_search_source_guild() {
         "guild_name should be present for guild source"
     );
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // Global Search — Source DM
 // ============================================================================
 
-#[tokio::test]
-async fn test_global_search_source_dm() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_global_search_source_dm(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_a, _) = create_test_user(&app.pool).await;
     let (user_b, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_a);
@@ -266,18 +256,15 @@ async fn test_global_search_source_dm() {
         "guild_name should be null for DM source"
     );
 
-    delete_dm_channel(&app.pool, dm_id).await;
-    delete_user(&app.pool, user_a).await;
-    delete_user(&app.pool, user_b).await;
 }
 
 // ============================================================================
 // Global Search — Excludes Inaccessible
 // ============================================================================
 
-#[tokio::test]
-async fn test_global_search_excludes_inaccessible() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_global_search_excludes_inaccessible(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_a, _) = create_test_user(&app.pool).await;
     let (user_b, _) = create_test_user(&app.pool).await;
 
@@ -304,19 +291,15 @@ async fn test_global_search_excludes_inaccessible() {
         guild_b.to_string()
     );
 
-    delete_guild(&app.pool, guild_a).await;
-    delete_guild(&app.pool, guild_b).await;
-    delete_user(&app.pool, user_a).await;
-    delete_user(&app.pool, user_b).await;
 }
 
 // ============================================================================
 // Global Search — Excludes Deleted Messages
 // ============================================================================
 
-#[tokio::test]
-async fn test_global_search_excludes_deleted() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_global_search_excludes_deleted(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -335,17 +318,15 @@ async fn test_global_search_excludes_deleted() {
         "Soft-deleted message should be excluded from global search"
     );
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // Global Search — Excludes Encrypted Messages
 // ============================================================================
 
-#[tokio::test]
-async fn test_global_search_excludes_encrypted() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_global_search_excludes_encrypted(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -370,17 +351,15 @@ async fn test_global_search_excludes_encrypted() {
         "Encrypted message should be excluded from global search"
     );
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // Global Search — Date Filter
 // ============================================================================
 
-#[tokio::test]
-async fn test_global_search_date_filter() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_global_search_date_filter(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -406,17 +385,15 @@ async fn test_global_search_date_filter() {
         "Only the recent message should match with date_from filter"
     );
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // Global Search — Author Filter
 // ============================================================================
 
-#[tokio::test]
-async fn test_global_search_author_filter() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_global_search_author_filter(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_a, _) = create_test_user(&app.pool).await;
     let (user_b, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_a).await;
@@ -436,18 +413,15 @@ async fn test_global_search_author_filter() {
     assert_eq!(json["total"], 1);
     assert_eq!(json["results"][0]["author"]["id"], user_b.to_string());
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_a).await;
-    delete_user(&app.pool, user_b).await;
 }
 
 // ============================================================================
 // Global Search — Has Link
 // ============================================================================
 
-#[tokio::test]
-async fn test_global_search_has_link() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_global_search_has_link(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -472,17 +446,15 @@ async fn test_global_search_has_link() {
         "Only the message with a link should match"
     );
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // Global Search — Has File
 // ============================================================================
 
-#[tokio::test]
-async fn test_global_search_has_file() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_global_search_has_file(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -509,17 +481,15 @@ async fn test_global_search_has_file() {
         "Only the message with attachment should match"
     );
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // Global Search — Sort by Relevance
 // ============================================================================
 
-#[tokio::test]
-async fn test_global_search_sort_relevance() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_global_search_sort_relevance(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -549,17 +519,15 @@ async fn test_global_search_sort_relevance() {
         "Results should be sorted by rank descending: {rank_0} >= {rank_1}"
     );
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // Global Search — Sort by Date
 // ============================================================================
 
-#[tokio::test]
-async fn test_global_search_sort_date() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_global_search_sort_date(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -590,17 +558,15 @@ async fn test_global_search_sort_date() {
         "sort=date should return newest first: {date_0} > {date_1}"
     );
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // Global Search — Validation (data-driven)
 // ============================================================================
 
-#[tokio::test]
-async fn test_global_search_validation() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_global_search_validation(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -621,16 +587,15 @@ async fn test_global_search_validation() {
         assert_eq!(resp.status(), 400, "{label} should return 400");
     }
 
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // Global Search — Pagination (with offset verification)
 // ============================================================================
 
-#[tokio::test]
-async fn test_global_search_pagination() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_global_search_pagination(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -701,17 +666,15 @@ async fn test_global_search_pagination() {
         "Should return empty results when offset exceeds total"
     );
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // Global Search — Limit Clamping
 // ============================================================================
 
-#[tokio::test]
-async fn test_global_search_limit_clamping() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_global_search_limit_clamping(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -749,17 +712,15 @@ async fn test_global_search_limit_clamping() {
         "Clamped limit=1 should return 1 result"
     );
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // Global Search — Channel ID Filter (Happy Path)
 // ============================================================================
 
-#[tokio::test]
-async fn test_global_search_channel_id_filter() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_global_search_channel_id_filter(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let ch_a = create_channel(&app.pool, guild_id, "channel-a").await;
@@ -796,17 +757,15 @@ async fn test_global_search_channel_id_filter() {
         "Result should be from the filtered channel"
     );
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // Global Search — Channel ID Filter (Forbidden)
 // ============================================================================
 
-#[tokio::test]
-async fn test_global_search_channel_id_forbidden() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_global_search_channel_id_forbidden(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_a, _) = create_test_user(&app.pool).await;
     let (user_b, _) = create_test_user(&app.pool).await;
 
@@ -825,7 +784,4 @@ async fn test_global_search_channel_id_forbidden() {
         "Should return 403 when filtering by a channel the user cannot access"
     );
 
-    delete_guild(&app.pool, guild_a).await;
-    delete_user(&app.pool, user_a).await;
-    delete_user(&app.pool, user_b).await;
 }

--- a/server/tests/integration/global_search_http.rs
+++ b/server/tests/integration/global_search_http.rs
@@ -11,9 +11,8 @@ use sqlx::PgPool;
 
 use super::helpers::{
     add_guild_member, body_to_json, create_channel, create_dm_channel, create_guild,
-    create_test_user, generate_access_token,
-    insert_attachment, insert_deleted_message, insert_encrypted_message, insert_message,
-    insert_message_at, TestApp,
+    create_test_user, generate_access_token, insert_attachment, insert_deleted_message,
+    insert_encrypted_message, insert_message, insert_message_at, TestApp,
 };
 
 // ============================================================================
@@ -105,7 +104,6 @@ async fn test_global_search_basic(pool: PgPool) {
     // Verify rank is positive
     let rank = result["rank"].as_f64().unwrap();
     assert!(rank > 0.0, "rank should be positive, got: {rank}");
-
 }
 
 // ============================================================================
@@ -146,7 +144,6 @@ async fn test_global_search_multi_guild(pool: PgPool) {
         guild_ids.contains(&guild_b.to_string().as_str()),
         "Should include result from guild B"
     );
-
 }
 
 // ============================================================================
@@ -184,7 +181,6 @@ async fn test_global_search_includes_dms(pool: PgPool) {
         "Should have a guild source"
     );
     assert!(source_types.contains(&"dm"), "Should have a dm source");
-
 }
 
 // ============================================================================
@@ -221,7 +217,6 @@ async fn test_global_search_source_guild(pool: PgPool) {
         source["guild_name"].is_string(),
         "guild_name should be present for guild source"
     );
-
 }
 
 // ============================================================================
@@ -255,7 +250,6 @@ async fn test_global_search_source_dm(pool: PgPool) {
         source["guild_name"].is_null(),
         "guild_name should be null for DM source"
     );
-
 }
 
 // ============================================================================
@@ -290,7 +284,6 @@ async fn test_global_search_excludes_inaccessible(pool: PgPool) {
         json["results"][0]["source"]["guild_id"],
         guild_b.to_string()
     );
-
 }
 
 // ============================================================================
@@ -317,7 +310,6 @@ async fn test_global_search_excludes_deleted(pool: PgPool) {
         json["total"], 1,
         "Soft-deleted message should be excluded from global search"
     );
-
 }
 
 // ============================================================================
@@ -350,7 +342,6 @@ async fn test_global_search_excludes_encrypted(pool: PgPool) {
         json["total"], 1,
         "Encrypted message should be excluded from global search"
     );
-
 }
 
 // ============================================================================
@@ -384,7 +375,6 @@ async fn test_global_search_date_filter(pool: PgPool) {
         json["total"], 1,
         "Only the recent message should match with date_from filter"
     );
-
 }
 
 // ============================================================================
@@ -412,7 +402,6 @@ async fn test_global_search_author_filter(pool: PgPool) {
     let json = body_to_json(resp).await;
     assert_eq!(json["total"], 1);
     assert_eq!(json["results"][0]["author"]["id"], user_b.to_string());
-
 }
 
 // ============================================================================
@@ -445,7 +434,6 @@ async fn test_global_search_has_link(pool: PgPool) {
         json["total"], 1,
         "Only the message with a link should match"
     );
-
 }
 
 // ============================================================================
@@ -480,7 +468,6 @@ async fn test_global_search_has_file(pool: PgPool) {
         json["total"], 1,
         "Only the message with attachment should match"
     );
-
 }
 
 // ============================================================================
@@ -518,7 +505,6 @@ async fn test_global_search_sort_relevance(pool: PgPool) {
         rank_0 >= rank_1,
         "Results should be sorted by rank descending: {rank_0} >= {rank_1}"
     );
-
 }
 
 // ============================================================================
@@ -557,7 +543,6 @@ async fn test_global_search_sort_date(pool: PgPool) {
         date_0 > date_1,
         "sort=date should return newest first: {date_0} > {date_1}"
     );
-
 }
 
 // ============================================================================
@@ -586,7 +571,6 @@ async fn test_global_search_validation(pool: PgPool) {
         let resp = app.oneshot(req).await;
         assert_eq!(resp.status(), 400, "{label} should return 400");
     }
-
 }
 
 // ============================================================================
@@ -665,7 +649,6 @@ async fn test_global_search_pagination(pool: PgPool) {
         0,
         "Should return empty results when offset exceeds total"
     );
-
 }
 
 // ============================================================================
@@ -711,7 +694,6 @@ async fn test_global_search_limit_clamping(pool: PgPool) {
         1,
         "Clamped limit=1 should return 1 result"
     );
-
 }
 
 // ============================================================================
@@ -756,7 +738,6 @@ async fn test_global_search_channel_id_filter(pool: PgPool) {
         ch_a.to_string(),
         "Result should be from the filtered channel"
     );
-
 }
 
 // ============================================================================
@@ -783,5 +764,4 @@ async fn test_global_search_channel_id_forbidden(pool: PgPool) {
         403,
         "Should return 403 when filtering by a channel the user cannot access"
     );
-
 }

--- a/server/tests/integration/guild_invite.rs
+++ b/server/tests/integration/guild_invite.rs
@@ -10,6 +10,7 @@
 //! Run ignored (integration) tests: `cargo test --test integration guild_invite -- --ignored`
 
 use chrono::{Duration, Utc};
+use sqlx::PgPool;
 use uuid::Uuid;
 
 // ============================================================================
@@ -266,22 +267,10 @@ fn test_max_active_invites_constant() {
 // Integration Tests (require database - marked as #[ignore])
 // ============================================================================
 
-/// Helper to create a test database pool.
-#[allow(dead_code)]
-async fn create_test_pool() -> sqlx::PgPool {
-    let database_url =
-        std::env::var("DATABASE_URL").unwrap_or_else(|_| "postgres://localhost/vc_test".into());
-
-    sqlx::PgPool::connect(&database_url)
-        .await
-        .expect("Failed to connect to test database")
-}
-
-#[tokio::test]
+#[sqlx::test]
 #[ignore] // Requires PostgreSQL
-async fn test_invite_rejected_when_expired() {
+async fn test_invite_rejected_when_expired(_pool: PgPool) {
     // This test verifies the database query filters out expired invites
-    let _pool = create_test_pool().await;
 
     // The SQL query in join_via_invite includes:
     // WHERE code = $1 AND (expires_at IS NULL OR expires_at > NOW())
@@ -294,11 +283,10 @@ async fn test_invite_rejected_when_expired() {
     // 4. Verify it returns "Invalid or expired invite code"
 }
 
-#[tokio::test]
+#[sqlx::test]
 #[ignore] // Requires PostgreSQL
-async fn test_invite_rate_limit_enforcement() {
+async fn test_invite_rate_limit_enforcement(_pool: PgPool) {
     // This test verifies max 10 active invites per guild
-    let _pool = create_test_pool().await;
 
     // The implementation checks:
     // if active_count.0 >= 10 {
@@ -312,11 +300,10 @@ async fn test_invite_rate_limit_enforcement() {
     // 4. Verify it returns validation error
 }
 
-#[tokio::test]
+#[sqlx::test]
 #[ignore] // Requires PostgreSQL
-async fn test_already_member_returns_guild_info() {
+async fn test_already_member_returns_guild_info(_pool: PgPool) {
     // This test verifies existing members get guild info without re-joining
-    let _pool = create_test_pool().await;
 
     // The implementation checks:
     // let is_member = db::is_guild_member(&state.db, invite.guild_id, auth.id).await?;
@@ -330,11 +317,10 @@ async fn test_already_member_returns_guild_info() {
     // 5. Verify use_count was NOT incremented
 }
 
-#[tokio::test]
+#[sqlx::test]
 #[ignore] // Requires PostgreSQL
-async fn test_invite_use_count_increments() {
+async fn test_invite_use_count_increments(_pool: PgPool) {
     // This test verifies use_count increments when invite is used
-    let _pool = create_test_pool().await;
 
     // Would need to:
     // 1. Create test guild
@@ -345,11 +331,10 @@ async fn test_invite_use_count_increments() {
     // 6. Verify use_count = 2
 }
 
-#[tokio::test]
+#[sqlx::test]
 #[ignore] // Requires PostgreSQL
-async fn test_invite_code_collision_handling() {
+async fn test_invite_code_collision_handling(_pool: PgPool) {
     // This test verifies code regeneration on collision
-    let _pool = create_test_pool().await;
 
     // The implementation retries up to 5 times:
     // while attempts < 5 {
@@ -360,11 +345,10 @@ async fn test_invite_code_collision_handling() {
     // }
 }
 
-#[tokio::test]
+#[sqlx::test]
 #[ignore] // Requires PostgreSQL
-async fn test_delete_invite_removes_from_db() {
+async fn test_delete_invite_removes_from_db(_pool: PgPool) {
     // This test verifies invite deletion
-    let _pool = create_test_pool().await;
 
     // Would need to:
     // 1. Create test guild
@@ -374,30 +358,27 @@ async fn test_delete_invite_removes_from_db() {
     // 5. Verify use returns "Invalid or expired invite code"
 }
 
-#[tokio::test]
+#[sqlx::test]
 #[ignore] // Requires PostgreSQL
-async fn test_only_owner_can_create_invite() {
+async fn test_only_owner_can_create_invite(_pool: PgPool) {
     // This test verifies ownership check for invite creation
-    let _pool = create_test_pool().await;
 
     // The implementation checks:
     // if guild.0 != auth.id { return Err(GuildError::Forbidden); }
 }
 
-#[tokio::test]
+#[sqlx::test]
 #[ignore] // Requires PostgreSQL
-async fn test_only_owner_can_delete_invite() {
+async fn test_only_owner_can_delete_invite(_pool: PgPool) {
     // This test verifies ownership check for invite deletion
-    let _pool = create_test_pool().await;
 
     // Same ownership check as create
 }
 
-#[tokio::test]
+#[sqlx::test]
 #[ignore] // Requires PostgreSQL
-async fn test_only_owner_can_list_invites() {
+async fn test_only_owner_can_list_invites(_pool: PgPool) {
     // This test verifies ownership check for listing invites
-    let _pool = create_test_pool().await;
 
     // Same ownership check as create/delete
 }
@@ -406,9 +387,9 @@ async fn test_only_owner_can_list_invites() {
 // Future Test Stubs (for planned features)
 // ============================================================================
 
-#[tokio::test]
+#[sqlx::test]
 #[ignore] // Feature not yet implemented
-async fn test_invite_rejected_after_max_uses() {
+async fn test_invite_rejected_after_max_uses(_pool: PgPool) {
     // TODO: When max_uses is added to GuildInvite:
     // 1. Create invite with max_uses = 5
     // 2. Have 5 users join
@@ -416,9 +397,9 @@ async fn test_invite_rejected_after_max_uses() {
     // 4. Verify rejection
 }
 
-#[tokio::test]
+#[sqlx::test]
 #[ignore] // Feature not yet implemented
-async fn test_banned_user_cannot_join_via_invite() {
+async fn test_banned_user_cannot_join_via_invite(_pool: PgPool) {
     // TODO: When bans table is implemented:
     // 1. Create guild and invite
     // 2. Ban a user from guild
@@ -426,9 +407,9 @@ async fn test_banned_user_cannot_join_via_invite() {
     // 4. Verify rejection with appropriate error
 }
 
-#[tokio::test]
+#[sqlx::test]
 #[ignore] // Feature not yet implemented
-async fn test_invite_to_suspended_guild_rejected() {
+async fn test_invite_to_suspended_guild_rejected(_pool: PgPool) {
     // TODO: When guild suspension is implemented:
     // 1. Create guild and invite
     // 2. Suspend guild

--- a/server/tests/integration/guild_limits.rs
+++ b/server/tests/integration/guild_limits.rs
@@ -33,7 +33,6 @@ async fn test_guild_creation_limit(pool: PgPool) {
     let token = generate_access_token(&app.config, user_id);
 
     // Create 2 guilds (at limit)
-    let mut guild_ids = Vec::new();
     for i in 0..2 {
         let resp = app
             .oneshot(
@@ -45,8 +44,6 @@ async fn test_guild_creation_limit(pool: PgPool) {
             )
             .await;
         assert_eq!(resp.status(), StatusCode::OK, "Guild {i} should succeed");
-        let body = body_to_json(resp).await;
-        guild_ids.push(body["id"].as_str().unwrap().to_string());
     }
 
     // 3rd guild should fail

--- a/server/tests/integration/guild_limits.rs
+++ b/server/tests/integration/guild_limits.rs
@@ -7,8 +7,7 @@ use vc_server::config::Config;
 
 use super::helpers::{
     add_guild_member, body_to_json, create_bot_application, create_channel, create_guild,
-    create_test_user, generate_access_token,
-    TestApp,
+    create_test_user, generate_access_token, TestApp,
 };
 
 /// Helper: create a Config with low limits for testing.
@@ -258,7 +257,6 @@ async fn test_bot_limit(pool: PgPool) {
     // Create 2 bots
     let (_app1_id, bot1_id, _) = create_bot_application(&app.pool, owner_id).await;
     let (_app2_id, bot2_id, _) = create_bot_application(&app.pool, owner_id).await;
-
 
     // Install first bot (1/1)
     let resp = app

--- a/server/tests/integration/guild_limits.rs
+++ b/server/tests/integration/guild_limits.rs
@@ -2,11 +2,12 @@
 
 use axum::body::Body;
 use axum::http::{Method, StatusCode};
+use sqlx::PgPool;
 use vc_server::config::Config;
 
 use super::helpers::{
     add_guild_member, body_to_json, create_bot_application, create_channel, create_guild,
-    create_test_user, delete_bot_application, delete_guild, delete_user, generate_access_token,
+    create_test_user, generate_access_token,
     TestApp,
 };
 
@@ -26,13 +27,11 @@ fn low_limit_config() -> Config {
 // Guild creation limit
 // ============================================================================
 
-#[tokio::test]
-async fn test_guild_creation_limit() {
-    let app = TestApp::with_config(low_limit_config()).await;
+#[sqlx::test]
+async fn test_guild_creation_limit(pool: PgPool) {
+    let app = TestApp::with_pool_and_config(pool.clone(), low_limit_config()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     // Create 2 guilds (at limit)
     let mut guild_ids = Vec::new();
@@ -64,35 +63,21 @@ async fn test_guild_creation_limit() {
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     let body = body_to_json(resp).await;
     assert_eq!(body["error"], "LIMIT_EXCEEDED");
-
-    // Cleanup
-    for gid in &guild_ids {
-        let uuid = uuid::Uuid::parse_str(gid).unwrap();
-        delete_guild(&app.pool, uuid).await;
-    }
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // Member limit on invite join
 // ============================================================================
 
-#[tokio::test]
-async fn test_member_limit_on_invite_join() {
-    let app = TestApp::with_config(low_limit_config()).await;
+#[sqlx::test]
+async fn test_member_limit_on_invite_join(pool: PgPool) {
+    let app = TestApp::with_pool_and_config(pool.clone(), low_limit_config()).await;
     let (owner_id, _) = create_test_user(&app.pool).await;
     let (user2_id, _) = create_test_user(&app.pool).await;
     let (user3_id, _) = create_test_user(&app.pool).await;
     let owner_token = generate_access_token(&app.config, owner_id);
     let user3_token = generate_access_token(&app.config, user3_id);
     let guild_id = create_guild(&app.pool, owner_id).await;
-    let mut guard = app.cleanup_guard();
-    guard.add(move |pool| async move {
-        delete_guild(&pool, guild_id).await;
-        delete_user(&pool, owner_id).await;
-        delete_user(&pool, user2_id).await;
-        delete_user(&pool, user3_id).await;
-    });
 
     // Owner is already member (1/2). Add user2 (2/2).
     add_guild_member(&app.pool, guild_id, user2_id).await;
@@ -123,24 +108,18 @@ async fn test_member_limit_on_invite_join() {
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     let body = body_to_json(resp).await;
     assert_eq!(body["error"], "LIMIT_EXCEEDED");
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // Channel limit
 // ============================================================================
 
-#[tokio::test]
-async fn test_channel_limit() {
-    let app = TestApp::with_config(low_limit_config()).await;
+#[sqlx::test]
+async fn test_channel_limit(pool: PgPool) {
+    let app = TestApp::with_pool_and_config(pool.clone(), low_limit_config()).await;
     let (owner_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, owner_id);
     let guild_id = create_guild(&app.pool, owner_id).await;
-    let mut guard = app.cleanup_guard();
-    guard.add(move |pool| async move {
-        delete_guild(&pool, guild_id).await;
-        delete_user(&pool, owner_id).await;
-    });
 
     // Create @everyone role with MANAGE_CHANNELS
     sqlx::query(
@@ -188,24 +167,18 @@ async fn test_channel_limit() {
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     let body = body_to_json(resp).await;
     assert_eq!(body["error"], "LIMIT_EXCEEDED");
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // Role limit
 // ============================================================================
 
-#[tokio::test]
-async fn test_role_limit() {
-    let app = TestApp::with_config(low_limit_config()).await;
+#[sqlx::test]
+async fn test_role_limit(pool: PgPool) {
+    let app = TestApp::with_pool_and_config(pool.clone(), low_limit_config()).await;
     let (owner_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, owner_id);
     let guild_id = create_guild(&app.pool, owner_id).await;
-    let mut guard = app.cleanup_guard();
-    guard.add(move |pool| async move {
-        delete_guild(&pool, guild_id).await;
-        delete_user(&pool, owner_id).await;
-    });
 
     sqlx::query(
         "UPDATE guild_roles SET permissions = $1 WHERE guild_id = $2 AND is_default = true",
@@ -258,20 +231,18 @@ async fn test_role_limit() {
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     let body = body_to_json(resp).await;
     assert_eq!(body["error"], "LIMIT_EXCEEDED");
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // Bot limit
 // ============================================================================
 
-#[tokio::test]
-async fn test_bot_limit() {
-    let app = TestApp::with_config(low_limit_config()).await;
+#[sqlx::test]
+async fn test_bot_limit(pool: PgPool) {
+    let app = TestApp::with_pool_and_config(pool.clone(), low_limit_config()).await;
     let (owner_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, owner_id);
     let guild_id = create_guild(&app.pool, owner_id).await;
-    let mut guard = app.cleanup_guard();
 
     // Create @everyone with MANAGE_GUILD
     sqlx::query(
@@ -285,15 +256,9 @@ async fn test_bot_limit() {
     .unwrap();
 
     // Create 2 bots
-    let (app1_id, bot1_id, _) = create_bot_application(&app.pool, owner_id).await;
-    let (app2_id, bot2_id, _) = create_bot_application(&app.pool, owner_id).await;
+    let (_app1_id, bot1_id, _) = create_bot_application(&app.pool, owner_id).await;
+    let (_app2_id, bot2_id, _) = create_bot_application(&app.pool, owner_id).await;
 
-    guard.add(move |pool| async move {
-        delete_bot_application(&pool, app1_id).await;
-        delete_bot_application(&pool, app2_id).await;
-        delete_guild(&pool, guild_id).await;
-        delete_user(&pool, owner_id).await;
-    });
 
     // Install first bot (1/1)
     let resp = app
@@ -328,24 +293,18 @@ async fn test_bot_limit() {
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     let body = body_to_json(resp).await;
     assert_eq!(body["error"], "LIMIT_EXCEEDED");
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // Emoji limit
 // ============================================================================
 
-#[tokio::test]
-async fn test_emoji_limit() {
-    let app = TestApp::with_config(low_limit_config()).await;
+#[sqlx::test]
+async fn test_emoji_limit(pool: PgPool) {
+    let app = TestApp::with_pool_and_config(pool.clone(), low_limit_config()).await;
     let (owner_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, owner_id);
     let guild_id = create_guild(&app.pool, owner_id).await;
-    let mut guard = app.cleanup_guard();
-    guard.add(move |pool| async move {
-        delete_guild(&pool, guild_id).await;
-        delete_user(&pool, owner_id).await;
-    });
 
     // Insert 1 emoji directly (at limit of 1)
     sqlx::query(
@@ -376,30 +335,22 @@ async fn test_emoji_limit() {
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     let body = body_to_json(resp).await;
     assert_eq!(body["error"], "LIMIT_EXCEEDED");
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // Member limit on discovery join
 // ============================================================================
 
-#[tokio::test]
-async fn test_member_limit_on_discovery_join() {
+#[sqlx::test]
+async fn test_member_limit_on_discovery_join(pool: PgPool) {
     let mut config = low_limit_config();
     config.enable_guild_discovery = true;
-    let app = TestApp::with_config(config).await;
+    let app = TestApp::with_pool_and_config(pool.clone(), config).await;
     let (owner_id, _) = create_test_user(&app.pool).await;
     let (user2_id, _) = create_test_user(&app.pool).await;
     let (user3_id, _) = create_test_user(&app.pool).await;
     let user3_token = generate_access_token(&app.config, user3_id);
     let guild_id = create_guild(&app.pool, owner_id).await;
-    let mut guard = app.cleanup_guard();
-    guard.add(move |pool| async move {
-        delete_guild(&pool, guild_id).await;
-        delete_user(&pool, owner_id).await;
-        delete_user(&pool, user2_id).await;
-        delete_user(&pool, user3_id).await;
-    });
 
     // Make guild discoverable
     sqlx::query("UPDATE guilds SET discoverable = true WHERE id = $1")
@@ -426,24 +377,17 @@ async fn test_member_limit_on_discovery_join() {
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     let body = body_to_json(resp).await;
     assert_eq!(body["error"], "LIMIT_EXCEEDED");
-    guard.cleanup().await;
 }
 
-#[tokio::test]
-async fn test_globally_banned_user_cannot_join_via_discovery() {
+#[sqlx::test]
+async fn test_globally_banned_user_cannot_join_via_discovery(pool: PgPool) {
     let mut config = low_limit_config();
     config.enable_guild_discovery = true;
-    let app = TestApp::with_config(config).await;
+    let app = TestApp::with_pool_and_config(pool.clone(), config).await;
     let (owner_id, _) = create_test_user(&app.pool).await;
     let (banned_user_id, _) = create_test_user(&app.pool).await;
     let banned_token = generate_access_token(&app.config, banned_user_id);
     let guild_id = create_guild(&app.pool, owner_id).await;
-    let mut guard = app.cleanup_guard();
-    guard.add(move |pool| async move {
-        delete_guild(&pool, guild_id).await;
-        delete_user(&pool, owner_id).await;
-        delete_user(&pool, banned_user_id).await;
-    });
 
     sqlx::query("UPDATE guilds SET discoverable = true WHERE id = $1")
         .bind(guild_id)
@@ -473,24 +417,18 @@ async fn test_globally_banned_user_cannot_join_via_discovery() {
     assert_eq!(banned_resp.status(), StatusCode::FORBIDDEN);
     let body = body_to_json(banned_resp).await;
     assert_eq!(body["error"], "FORBIDDEN");
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // Usage endpoint
 // ============================================================================
 
-#[tokio::test]
-async fn test_usage_endpoint() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_usage_endpoint(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (owner_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, owner_id);
     let guild_id = create_guild(&app.pool, owner_id).await;
-    let mut guard = app.cleanup_guard();
-    guard.add(move |pool| async move {
-        delete_guild(&pool, guild_id).await;
-        delete_user(&pool, owner_id).await;
-    });
 
     // Create some channels
     create_channel(&app.pool, guild_id, "general").await;
@@ -513,22 +451,15 @@ async fn test_usage_endpoint() {
     assert_eq!(body["channels"]["current"], 2);
     assert!(body["members"]["limit"].as_i64().unwrap() > 0);
     assert!(body["channels"]["limit"].as_i64().unwrap() > 0);
-    guard.cleanup().await;
 }
 
-#[tokio::test]
-async fn test_usage_requires_membership() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_usage_requires_membership(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (owner_id, _) = create_test_user(&app.pool).await;
     let (outsider_id, _) = create_test_user(&app.pool).await;
     let outsider_token = generate_access_token(&app.config, outsider_id);
     let guild_id = create_guild(&app.pool, owner_id).await;
-    let mut guard = app.cleanup_guard();
-    guard.add(move |pool| async move {
-        delete_guild(&pool, guild_id).await;
-        delete_user(&pool, owner_id).await;
-        delete_user(&pool, outsider_id).await;
-    });
 
     let resp = app
         .oneshot(
@@ -539,16 +470,15 @@ async fn test_usage_requires_membership() {
         )
         .await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // Instance limits endpoint
 // ============================================================================
 
-#[tokio::test]
-async fn test_instance_limits_endpoint() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_instance_limits_endpoint(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
 
     let resp = app
         .oneshot(

--- a/server/tests/integration/pages.rs
+++ b/server/tests/integration/pages.rs
@@ -11,16 +11,6 @@ use vc_server::pages::{
     PageListItem, UpdatePageRequest,
 };
 
-/// Helper to create a test database pool.
-async fn create_test_pool() -> PgPool {
-    let database_url =
-        std::env::var("DATABASE_URL").unwrap_or_else(|_| "postgres://localhost/vc_test".into());
-
-    PgPool::connect(&database_url)
-        .await
-        .expect("Failed to connect to test database")
-}
-
 /// Helper to create a unique test slug.
 fn test_slug() -> String {
     format!("test-page-{}", &Uuid::new_v4().to_string()[..8])
@@ -92,10 +82,8 @@ fn test_is_reserved_slug() {
 }
 
 /// Test page count for platform pages.
-#[tokio::test]
-#[ignore] // Requires PostgreSQL
-async fn test_count_platform_pages() {
-    let pool = create_test_pool().await;
+#[sqlx::test]
+async fn test_count_platform_pages(pool: PgPool) {
 
     let count = count_pages(&pool, None)
         .await
@@ -106,10 +94,8 @@ async fn test_count_platform_pages() {
 }
 
 /// Test page count for guild pages.
-#[tokio::test]
-#[ignore] // Requires PostgreSQL
-async fn test_count_guild_pages() {
-    let pool = create_test_pool().await;
+#[sqlx::test]
+async fn test_count_guild_pages(pool: PgPool) {
 
     // Use a random guild ID (won't exist, should return 0)
     let guild_id = Uuid::new_v4();
@@ -122,10 +108,8 @@ async fn test_count_guild_pages() {
 }
 
 /// Test slug existence check for non-existent slug.
-#[tokio::test]
-#[ignore] // Requires PostgreSQL
-async fn test_slug_not_exists() {
-    let pool = create_test_pool().await;
+#[sqlx::test]
+async fn test_slug_not_exists(pool: PgPool) {
     let slug = test_slug();
 
     let exists = slug_exists(&pool, None, &slug, None)

--- a/server/tests/integration/pages.rs
+++ b/server/tests/integration/pages.rs
@@ -84,7 +84,6 @@ fn test_is_reserved_slug() {
 /// Test page count for platform pages.
 #[sqlx::test]
 async fn test_count_platform_pages(pool: PgPool) {
-
     let count = count_pages(&pool, None)
         .await
         .expect("Failed to count platform pages");
@@ -96,7 +95,6 @@ async fn test_count_platform_pages(pool: PgPool) {
 /// Test page count for guild pages.
 #[sqlx::test]
 async fn test_count_guild_pages(pool: PgPool) {
-
     // Use a random guild ID (won't exist, should return 0)
     let guild_id = Uuid::new_v4();
     let count = count_pages(&pool, Some(guild_id))

--- a/server/tests/integration/search.rs
+++ b/server/tests/integration/search.rs
@@ -6,16 +6,6 @@
 use sqlx::PgPool;
 use uuid::Uuid;
 
-/// Helper to create a test database pool.
-async fn create_test_pool() -> PgPool {
-    let database_url =
-        std::env::var("DATABASE_URL").unwrap_or_else(|_| "postgres://localhost/vc_test".into());
-
-    PgPool::connect(&database_url)
-        .await
-        .expect("Failed to connect to test database")
-}
-
 /// Helper to create a test user and return their ID.
 async fn create_test_user(pool: &PgPool) -> Uuid {
     let user_id = Uuid::new_v4();
@@ -118,52 +108,12 @@ async fn create_test_message(
     message_id
 }
 
-/// Helper to cleanup test data.
-async fn cleanup_test_data(pool: &PgPool, user_id: Uuid, guild_id: Uuid) {
-    // Delete messages first (FK constraint)
-    sqlx::query("DELETE FROM messages WHERE user_id = $1")
-        .bind(user_id)
-        .execute(pool)
-        .await
-        .ok();
-
-    // Delete channels
-    sqlx::query("DELETE FROM channels WHERE guild_id = $1")
-        .bind(guild_id)
-        .execute(pool)
-        .await
-        .ok();
-
-    // Delete guild members
-    sqlx::query("DELETE FROM guild_members WHERE guild_id = $1")
-        .bind(guild_id)
-        .execute(pool)
-        .await
-        .ok();
-
-    // Delete guild
-    sqlx::query("DELETE FROM guilds WHERE id = $1")
-        .bind(guild_id)
-        .execute(pool)
-        .await
-        .ok();
-
-    // Delete user
-    sqlx::query("DELETE FROM users WHERE id = $1")
-        .bind(user_id)
-        .execute(pool)
-        .await
-        .ok();
-}
-
 // ============================================================================
 // Search Query Tests
 // ============================================================================
 
-#[tokio::test]
-#[ignore = "requires database"]
-async fn test_search_messages_basic() {
-    let pool = create_test_pool().await;
+#[sqlx::test]
+async fn test_search_messages_basic(pool: PgPool) {
     let user_id = create_test_user(&pool).await;
     let guild_id = create_test_guild(&pool, user_id).await;
     let channel_id = create_test_channel(&pool, guild_id, "general").await;
@@ -193,13 +143,10 @@ async fn test_search_messages_basic() {
 
     assert_eq!(results.len(), 2, "Expected 2 results for 'test'");
 
-    cleanup_test_data(&pool, user_id, guild_id).await;
 }
 
-#[tokio::test]
-#[ignore = "requires database"]
-async fn test_search_messages_no_results() {
-    let pool = create_test_pool().await;
+#[sqlx::test]
+async fn test_search_messages_no_results(pool: PgPool) {
     let user_id = create_test_user(&pool).await;
     let guild_id = create_test_guild(&pool, user_id).await;
     let channel_id = create_test_channel(&pool, guild_id, "general").await;
@@ -226,13 +173,10 @@ async fn test_search_messages_no_results() {
 
     assert_eq!(results.len(), 0, "Expected no results for 'nonexistent'");
 
-    cleanup_test_data(&pool, user_id, guild_id).await;
 }
 
-#[tokio::test]
-#[ignore = "requires database"]
-async fn test_search_messages_pagination() {
-    let pool = create_test_pool().await;
+#[sqlx::test]
+async fn test_search_messages_pagination(pool: PgPool) {
     let user_id = create_test_user(&pool).await;
     let guild_id = create_test_guild(&pool, user_id).await;
     let channel_id = create_test_channel(&pool, guild_id, "general").await;
@@ -304,13 +248,10 @@ async fn test_search_messages_pagination() {
         );
     }
 
-    cleanup_test_data(&pool, user_id, guild_id).await;
 }
 
-#[tokio::test]
-#[ignore = "requires database"]
-async fn test_search_messages_count() {
-    let pool = create_test_pool().await;
+#[sqlx::test]
+async fn test_search_messages_count(pool: PgPool) {
     let user_id = create_test_user(&pool).await;
     let guild_id = create_test_guild(&pool, user_id).await;
     let channel_id = create_test_channel(&pool, guild_id, "general").await;
@@ -342,13 +283,10 @@ async fn test_search_messages_count() {
 
     assert_eq!(count.0, 15, "Expected 15 matching messages");
 
-    cleanup_test_data(&pool, user_id, guild_id).await;
 }
 
-#[tokio::test]
-#[ignore = "requires database"]
-async fn test_search_excludes_deleted_messages() {
-    let pool = create_test_pool().await;
+#[sqlx::test]
+async fn test_search_excludes_deleted_messages(pool: PgPool) {
     let user_id = create_test_user(&pool).await;
     let guild_id = create_test_guild(&pool, user_id).await;
     let channel_id = create_test_channel(&pool, guild_id, "general").await;
@@ -393,13 +331,10 @@ async fn test_search_excludes_deleted_messages() {
         "Deleted message should not be in results"
     );
 
-    cleanup_test_data(&pool, user_id, guild_id).await;
 }
 
-#[tokio::test]
-#[ignore = "requires database"]
-async fn test_search_websearch_syntax() {
-    let pool = create_test_pool().await;
+#[sqlx::test]
+async fn test_search_websearch_syntax(pool: PgPool) {
     let user_id = create_test_user(&pool).await;
     let guild_id = create_test_guild(&pool, user_id).await;
     let channel_id = create_test_channel(&pool, guild_id, "general").await;
@@ -451,5 +386,4 @@ async fn test_search_websearch_syntax() {
         "Expected 3 results for 'quick OR lazy'"
     );
 
-    cleanup_test_data(&pool, user_id, guild_id).await;
 }

--- a/server/tests/integration/search.rs
+++ b/server/tests/integration/search.rs
@@ -142,7 +142,6 @@ async fn test_search_messages_basic(pool: PgPool) {
     .expect("Search query failed");
 
     assert_eq!(results.len(), 2, "Expected 2 results for 'test'");
-
 }
 
 #[sqlx::test]
@@ -172,7 +171,6 @@ async fn test_search_messages_no_results(pool: PgPool) {
     .expect("Search query failed");
 
     assert_eq!(results.len(), 0, "Expected no results for 'nonexistent'");
-
 }
 
 #[sqlx::test]
@@ -247,7 +245,6 @@ async fn test_search_messages_pagination(pool: PgPool) {
             "Pages should not have overlapping results"
         );
     }
-
 }
 
 #[sqlx::test]
@@ -282,7 +279,6 @@ async fn test_search_messages_count(pool: PgPool) {
     .expect("Count query failed");
 
     assert_eq!(count.0, 15, "Expected 15 matching messages");
-
 }
 
 #[sqlx::test]
@@ -330,7 +326,6 @@ async fn test_search_excludes_deleted_messages(pool: PgPool) {
         results[0].0, msg_id,
         "Deleted message should not be in results"
     );
-
 }
 
 #[sqlx::test]
@@ -385,5 +380,4 @@ async fn test_search_websearch_syntax(pool: PgPool) {
         3,
         "Expected 3 results for 'quick OR lazy'"
     );
-
 }

--- a/server/tests/integration/search_http.rs
+++ b/server/tests/integration/search_http.rs
@@ -6,13 +6,14 @@
 //! Run with: `cargo test --test integration search_http`
 
 use axum::body::Body;
+use sqlx::PgPool;
 use axum::http::Method;
 use uuid::Uuid;
 use vc_server::permissions::GuildPermissions;
 
 use super::helpers::{
     add_guild_member, body_to_json, create_channel, create_dm_channel, create_guild,
-    create_guild_with_default_role, create_test_user, delete_dm_channel, delete_guild, delete_user,
+    create_guild_with_default_role, create_test_user,
     generate_access_token, insert_attachment, insert_encrypted_message, insert_message,
     insert_message_at, TestApp,
 };
@@ -48,9 +49,9 @@ fn dm_search_request(query_string: &str, token: &str) -> axum::http::Request<Bod
 // Guild Search — Auth
 // ============================================================================
 
-#[tokio::test]
-async fn test_guild_search_requires_auth() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_guild_search_requires_auth(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
 
@@ -64,17 +65,15 @@ async fn test_guild_search_requires_auth() {
     let resp = app.oneshot(req).await;
     assert_eq!(resp.status(), 401);
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // Guild Search — Non-member Forbidden
 // ============================================================================
 
-#[tokio::test]
-async fn test_guild_search_non_member_forbidden() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_guild_search_non_member_forbidden(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (owner_id, _) = create_test_user(&app.pool).await;
     let (outsider_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, owner_id).await;
@@ -88,18 +87,15 @@ async fn test_guild_search_non_member_forbidden() {
     let resp = app.oneshot(req).await;
     assert_eq!(resp.status(), 403);
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, owner_id).await;
-    delete_user(&app.pool, outsider_id).await;
 }
 
 // ============================================================================
 // Guild Search — Nonexistent Guild
 // ============================================================================
 
-#[tokio::test]
-async fn test_guild_search_nonexistent_guild() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_guild_search_nonexistent_guild(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
@@ -108,16 +104,15 @@ async fn test_guild_search_nonexistent_guild() {
     let resp = app.oneshot(req).await;
     assert_eq!(resp.status(), 404);
 
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // Guild Search — Basic
 // ============================================================================
 
-#[tokio::test]
-async fn test_guild_search_basic() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_guild_search_basic(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -135,17 +130,15 @@ async fn test_guild_search_basic() {
     assert_eq!(json["total"], 2);
     assert_eq!(json["results"].as_array().unwrap().len(), 2);
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // Guild Search — Excludes Encrypted
 // ============================================================================
 
-#[tokio::test]
-async fn test_guild_search_excludes_encrypted() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_guild_search_excludes_encrypted(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -161,17 +154,15 @@ async fn test_guild_search_excludes_encrypted() {
     let json = body_to_json(resp).await;
     assert_eq!(json["total"], 1, "Encrypted message should be excluded");
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // Guild Search — Date Filter
 // ============================================================================
 
-#[tokio::test]
-async fn test_guild_search_date_filter() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_guild_search_date_filter(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -195,17 +186,15 @@ async fn test_guild_search_date_filter() {
     let json = body_to_json(resp).await;
     assert_eq!(json["total"], 1, "Only the recent message should match");
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // Guild Search — Author Filter
 // ============================================================================
 
-#[tokio::test]
-async fn test_guild_search_author_filter() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_guild_search_author_filter(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_a, _) = create_test_user(&app.pool).await;
     let (user_b, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_a).await;
@@ -226,18 +215,15 @@ async fn test_guild_search_author_filter() {
     assert_eq!(json["total"], 1);
     assert_eq!(json["results"][0]["author"]["id"], user_b.to_string());
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_a).await;
-    delete_user(&app.pool, user_b).await;
 }
 
 // ============================================================================
 // Guild Search — Channel Filter
 // ============================================================================
 
-#[tokio::test]
-async fn test_guild_search_channel_filter() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_guild_search_channel_filter(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let ch_a = create_channel(&app.pool, guild_id, "channel-a").await;
@@ -256,17 +242,15 @@ async fn test_guild_search_channel_filter() {
     assert_eq!(json["total"], 1);
     assert_eq!(json["results"][0]["channel_id"], ch_a.to_string());
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // Guild Search — Has Link
 // ============================================================================
 
-#[tokio::test]
-async fn test_guild_search_has_link() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_guild_search_has_link(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -291,17 +275,15 @@ async fn test_guild_search_has_link() {
         "Only the message with a link should match"
     );
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // Guild Search — Has File
 // ============================================================================
 
-#[tokio::test]
-async fn test_guild_search_has_file() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_guild_search_has_file(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -322,17 +304,15 @@ async fn test_guild_search_has_file() {
         "Only the message with attachment should match"
     );
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // Guild Search — Validation Errors (data-driven)
 // ============================================================================
 
-#[tokio::test]
-async fn test_guild_search_validation() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_guild_search_validation(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     create_channel(&app.pool, guild_id, "general").await;
@@ -353,17 +333,15 @@ async fn test_guild_search_validation() {
         assert_eq!(resp.status(), 400, "{label} should return 400");
     }
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // DM Search — Auth
 // ============================================================================
 
-#[tokio::test]
-async fn test_dm_search_requires_auth() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_dm_search_requires_auth(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
 
     let req = TestApp::request(Method::GET, "/api/dm/search?q=test")
         .body(Body::empty())
@@ -377,9 +355,9 @@ async fn test_dm_search_requires_auth() {
 // DM Search — Basic
 // ============================================================================
 
-#[tokio::test]
-async fn test_dm_search_basic() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_dm_search_basic(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_a, _) = create_test_user(&app.pool).await;
     let (user_b, _) = create_test_user(&app.pool).await;
     let dm_id = create_dm_channel(&app.pool, user_a, user_b).await;
@@ -397,18 +375,15 @@ async fn test_dm_search_basic() {
     assert_eq!(json["total"], 2);
     assert_eq!(json["results"].as_array().unwrap().len(), 2);
 
-    delete_dm_channel(&app.pool, dm_id).await;
-    delete_user(&app.pool, user_a).await;
-    delete_user(&app.pool, user_b).await;
 }
 
 // ============================================================================
 // DM Search — Only Own DMs
 // ============================================================================
 
-#[tokio::test]
-async fn test_dm_search_only_own_dms() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_dm_search_only_own_dms(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_a, _) = create_test_user(&app.pool).await;
     let (user_b, _) = create_test_user(&app.pool).await;
     let (user_c, _) = create_test_user(&app.pool).await;
@@ -434,20 +409,15 @@ async fn test_dm_search_only_own_dms() {
     );
     assert_eq!(json["results"][0]["channel_id"], dm_ab.to_string());
 
-    delete_dm_channel(&app.pool, dm_ab).await;
-    delete_dm_channel(&app.pool, dm_bc).await;
-    delete_user(&app.pool, user_a).await;
-    delete_user(&app.pool, user_b).await;
-    delete_user(&app.pool, user_c).await;
 }
 
 // ============================================================================
 // DM Search — Channel Filter
 // ============================================================================
 
-#[tokio::test]
-async fn test_dm_search_channel_filter() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_dm_search_channel_filter(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_a, _) = create_test_user(&app.pool).await;
     let (user_b, _) = create_test_user(&app.pool).await;
     let (user_c, _) = create_test_user(&app.pool).await;
@@ -469,20 +439,15 @@ async fn test_dm_search_channel_filter() {
     assert_eq!(json["total"], 1);
     assert_eq!(json["results"][0]["channel_id"], dm_ab.to_string());
 
-    delete_dm_channel(&app.pool, dm_ab).await;
-    delete_dm_channel(&app.pool, dm_ac).await;
-    delete_user(&app.pool, user_a).await;
-    delete_user(&app.pool, user_b).await;
-    delete_user(&app.pool, user_c).await;
 }
 
 // ============================================================================
 // DM Search — Excludes Encrypted
 // ============================================================================
 
-#[tokio::test]
-async fn test_dm_search_excludes_encrypted() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_dm_search_excludes_encrypted(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_a, _) = create_test_user(&app.pool).await;
     let (user_b, _) = create_test_user(&app.pool).await;
     let dm_id = create_dm_channel(&app.pool, user_a, user_b).await;
@@ -501,18 +466,15 @@ async fn test_dm_search_excludes_encrypted() {
         "Encrypted DM should be excluded from search"
     );
 
-    delete_dm_channel(&app.pool, dm_id).await;
-    delete_user(&app.pool, user_a).await;
-    delete_user(&app.pool, user_b).await;
 }
 
 // ============================================================================
 // Guild Search — Headline contains <mark>
 // ============================================================================
 
-#[tokio::test]
-async fn test_guild_search_headline_contains_mark() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_guild_search_headline_contains_mark(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -543,17 +505,15 @@ async fn test_guild_search_headline_contains_mark() {
         "headline should contain </mark> tags, got: {headline}"
     );
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // Guild Search — Rank present
 // ============================================================================
 
-#[tokio::test]
-async fn test_guild_search_rank_present() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_guild_search_rank_present(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -581,17 +541,15 @@ async fn test_guild_search_rank_present() {
         "rank should be a positive float, got: {rank:?}"
     );
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // Guild Search — Sort by relevance
 // ============================================================================
 
-#[tokio::test]
-async fn test_guild_search_sort_relevance() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_guild_search_sort_relevance(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -630,17 +588,15 @@ async fn test_guild_search_sort_relevance() {
         "Results should be sorted by rank descending: {rank_0} >= {rank_1}"
     );
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
 // Guild Search — Sort by date
 // ============================================================================
 
-#[tokio::test]
-async fn test_guild_search_sort_date() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_guild_search_sort_date(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -671,8 +627,6 @@ async fn test_guild_search_sort_date() {
         "sort=date should return newest first: {date_0} > {date_1}"
     );
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
@@ -682,9 +636,9 @@ async fn test_guild_search_sort_date() {
 /// Special characters that should not cause errors or SQL injection.
 /// `websearch_to_tsquery` uses parameterized queries so special SQL characters
 /// are never interpolated into the query string.
-#[tokio::test]
-async fn test_guild_search_special_characters_no_error() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_guild_search_special_characters_no_error(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     create_channel(&app.pool, guild_id, "general").await;
@@ -718,14 +672,12 @@ async fn test_guild_search_special_characters_no_error() {
         );
     }
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 /// A query longer than 1000 characters must be rejected with 400.
-#[tokio::test]
-async fn test_guild_search_long_query_rejected() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_guild_search_long_query_rejected(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     create_channel(&app.pool, guild_id, "general").await;
@@ -742,14 +694,12 @@ async fn test_guild_search_long_query_rejected() {
         "query of 1001 chars should be rejected with 400"
     );
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 /// A query of exactly 1000 characters must be accepted (boundary condition).
-#[tokio::test]
-async fn test_guild_search_max_length_query_accepted() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_guild_search_max_length_query_accepted(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     create_channel(&app.pool, guild_id, "general").await;
@@ -766,16 +716,14 @@ async fn test_guild_search_max_length_query_accepted() {
         "query of exactly 1000 chars should be accepted"
     );
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 /// Messages containing HTML/XSS payloads are returned verbatim in the `content`
 /// field. The server must not alter the stored content; the client is responsible
 /// for HTML-escaping on render.
-#[tokio::test]
-async fn test_guild_search_xss_content_returned_verbatim() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_guild_search_xss_content_returned_verbatim(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -804,8 +752,6 @@ async fn test_guild_search_xss_content_returned_verbatim() {
         "content field must not be HTML-escaped by the server; clients escape on render"
     );
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
@@ -814,9 +760,9 @@ async fn test_guild_search_xss_content_returned_verbatim() {
 
 /// Insert 210 matching messages and verify that pagination returns correct
 /// non-overlapping pages and that the total count is accurate.
-#[tokio::test]
-async fn test_guild_search_large_result_set_pagination() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_guild_search_large_result_set_pagination(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
@@ -890,8 +836,6 @@ async fn test_guild_search_large_result_set_pagination() {
         "page 1 and page 2 must not share any message IDs"
     );
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, user_id).await;
 }
 
 // ============================================================================
@@ -966,9 +910,9 @@ async fn create_channel_perm_override(
 /// - Both channels have a matching message
 ///
 /// Expected: search returns only the message from the visible channel.
-#[tokio::test]
-async fn test_guild_search_excludes_hidden_channels() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_guild_search_excludes_hidden_channels(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (owner_id, _) = create_test_user(&app.pool).await;
     let (member_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, member_id);
@@ -1030,15 +974,12 @@ async fn test_guild_search_excludes_hidden_channels() {
         "result must be from the visible channel, not the restricted one"
     );
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, owner_id).await;
-    delete_user(&app.pool, member_id).await;
 }
 
 /// Guild owner bypasses channel permission overrides and can find messages in all channels.
-#[tokio::test]
-async fn test_guild_search_owner_sees_all_channels() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_guild_search_owner_sees_all_channels(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (owner_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, owner_id);
 
@@ -1070,15 +1011,13 @@ async fn test_guild_search_owner_sees_all_channels() {
         "guild owner must bypass channel permission overrides"
     );
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, owner_id).await;
 }
 
 /// A channel-level allow override for `VIEW_CHANNEL` grants search access
 /// even when @everyone has no `VIEW_CHANNEL` at guild level.
-#[tokio::test]
-async fn test_guild_search_channel_allow_override_grants_access() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_guild_search_channel_allow_override_grants_access(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (owner_id, _) = create_test_user(&app.pool).await;
     let (member_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, member_id);
@@ -1125,16 +1064,13 @@ async fn test_guild_search_channel_allow_override_grants_access() {
         special_ch.to_string()
     );
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, owner_id).await;
-    delete_user(&app.pool, member_id).await;
 }
 
 /// When the user provides a `channel_id` filter for a channel they cannot view,
 /// the search must return 0 results and must not leak information.
-#[tokio::test]
-async fn test_guild_search_channel_filter_respects_visibility() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_guild_search_channel_filter_respects_visibility(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (owner_id, _) = create_test_user(&app.pool).await;
     let (member_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, member_id);
@@ -1165,9 +1101,6 @@ async fn test_guild_search_channel_filter_respects_visibility() {
         "filtering to a hidden channel must return 0 results to avoid info leakage"
     );
 
-    delete_guild(&app.pool, guild_id).await;
-    delete_user(&app.pool, owner_id).await;
-    delete_user(&app.pool, member_id).await;
 }
 
 // ============================================================================
@@ -1175,12 +1108,12 @@ async fn test_guild_search_channel_filter_respects_visibility() {
 // ============================================================================
 
 /// DM search with a query longer than 1000 characters must return 400.
-#[tokio::test]
-async fn test_dm_search_long_query_rejected() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_dm_search_long_query_rejected(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_a, _) = create_test_user(&app.pool).await;
     let (user_b, _) = create_test_user(&app.pool).await;
-    let dm_id = create_dm_channel(&app.pool, user_a, user_b).await;
+    let _dm_id = create_dm_channel(&app.pool, user_a, user_b).await;
     let token = generate_access_token(&app.config, user_a);
 
     let long_query = "a".repeat(1001);
@@ -1193,7 +1126,4 @@ async fn test_dm_search_long_query_rejected() {
         "DM search query of 1001 chars should be rejected with 400"
     );
 
-    delete_dm_channel(&app.pool, dm_id).await;
-    delete_user(&app.pool, user_a).await;
-    delete_user(&app.pool, user_b).await;
 }

--- a/server/tests/integration/search_http.rs
+++ b/server/tests/integration/search_http.rs
@@ -6,16 +6,15 @@
 //! Run with: `cargo test --test integration search_http`
 
 use axum::body::Body;
-use sqlx::PgPool;
 use axum::http::Method;
+use sqlx::PgPool;
 use uuid::Uuid;
 use vc_server::permissions::GuildPermissions;
 
 use super::helpers::{
     add_guild_member, body_to_json, create_channel, create_dm_channel, create_guild,
-    create_guild_with_default_role, create_test_user,
-    generate_access_token, insert_attachment, insert_encrypted_message, insert_message,
-    insert_message_at, TestApp,
+    create_guild_with_default_role, create_test_user, generate_access_token, insert_attachment,
+    insert_encrypted_message, insert_message, insert_message_at, TestApp,
 };
 
 // ============================================================================
@@ -64,7 +63,6 @@ async fn test_guild_search_requires_auth(pool: PgPool) {
 
     let resp = app.oneshot(req).await;
     assert_eq!(resp.status(), 401);
-
 }
 
 // ============================================================================
@@ -86,7 +84,6 @@ async fn test_guild_search_non_member_forbidden(pool: PgPool) {
     let req = guild_search_request(guild_id, "q=test", &token);
     let resp = app.oneshot(req).await;
     assert_eq!(resp.status(), 403);
-
 }
 
 // ============================================================================
@@ -103,7 +100,6 @@ async fn test_guild_search_nonexistent_guild(pool: PgPool) {
     let req = guild_search_request(fake_guild_id, "q=test", &token);
     let resp = app.oneshot(req).await;
     assert_eq!(resp.status(), 404);
-
 }
 
 // ============================================================================
@@ -129,7 +125,6 @@ async fn test_guild_search_basic(pool: PgPool) {
     let json = body_to_json(resp).await;
     assert_eq!(json["total"], 2);
     assert_eq!(json["results"].as_array().unwrap().len(), 2);
-
 }
 
 // ============================================================================
@@ -153,7 +148,6 @@ async fn test_guild_search_excludes_encrypted(pool: PgPool) {
 
     let json = body_to_json(resp).await;
     assert_eq!(json["total"], 1, "Encrypted message should be excluded");
-
 }
 
 // ============================================================================
@@ -185,7 +179,6 @@ async fn test_guild_search_date_filter(pool: PgPool) {
 
     let json = body_to_json(resp).await;
     assert_eq!(json["total"], 1, "Only the recent message should match");
-
 }
 
 // ============================================================================
@@ -214,7 +207,6 @@ async fn test_guild_search_author_filter(pool: PgPool) {
     let json = body_to_json(resp).await;
     assert_eq!(json["total"], 1);
     assert_eq!(json["results"][0]["author"]["id"], user_b.to_string());
-
 }
 
 // ============================================================================
@@ -241,7 +233,6 @@ async fn test_guild_search_channel_filter(pool: PgPool) {
     let json = body_to_json(resp).await;
     assert_eq!(json["total"], 1);
     assert_eq!(json["results"][0]["channel_id"], ch_a.to_string());
-
 }
 
 // ============================================================================
@@ -274,7 +265,6 @@ async fn test_guild_search_has_link(pool: PgPool) {
         json["total"], 1,
         "Only the message with a link should match"
     );
-
 }
 
 // ============================================================================
@@ -303,7 +293,6 @@ async fn test_guild_search_has_file(pool: PgPool) {
         json["total"], 1,
         "Only the message with attachment should match"
     );
-
 }
 
 // ============================================================================
@@ -332,7 +321,6 @@ async fn test_guild_search_validation(pool: PgPool) {
         let resp = app.oneshot(req).await;
         assert_eq!(resp.status(), 400, "{label} should return 400");
     }
-
 }
 
 // ============================================================================
@@ -374,7 +362,6 @@ async fn test_dm_search_basic(pool: PgPool) {
     let json = body_to_json(resp).await;
     assert_eq!(json["total"], 2);
     assert_eq!(json["results"].as_array().unwrap().len(), 2);
-
 }
 
 // ============================================================================
@@ -408,7 +395,6 @@ async fn test_dm_search_only_own_dms(pool: PgPool) {
         "User A should only see their own DM results"
     );
     assert_eq!(json["results"][0]["channel_id"], dm_ab.to_string());
-
 }
 
 // ============================================================================
@@ -438,7 +424,6 @@ async fn test_dm_search_channel_filter(pool: PgPool) {
     let json = body_to_json(resp).await;
     assert_eq!(json["total"], 1);
     assert_eq!(json["results"][0]["channel_id"], dm_ab.to_string());
-
 }
 
 // ============================================================================
@@ -465,7 +450,6 @@ async fn test_dm_search_excludes_encrypted(pool: PgPool) {
         json["total"], 1,
         "Encrypted DM should be excluded from search"
     );
-
 }
 
 // ============================================================================
@@ -504,7 +488,6 @@ async fn test_guild_search_headline_contains_mark(pool: PgPool) {
         headline.contains("</mark>"),
         "headline should contain </mark> tags, got: {headline}"
     );
-
 }
 
 // ============================================================================
@@ -540,7 +523,6 @@ async fn test_guild_search_rank_present(pool: PgPool) {
         rank.unwrap() > 0.0,
         "rank should be a positive float, got: {rank:?}"
     );
-
 }
 
 // ============================================================================
@@ -587,7 +569,6 @@ async fn test_guild_search_sort_relevance(pool: PgPool) {
         rank_0 >= rank_1,
         "Results should be sorted by rank descending: {rank_0} >= {rank_1}"
     );
-
 }
 
 // ============================================================================
@@ -626,7 +607,6 @@ async fn test_guild_search_sort_date(pool: PgPool) {
         date_0 > date_1,
         "sort=date should return newest first: {date_0} > {date_1}"
     );
-
 }
 
 // ============================================================================
@@ -671,7 +651,6 @@ async fn test_guild_search_special_characters_no_error(pool: PgPool) {
             "'{label}' returned unexpected status {status} — expected 200 or 400"
         );
     }
-
 }
 
 /// A query longer than 1000 characters must be rejected with 400.
@@ -693,7 +672,6 @@ async fn test_guild_search_long_query_rejected(pool: PgPool) {
         400,
         "query of 1001 chars should be rejected with 400"
     );
-
 }
 
 /// A query of exactly 1000 characters must be accepted (boundary condition).
@@ -715,7 +693,6 @@ async fn test_guild_search_max_length_query_accepted(pool: PgPool) {
         200,
         "query of exactly 1000 chars should be accepted"
     );
-
 }
 
 /// Messages containing HTML/XSS payloads are returned verbatim in the `content`
@@ -751,7 +728,6 @@ async fn test_guild_search_xss_content_returned_verbatim(pool: PgPool) {
         !content.contains("&lt;"),
         "content field must not be HTML-escaped by the server; clients escape on render"
     );
-
 }
 
 // ============================================================================
@@ -835,7 +811,6 @@ async fn test_guild_search_large_result_set_pagination(pool: PgPool) {
         ids1.is_disjoint(&ids2),
         "page 1 and page 2 must not share any message IDs"
     );
-
 }
 
 // ============================================================================
@@ -973,7 +948,6 @@ async fn test_guild_search_excludes_hidden_channels(pool: PgPool) {
         visible_ch.to_string(),
         "result must be from the visible channel, not the restricted one"
     );
-
 }
 
 /// Guild owner bypasses channel permission overrides and can find messages in all channels.
@@ -1010,7 +984,6 @@ async fn test_guild_search_owner_sees_all_channels(pool: PgPool) {
         json["total"], 1,
         "guild owner must bypass channel permission overrides"
     );
-
 }
 
 /// A channel-level allow override for `VIEW_CHANNEL` grants search access
@@ -1063,7 +1036,6 @@ async fn test_guild_search_channel_allow_override_grants_access(pool: PgPool) {
         json["results"][0]["channel_id"].as_str().unwrap(),
         special_ch.to_string()
     );
-
 }
 
 /// When the user provides a `channel_id` filter for a channel they cannot view,
@@ -1100,7 +1072,6 @@ async fn test_guild_search_channel_filter_respects_visibility(pool: PgPool) {
         json["total"], 0,
         "filtering to a hidden channel must return 0 results to avoid info leakage"
     );
-
 }
 
 // ============================================================================
@@ -1125,5 +1096,4 @@ async fn test_dm_search_long_query_rejected(pool: PgPool) {
         400,
         "DM search query of 1001 chars should be rejected with 400"
     );
-
 }

--- a/server/tests/integration/voice_sfu.rs
+++ b/server/tests/integration/voice_sfu.rs
@@ -339,19 +339,8 @@ async fn test_room_remove_nonexistent_screen_share() {
 }
 
 // ============================================================================
-// Integration Tests (require database/WebRTC - marked as #[ignore])
+// Integration Tests (require WebRTC - marked as #[ignore])
 // ============================================================================
-
-/// Helper to create a test database pool.
-#[allow(dead_code)]
-async fn create_test_pool() -> sqlx::PgPool {
-    let database_url =
-        std::env::var("DATABASE_URL").unwrap_or_else(|_| "postgres://localhost/vc_test".into());
-
-    sqlx::PgPool::connect(&database_url)
-        .await
-        .expect("Failed to connect to test database")
-}
 
 #[tokio::test]
 #[ignore] // Requires PostgreSQL and WebRTC

--- a/server/tests/integration/webhooks.rs
+++ b/server/tests/integration/webhooks.rs
@@ -2,29 +2,28 @@
 
 use axum::body::Body;
 use axum::http::{Method, StatusCode};
+use sqlx::PgPool;
 use vc_server::config::Config;
 
 use super::helpers::*;
 
-async fn webhook_test_app() -> TestApp {
+async fn webhook_test_app(pool: PgPool) -> TestApp {
     let mut config = Config::default_for_test();
     config.mfa_encryption_key =
         Some("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f".to_string());
-    TestApp::with_config(config).await
+    TestApp::with_pool_and_config(pool, config).await
 }
 
 // ============================================================================
 // CRUD Tests
 // ============================================================================
 
-#[tokio::test]
-async fn create_webhook_returns_signing_secret() {
-    let app = webhook_test_app().await;
+#[sqlx::test]
+async fn create_webhook_returns_signing_secret(pool: PgPool) {
+    let app = webhook_test_app(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let (app_id, _, _) = create_bot_application(&app.pool, user_id).await;
     let token = generate_access_token(&app.config, user_id);
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     let body = serde_json::json!({
         "url": "https://example.com/webhook",
@@ -48,17 +47,14 @@ async fn create_webhook_returns_signing_secret() {
     assert_eq!(json["signing_secret"].as_str().unwrap().len(), 64);
     assert_eq!(json["url"], "https://example.com/webhook");
     assert_eq!(json["active"], true);
-    guard.cleanup().await;
 }
 
-#[tokio::test]
-async fn list_webhooks_does_not_return_secret() {
-    let app = webhook_test_app().await;
+#[sqlx::test]
+async fn list_webhooks_does_not_return_secret(pool: PgPool) {
+    let app = webhook_test_app(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let (app_id, _, _) = create_bot_application(&app.pool, user_id).await;
     let token = generate_access_token(&app.config, user_id);
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     // Create a webhook first
     create_test_webhook(
@@ -81,17 +77,14 @@ async fn list_webhooks_does_not_return_secret() {
     let list = json.as_array().unwrap();
     assert_eq!(list.len(), 1);
     assert!(list[0].get("signing_secret").is_none());
-    guard.cleanup().await;
 }
 
-#[tokio::test]
-async fn get_webhook_returns_details() {
-    let app = webhook_test_app().await;
+#[sqlx::test]
+async fn get_webhook_returns_details(pool: PgPool) {
+    let app = webhook_test_app(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let (app_id, _, _) = create_bot_application(&app.pool, user_id).await;
     let token = generate_access_token(&app.config, user_id);
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     let wh_id = create_test_webhook(
         &app.pool,
@@ -115,17 +108,14 @@ async fn get_webhook_returns_details() {
     let json = body_to_json(resp).await;
     assert_eq!(json["url"], "https://example.com/wh");
     assert_eq!(json["active"], true);
-    guard.cleanup().await;
 }
 
-#[tokio::test]
-async fn update_webhook_url_and_events() {
-    let app = webhook_test_app().await;
+#[sqlx::test]
+async fn update_webhook_url_and_events(pool: PgPool) {
+    let app = webhook_test_app(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let (app_id, _, _) = create_bot_application(&app.pool, user_id).await;
     let token = generate_access_token(&app.config, user_id);
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     let wh_id = create_test_webhook(
         &app.pool,
@@ -156,17 +146,14 @@ async fn update_webhook_url_and_events() {
     let json = body_to_json(resp).await;
     assert_eq!(json["url"], "https://example.com/new-url");
     assert_eq!(json["active"], false);
-    guard.cleanup().await;
 }
 
-#[tokio::test]
-async fn delete_webhook_succeeds() {
-    let app = webhook_test_app().await;
+#[sqlx::test]
+async fn delete_webhook_succeeds(pool: PgPool) {
+    let app = webhook_test_app(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let (app_id, _, _) = create_bot_application(&app.pool, user_id).await;
     let token = generate_access_token(&app.config, user_id);
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     let wh_id = create_test_webhook(
         &app.pool,
@@ -186,23 +173,19 @@ async fn delete_webhook_succeeds() {
 
     let resp = app.oneshot(req).await;
     assert_eq!(resp.status(), StatusCode::NO_CONTENT);
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // Ownership Tests
 // ============================================================================
 
-#[tokio::test]
-async fn non_owner_cannot_manage_webhooks() {
-    let app = webhook_test_app().await;
+#[sqlx::test]
+async fn non_owner_cannot_manage_webhooks(pool: PgPool) {
+    let app = webhook_test_app(pool.clone()).await;
     let (owner_id, _) = create_test_user(&app.pool).await;
     let (other_id, _) = create_test_user(&app.pool).await;
     let (app_id, _, _) = create_bot_application(&app.pool, owner_id).await;
     let other_token = generate_access_token(&app.config, other_id);
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(owner_id);
-    guard.delete_user(other_id);
 
     let body = serde_json::json!({
         "url": "https://example.com/webhook",
@@ -220,21 +203,18 @@ async fn non_owner_cannot_manage_webhooks() {
 
     let resp = app.oneshot(req).await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // Validation Tests
 // ============================================================================
 
-#[tokio::test]
-async fn invalid_url_rejected() {
-    let app = webhook_test_app().await;
+#[sqlx::test]
+async fn invalid_url_rejected(pool: PgPool) {
+    let app = webhook_test_app(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let (app_id, _, _) = create_bot_application(&app.pool, user_id).await;
     let token = generate_access_token(&app.config, user_id);
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     let body = serde_json::json!({
         "url": "not-a-url",
@@ -252,17 +232,14 @@ async fn invalid_url_rejected() {
 
     let resp = app.oneshot(req).await;
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-    guard.cleanup().await;
 }
 
-#[tokio::test]
-async fn empty_events_rejected() {
-    let app = webhook_test_app().await;
+#[sqlx::test]
+async fn empty_events_rejected(pool: PgPool) {
+    let app = webhook_test_app(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let (app_id, _, _) = create_bot_application(&app.pool, user_id).await;
     let token = generate_access_token(&app.config, user_id);
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     let body = serde_json::json!({
         "url": "https://example.com/webhook",
@@ -280,17 +257,14 @@ async fn empty_events_rejected() {
 
     let resp = app.oneshot(req).await;
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-    guard.cleanup().await;
 }
 
-#[tokio::test]
-async fn max_5_webhooks_enforced() {
-    let app = webhook_test_app().await;
+#[sqlx::test]
+async fn max_5_webhooks_enforced(pool: PgPool) {
+    let app = webhook_test_app(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let (app_id, _, _) = create_bot_application(&app.pool, user_id).await;
     let token = generate_access_token(&app.config, user_id);
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     // Create 5 webhooks
     for i in 0..5 {
@@ -320,21 +294,18 @@ async fn max_5_webhooks_enforced() {
 
     let resp = app.oneshot(req).await;
     assert_eq!(resp.status(), StatusCode::CONFLICT);
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // Delivery Log Test
 // ============================================================================
 
-#[tokio::test]
-async fn delivery_log_initially_empty() {
-    let app = webhook_test_app().await;
+#[sqlx::test]
+async fn delivery_log_initially_empty(pool: PgPool) {
+    let app = webhook_test_app(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let (app_id, _, _) = create_bot_application(&app.pool, user_id).await;
     let token = generate_access_token(&app.config, user_id);
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     let wh_id = create_test_webhook(
         &app.pool,
@@ -357,5 +328,4 @@ async fn delivery_log_initially_empty() {
 
     let json = body_to_json(resp).await;
     assert_eq!(json.as_array().unwrap().len(), 0);
-    guard.cleanup().await;
 }

--- a/server/tests/integration/websocket_integration.rs
+++ b/server/tests/integration/websocket_integration.rs
@@ -8,14 +8,12 @@ use vc_server::db;
 use vc_server::ws::{OutboundMsg, ServerEvent};
 
 // Mock WebSocket connection logic for testing
-#[tokio::test]
-async fn test_websocket_broadcast_flow() {
+#[sqlx::test]
+async fn test_websocket_broadcast_flow(pool: PgPool) {
     // 1. Setup Test Environment (DB, Redis, AppState)
     // Note: We need a real Redis and Postgres for this integration test
     let config = Config::default_for_test();
-    let db_pool: PgPool = db::create_pool(&config.database_url)
-        .await
-        .expect("Failed to connect to DB");
+    let db_pool: PgPool = pool;
     let redis = db::create_redis_client(&config.redis_url)
         .await
         .expect("Failed to connect to Redis");
@@ -170,13 +168,11 @@ struct PermissionTestContext {
 
 impl PermissionTestContext {
     /// Setup test environment with guild, roles, and users
-    async fn setup() -> Self {
+    async fn setup(pool: PgPool) -> Self {
         use vc_server::permissions::GuildPermissions;
 
         let config = Config::default_for_test();
-        let db_pool: PgPool = db::create_pool(&config.database_url)
-            .await
-            .expect("Failed to connect to DB");
+        let db_pool: PgPool = pool;
         let redis = db::create_redis_client(&config.redis_url)
             .await
             .expect("Failed to connect to Redis");
@@ -366,11 +362,11 @@ impl PermissionTestContext {
 }
 
 /// Test that WebSocket Subscribe is denied without `VIEW_CHANNEL` permission
-#[tokio::test]
-async fn test_websocket_subscribe_denied_without_permission() {
+#[sqlx::test]
+async fn test_websocket_subscribe_denied_without_permission(pool: PgPool) {
     use tokio::sync::mpsc;
 
-    let ctx = PermissionTestContext::setup().await;
+    let ctx = PermissionTestContext::setup(pool).await;
 
     let (tx, mut rx) = mpsc::channel(10);
     let subscribed_channels = Arc::new(tokio::sync::RwLock::new(std::collections::HashSet::new()));
@@ -422,11 +418,11 @@ async fn test_websocket_subscribe_denied_without_permission() {
 }
 
 /// Test that WebSocket Subscribe is allowed with `VIEW_CHANNEL` permission
-#[tokio::test]
-async fn test_websocket_subscribe_allowed_with_permission() {
+#[sqlx::test]
+async fn test_websocket_subscribe_allowed_with_permission(pool: PgPool) {
     use tokio::sync::mpsc;
 
-    let ctx = PermissionTestContext::setup().await;
+    let ctx = PermissionTestContext::setup(pool).await;
 
     let (tx, mut rx) = mpsc::channel(10);
     let subscribed_channels = Arc::new(tokio::sync::RwLock::new(std::collections::HashSet::new()));
@@ -476,11 +472,11 @@ async fn test_websocket_subscribe_allowed_with_permission() {
 }
 
 /// Test that guild owner can subscribe (owner bypass)
-#[tokio::test]
-async fn test_websocket_subscribe_owner_bypass() {
+#[sqlx::test]
+async fn test_websocket_subscribe_owner_bypass(pool: PgPool) {
     use tokio::sync::mpsc;
 
-    let ctx = PermissionTestContext::setup().await;
+    let ctx = PermissionTestContext::setup(pool).await;
 
     let (tx, mut rx) = mpsc::channel(10);
     let subscribed_channels = Arc::new(tokio::sync::RwLock::new(std::collections::HashSet::new()));

--- a/server/tests/integration/workspaces.rs
+++ b/server/tests/integration/workspaces.rs
@@ -3,8 +3,8 @@
 //! Run with: `cargo test --test integration workspaces -- --nocapture`
 
 use axum::body::Body;
-use sqlx::PgPool;
 use axum::http::Method;
+use sqlx::PgPool;
 
 use super::helpers::{
     body_to_json, create_channel, create_guild, create_test_user, generate_access_token, TestApp,
@@ -19,7 +19,6 @@ async fn test_create_workspace(pool: PgPool) {
     let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
-
 
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
         .header("Authorization", format!("Bearer {token}"))
@@ -48,7 +47,6 @@ async fn test_create_workspace_name_too_long(pool: PgPool) {
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-
     let long_name = "a".repeat(101);
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
         .header("Authorization", format!("Bearer {token}"))
@@ -67,7 +65,6 @@ async fn test_create_workspace_icon_too_long(pool: PgPool) {
     let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
-
 
     let long_icon = "x".repeat(65);
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
@@ -94,7 +91,6 @@ async fn test_create_workspace_unicode_name_length(pool: PgPool) {
     let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
-
 
     // 100 CJK characters (300 bytes in UTF-8) should be accepted
     let cjk_name: String = "你".repeat(100);
@@ -132,7 +128,6 @@ async fn test_create_workspace_empty_name(pool: PgPool) {
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
         .header("Authorization", format!("Bearer {token}"))
         .header("Content-Type", "application/json")
@@ -150,7 +145,6 @@ async fn test_create_workspace_limit_exceeded(pool: PgPool) {
     let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
-
 
     // Fill up to the limit via direct DB inserts
     let limit = app.config.max_workspaces_per_user;
@@ -186,7 +180,6 @@ async fn test_list_workspaces(pool: PgPool) {
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-
     // Create 3 workspaces
     for name in &["Alpha", "Beta", "Gamma"] {
         let req = TestApp::request(Method::POST, "/api/me/workspaces")
@@ -221,7 +214,6 @@ async fn test_list_workspaces_empty(pool: PgPool) {
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-
     let req = TestApp::request(Method::GET, "/api/me/workspaces")
         .header("Authorization", format!("Bearer {token}"))
         .body(Body::empty())
@@ -242,7 +234,6 @@ async fn test_get_workspace_with_entries(pool: PgPool) {
     let token = generate_access_token(&app.config, user_id);
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
-
 
     // Create workspace
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
@@ -293,7 +284,6 @@ async fn test_get_workspace_not_found(pool: PgPool) {
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-
     let fake_id = uuid::Uuid::new_v4();
     let req = TestApp::request(Method::GET, &format!("/api/me/workspaces/{fake_id}"))
         .header("Authorization", format!("Bearer {token}"))
@@ -340,7 +330,6 @@ async fn test_update_workspace(pool: PgPool) {
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-
     // Create
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
         .header("Authorization", format!("Bearer {token}"))
@@ -376,7 +365,6 @@ async fn test_update_workspace_clear_icon(pool: PgPool) {
     let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
-
 
     // Create with icon
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
@@ -440,7 +428,6 @@ async fn test_update_workspace_icon_too_long(pool: PgPool) {
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
         .header("Authorization", format!("Bearer {token}"))
         .header("Content-Type", "application/json")
@@ -473,7 +460,6 @@ async fn test_delete_workspace(pool: PgPool) {
     let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
-
 
     // Create
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
@@ -516,7 +502,6 @@ async fn test_add_entry(pool: PgPool) {
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "raids").await;
 
-
     // Create workspace
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
         .header("Authorization", format!("Bearer {token}"))
@@ -556,7 +541,6 @@ async fn test_add_entry_duplicate(pool: PgPool) {
     let token = generate_access_token(&app.config, user_id);
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "dup-test").await;
-
 
     // Create workspace
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
@@ -641,7 +625,6 @@ async fn test_add_entry_limit_exceeded(pool: PgPool) {
     let token = generate_access_token(&app.config, user_id);
     let guild_id = create_guild(&app.pool, user_id).await;
 
-
     // Create workspace
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
         .header("Authorization", format!("Bearer {token}"))
@@ -697,7 +680,6 @@ async fn test_remove_entry(pool: PgPool) {
     let token = generate_access_token(&app.config, user_id);
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "removable").await;
-
 
     // Create workspace + add entry
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
@@ -761,7 +743,6 @@ async fn test_reorder_entries(pool: PgPool) {
     let guild_id = create_guild(&app.pool, user_id).await;
     let ch1 = create_channel(&app.pool, guild_id, "ch-one").await;
     let ch2 = create_channel(&app.pool, guild_id, "ch-two").await;
-
 
     // Create workspace
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
@@ -828,7 +809,6 @@ async fn test_reorder_workspaces(pool: PgPool) {
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-
     // Create 3 workspaces
     let mut ws_ids = Vec::new();
     for name in &["First", "Second", "Third"] {
@@ -875,7 +855,6 @@ async fn test_reorder_entries_rejects_oversized_payload(pool: PgPool) {
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-
     let oversized = (0..=app.config.max_entries_per_workspace as usize)
         .map(|_| uuid::Uuid::new_v4().to_string())
         .collect::<Vec<_>>();
@@ -903,7 +882,6 @@ async fn test_reorder_workspaces_rejects_oversized_payload(pool: PgPool) {
     let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
-
 
     let oversized = (0..=app.config.max_workspaces_per_user as usize)
         .map(|_| uuid::Uuid::new_v4().to_string())

--- a/server/tests/integration/workspaces.rs
+++ b/server/tests/integration/workspaces.rs
@@ -3,6 +3,7 @@
 //! Run with: `cargo test --test integration workspaces -- --nocapture`
 
 use axum::body::Body;
+use sqlx::PgPool;
 use axum::http::Method;
 
 use super::helpers::{
@@ -13,14 +14,12 @@ use super::helpers::{
 // Workspace CRUD Tests
 // ============================================================================
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_create_workspace() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_create_workspace(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
         .header("Authorization", format!("Bearer {token}"))
@@ -41,17 +40,14 @@ async fn test_create_workspace() {
     assert_eq!(json["name"], "Gaming Setup");
     assert_eq!(json["icon"], "🎮");
     assert!(json["id"].is_string());
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_create_workspace_name_too_long() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_create_workspace_name_too_long(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     let long_name = "a".repeat(101);
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
@@ -64,17 +60,14 @@ async fn test_create_workspace_name_too_long() {
 
     let resp = app.oneshot(req).await;
     assert_eq!(resp.status(), 400, "Should reject name > 100 chars");
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_create_workspace_icon_too_long() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_create_workspace_icon_too_long(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     let long_icon = "x".repeat(65);
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
@@ -94,17 +87,14 @@ async fn test_create_workspace_icon_too_long() {
 
     let json = body_to_json(resp).await;
     assert_eq!(json["error"], "VALIDATION_ERROR");
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_create_workspace_unicode_name_length() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_create_workspace_unicode_name_length(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     // 100 CJK characters (300 bytes in UTF-8) should be accepted
     let cjk_name: String = "你".repeat(100);
@@ -134,17 +124,14 @@ async fn test_create_workspace_unicode_name_length() {
 
     let resp = app.oneshot(req).await;
     assert_eq!(resp.status(), 400, "101 Unicode chars should be rejected");
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_create_workspace_empty_name() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_create_workspace_empty_name(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
         .header("Authorization", format!("Bearer {token}"))
@@ -156,17 +143,14 @@ async fn test_create_workspace_empty_name() {
 
     let resp = app.oneshot(req).await;
     assert_eq!(resp.status(), 400, "Should reject empty/whitespace name");
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_create_workspace_limit_exceeded() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_create_workspace_limit_exceeded(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     // Fill up to the limit via direct DB inserts
     let limit = app.config.max_workspaces_per_user;
@@ -194,17 +178,14 @@ async fn test_create_workspace_limit_exceeded() {
 
     let json = body_to_json(resp).await;
     assert_eq!(json["error"], "LIMIT_EXCEEDED");
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_list_workspaces() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_list_workspaces(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     // Create 3 workspaces
     for name in &["Alpha", "Beta", "Gamma"] {
@@ -232,17 +213,14 @@ async fn test_list_workspaces() {
     let arr = json.as_array().expect("Should be an array");
     assert_eq!(arr.len(), 3, "Should have 3 workspaces");
     assert!(arr[0]["entry_count"].is_number());
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_list_workspaces_empty() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_list_workspaces_empty(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     let req = TestApp::request(Method::GET, "/api/me/workspaces")
         .header("Authorization", format!("Bearer {token}"))
@@ -255,19 +233,16 @@ async fn test_list_workspaces_empty() {
     let json = body_to_json(resp).await;
     let arr = json.as_array().expect("Should be an array");
     assert!(arr.is_empty(), "Should be empty");
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_get_workspace_with_entries() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_get_workspace_with_entries(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "general").await;
 
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     // Create workspace
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
@@ -310,17 +285,14 @@ async fn test_get_workspace_with_entries() {
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0]["channel_name"], "general");
     assert!(entries[0]["guild_name"].is_string());
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_get_workspace_not_found() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_get_workspace_not_found(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     let fake_id = uuid::Uuid::new_v4();
     let req = TestApp::request(Method::GET, &format!("/api/me/workspaces/{fake_id}"))
@@ -330,20 +302,15 @@ async fn test_get_workspace_not_found() {
 
     let resp = app.oneshot(req).await;
     assert_eq!(resp.status(), 404);
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_get_workspace_not_owner() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_get_workspace_not_owner(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user1_id, _) = create_test_user(&app.pool).await;
     let (user2_id, _) = create_test_user(&app.pool).await;
     let token1 = generate_access_token(&app.config, user1_id);
     let token2 = generate_access_token(&app.config, user2_id);
-
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user1_id);
-    guard.delete_user(user2_id);
 
     // User1 creates a workspace
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
@@ -365,17 +332,14 @@ async fn test_get_workspace_not_owner() {
 
     let resp = app.oneshot(req).await;
     assert_eq!(resp.status(), 404, "Other user should get 404");
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_update_workspace() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_update_workspace(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     // Create
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
@@ -405,17 +369,14 @@ async fn test_update_workspace() {
     let json = body_to_json(resp).await;
     assert_eq!(json["name"], "New Name");
     assert_eq!(json["icon"], "🎯");
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_update_workspace_clear_icon() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_update_workspace_clear_icon(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     // Create with icon
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
@@ -471,17 +432,14 @@ async fn test_update_workspace_clear_icon() {
     let json = body_to_json(resp).await;
     assert_eq!(json["name"], "Renamed");
     assert_eq!(json["icon"], "🔧", "Icon should be unchanged when omitted");
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_update_workspace_icon_too_long() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_update_workspace_icon_too_long(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
         .header("Authorization", format!("Bearer {token}"))
@@ -508,17 +466,14 @@ async fn test_update_workspace_icon_too_long() {
 
     let json = body_to_json(resp).await;
     assert_eq!(json["error"], "VALIDATION_ERROR");
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_delete_workspace() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_delete_workspace(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     // Create
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
@@ -547,23 +502,20 @@ async fn test_delete_workspace() {
         .unwrap();
     let resp = app.oneshot(req).await;
     assert_eq!(resp.status(), 404, "Should be gone");
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // Entry Tests
 // ============================================================================
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_add_entry() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_add_entry(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "raids").await;
 
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     // Create workspace
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
@@ -595,19 +547,16 @@ async fn test_add_entry() {
     let json = body_to_json(resp).await;
     assert_eq!(json["channel_name"], "raids");
     assert!(json["guild_name"].is_string());
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_add_entry_duplicate() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_add_entry_duplicate(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "dup-test").await;
 
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     // Create workspace
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
@@ -644,12 +593,11 @@ async fn test_add_entry_duplicate() {
         .unwrap();
     let resp = app.oneshot(req).await;
     assert_eq!(resp.status(), 409, "Should reject duplicate entry");
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_add_entry_no_guild_membership() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_add_entry_no_guild_membership(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let (other_user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
@@ -657,10 +605,6 @@ async fn test_add_entry_no_guild_membership() {
     // Other user's guild — user_id is NOT a member
     let guild_id = create_guild(&app.pool, other_user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "secret").await;
-
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
-    guard.delete_user(other_user_id);
 
     // Create workspace
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
@@ -688,18 +632,15 @@ async fn test_add_entry_no_guild_membership() {
         .unwrap();
     let resp = app.oneshot(req).await;
     assert_eq!(resp.status(), 404, "Should reject non-member");
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_add_entry_limit_exceeded() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_add_entry_limit_exceeded(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
     let guild_id = create_guild(&app.pool, user_id).await;
 
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     // Create workspace
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
@@ -747,19 +688,16 @@ async fn test_add_entry_limit_exceeded() {
 
     let json = body_to_json(resp).await;
     assert_eq!(json["error"], "LIMIT_EXCEEDED");
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_remove_entry() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_remove_entry(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
     let guild_id = create_guild(&app.pool, user_id).await;
     let channel_id = create_channel(&app.pool, guild_id, "removable").await;
 
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     // Create workspace + add entry
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
@@ -809,24 +747,21 @@ async fn test_remove_entry() {
     let json = body_to_json(resp).await;
     let entries = json["entries"].as_array().unwrap();
     assert!(entries.is_empty(), "Should have no entries after removal");
-    guard.cleanup().await;
 }
 
 // ============================================================================
 // Reorder Tests
 // ============================================================================
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_reorder_entries() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_reorder_entries(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
     let guild_id = create_guild(&app.pool, user_id).await;
     let ch1 = create_channel(&app.pool, guild_id, "ch-one").await;
     let ch2 = create_channel(&app.pool, guild_id, "ch-two").await;
 
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     // Create workspace
     let req = TestApp::request(Method::POST, "/api/me/workspaces")
@@ -885,17 +820,14 @@ async fn test_reorder_entries() {
     let entries = json["entries"].as_array().unwrap();
     assert_eq!(entries[0]["channel_name"], "ch-two");
     assert_eq!(entries[1]["channel_name"], "ch-one");
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_reorder_workspaces() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_reorder_workspaces(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
     // Create 3 workspaces
     let mut ws_ids = Vec::new();
@@ -935,19 +867,16 @@ async fn test_reorder_workspaces() {
     assert_eq!(arr[0]["name"], "Third");
     assert_eq!(arr[1]["name"], "Second");
     assert_eq!(arr[2]["name"], "First");
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_reorder_entries_rejects_oversized_payload() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_reorder_entries_rejects_oversized_payload(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
-    let oversized = (0..(app.config.max_entries_per_workspace as usize + 1))
+    let oversized = (0..=app.config.max_entries_per_workspace as usize)
         .map(|_| uuid::Uuid::new_v4().to_string())
         .collect::<Vec<_>>();
 
@@ -967,19 +896,16 @@ async fn test_reorder_entries_rejects_oversized_payload() {
 
     let json = body_to_json(resp).await;
     assert_eq!(json["error"], "VALIDATION_ERROR");
-    guard.cleanup().await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_reorder_workspaces_rejects_oversized_payload() {
-    let app = TestApp::new().await;
+#[sqlx::test]
+async fn test_reorder_workspaces_rejects_oversized_payload(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
     let (user_id, _) = create_test_user(&app.pool).await;
     let token = generate_access_token(&app.config, user_id);
 
-    let mut guard = app.cleanup_guard();
-    guard.delete_user(user_id);
 
-    let oversized = (0..(app.config.max_workspaces_per_user as usize + 1))
+    let oversized = (0..=app.config.max_workspaces_per_user as usize)
         .map(|_| uuid::Uuid::new_v4().to_string())
         .collect::<Vec<_>>();
 
@@ -996,5 +922,4 @@ async fn test_reorder_workspaces_rejects_oversized_payload() {
 
     let json = body_to_json(resp).await;
     assert_eq!(json["error"], "VALIDATION_ERROR");
-    guard.cleanup().await;
 }


### PR DESCRIPTION
## Summary

Phase 4 (final batch) of the integration-test migration to `#[sqlx::test]`'s per-test DB isolation. All DB-using integration tests now run on per-test databases cloned from a template, eliminating the shared-pool mutex contention that caused intermittent 40P01 (`deadlock_detected`) flakes — most prominently in `search_http.rs`.

## Migrated files (14 planned + 2 incidental)

Per the phase plan (`docs/superpowers/plans/2026-04-18-phase4-batch-c-social-search-misc.md`):

1. `bot_ecosystem.rs` — 21 `TestApp::new` tests
2. `bot_intents.rs` — 10 tests (6 HTTP + 4 pure in-memory intent-logic tests kept on `#[sqlx::test]` with `_pool` unused)
3. `guild_invite.rs` — 12 `#[ignore]`'d scaffolding tests, `create_test_pool` helper removed
4. `guild_limits.rs` — 11 `TestApp::with_config` tests, swapped to `TestApp::with_pool_and_config`
5. `mention_permission.rs` — already on `#[sqlx::test]` since PR #274; verified, no changes
6. `search.rs` — 6 `#[tokio::test] #[ignore]` direct-DB tests, `create_test_pool` + `cleanup_test_data` helpers removed
7. **`search_http.rs` — 30 HTTP search tests** (the long-running 40P01 flake source)
8. `global_search_http.rs` — 20 HTTP global-search tests
9. `e2ee_keys.rs` — 11 `#[ignore]`'d DB tests, `create_test_pool` + `cleanup_test_user` helpers removed
10. `filters_http.rs` — 17 tests annotated `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]` (dropped per Phase 2/3 precedent)
11. `webhooks.rs` — 10 tests; `webhook_test_app` helper now takes `pool`
12. `websocket_integration.rs` — 4 tests; inline `db::create_pool(...)` replaced with injected pool; `PermissionTestContext::setup` now takes `pool`
13. `workspaces.rs` — 24 tests annotated with `multi_thread` flavor (dropped); opportunistic `range_plus_one` clippy fix applied
14. `connectivity_http.rs` — 10 tests, including multi-line `guard.add` closure blocks removed

Incidental cleanups:
- `pages.rs` — 3 `#[tokio::test] #[ignore]` DB-using tests (missed from Task list but DB-using per the invariant rule). Migrated.
- `voice_sfu.rs` — removed dead `create_test_pool` helper (its `#[ignore]`'d tests are actually pure in-memory, not DB-using).

## Retained `#[tokio::test]` carve-outs (documented)

These files keep `#[tokio::test]` by design because every remaining annotated test is **pure in-memory** (no `PgPool`, no `TestApp`, no `sqlx::query` against a test-owned pool):

- `voice_rate_limit.rs` — 5 `VoiceRateLimiter` tests (uses `start_paused = true`)
- `voice_sfu.rs` — 15 `Room`/`ParticipantInfo`/`SfuServer` tests (incl. 5 `#[ignore]`'d WebRTC-only tests)
- `voice_mute_enforcement.rs` — 4 mute-state tests
- `screenshare.rs` — 5 in-memory `Room` multi-stream tests (the 7 HTTP tests already on `#[sqlx::test]`)
- `oidc.rs` — 4 in-memory `OidcProviderManager` tests (the 5 DB tests migrated in Phase 3)
- `ratelimit.rs` — 13 `#[tokio::test] #[ignore]` pure Redis / no DB tests

After this PR merges: every DB-using integration test in `server/tests/integration/` runs on `#[sqlx::test]`. `shared_pool` is still referenced by the no-arg `TestApp::new()` etc. delegates — Phase 5 deletes those delegates and the helper.

## Test plan

- [x] `cargo check -p vc-server --tests` — green
- [x] `cargo +nightly fmt --all -- --check` — green (one `style(test): apply rustfmt` commit)
- [x] `cargo clippy --all-features --workspace --exclude vc-client -- -D warnings` (non-test) — green
- [x] `cargo deny check advisories` — green
- [x] `cargo deny check licenses` — green
- [ ] CI `Rust Tests` — expected to finally stop firing 40P01 flakes

Note: local `cargo clippy --tests` (toolchain 1.93.1) flags one `uninlined_format_args` in `media_processing.rs:395`; that file was last touched in Phase 2 (`023c07c`) and CI at that commit passed. It's a local-toolchain-only signal, out of scope for this PR.

## Follow-ups

Phase 5 deletes `shared_pool`, `SHARED_POOL`, the no-arg `TestApp::new()` delegates, `[test-groups]` serialization, and the remaining `#[serial]` attributes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)