### PR TITLE
chore(infra): sqlx::test migration Phase 5 — delete legacy path + update docs

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,17 +3,3 @@
 slow-timeout = { period = "120s", terminate-after = 1 }
 # Continue running other tests even if one fails or times out
 fail-fast = false
-
-# Cross-process serialization for tests that mutate the singleton
-# `server_config.setup_complete` row. Each nextest test runs in its own process,
-# so the in-process `#[serial(setup)]` lock from `serial_test` does NOT serialize
-# tests across processes. Without this group, two parallel processes can both
-# call `set_setup_complete(false)` and then race their CAS UPDATE against each
-# other, producing 5×403 (or any-x-403) instead of the expected 1×204.
-# See issue #509.
-[test-groups]
-setup-state = { max-threads = 1 }
-
-[[profile.default.overrides]]
-filter = 'test(setup_http::) + test(setup_concurrent_http::)'
-test-group = 'setup-state'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Desktop client now displays remote screen shares via native VP8 decode
 
 ### Changed
+- Integration tests now use `#[sqlx::test]`'s per-test database isolation; the shared-pool model that produced sporadic Postgres deadlocks in CI is retired. Contributor-facing documentation is in `server/tests/AGENTS.md`.
 - Voice connections use dual PeerConnection architecture (publisher + subscriber) for reliable screen sharing and multi-user scalability
 - Screen sharing uses standard WebRTC `addTrack` negotiation instead of `replaceTrack` workarounds
 - Voice channel view uses tile-based grid with focus mode for screen shares and webcams

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7874,15 +7874,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7957,12 +7948,6 @@ dependencies = [
  "ring",
  "untrusted",
 ]
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sdp"
@@ -8393,32 +8378,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
  "darling 0.23.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "serial_test"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
-dependencies = [
- "futures-executor",
- "futures-util",
- "log",
- "once_cell",
- "parking_lot",
- "scc",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
-dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10769,7 +10728,6 @@ dependencies = [
  "rustls 0.23.37",
  "serde",
  "serde_json",
- "serial_test",
  "sha1",
  "sha2",
  "sqlx",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -130,7 +130,6 @@ tokio-util = { version = "0.7.18", features = ["io", "compat"] }
 
 [dev-dependencies]
 tokio-test = "0.4"
-serial_test = "3.2"
 http-body-util = "0.1"
 reqwest = { version = "0.12", features = ["json"] }
 

--- a/server/tests/AGENTS.md
+++ b/server/tests/AGENTS.md
@@ -3,84 +3,97 @@
 
 ## Purpose
 
-Integration tests for the Kaiku server. Tests API endpoints, WebSocket connections, and cross-service interactions with real database and Redis instances.
-
-## Key Files
-
-| File | Purpose |
-|------|---------|
-| `ratelimit_test.rs` | Comprehensive rate limiting tests (login, WebSocket, API endpoints) |
-| `websocket_integration_test.rs` | WebSocket connection lifecycle and message routing tests |
+Integration tests for the Kaiku server. Exercises HTTP handlers through
+the full axum router, WebSocket flows, and cross-service interactions
+against real PostgreSQL and Redis instances.
 
 ## For AI Agents
 
-### Test Environment Setup
+### Test environment setup
 
-Tests require running infrastructure:
+Tests require the dev infrastructure to be running:
 
 ```bash
-# Start test dependencies
-cd infra/compose && docker compose up -d
+# Start PostgreSQL, Valkey, RustFS (S3)
+podman compose -f docker-compose.dev.yml --profile storage up -d
 
-# Run integration tests
-cargo test -p vc-server --test '*'
+# Run the integration suite
+SQLX_OFFLINE=true cargo test -p vc-server --tests
 
-# Run specific test file
-cargo test -p vc-server --test ratelimit_test
+# Or a single test file
+cargo test -p vc-server --test integration setup_http
 ```
 
-### Test Database
+`DATABASE_URL` must point at the dev Postgres (`postgresql://voicechat:voicechat_dev@localhost:5433/voicechat`).
+`cargo sqlx prepare` populates `.sqlx/` so `SQLX_OFFLINE=true` works in CI.
 
-Integration tests use SQLx test fixtures:
-- Each test gets isolated database transaction
-- Rolled back after test completion
-- Defined via `#[sqlx::test]` attribute
+### Integration test pattern
 
-### Key Test Categories
-
-**Rate Limiting (`ratelimit_test.rs`):**
-- Login attempt limits
-- WebSocket connection limits
-- API endpoint rate limits
-- Sliding window behavior
-- IP-based and user-based limits
-
-**WebSocket (`websocket_integration_test.rs`):**
-- Connection establishment
-- Authentication handshake
-- Message routing
-- Reconnection handling
-- Error scenarios
-
-### Writing New Integration Tests
+Each integration test gets its own isolated PostgreSQL database via
+`#[sqlx::test]`:
 
 ```rust
 use sqlx::PgPool;
 
-#[sqlx::test(fixtures("users", "channels"))]
-async fn test_channel_access(pool: PgPool) {
-    // Test with seeded data
-    let app = create_test_app(pool).await;
+use crate::integration::helpers::{create_test_user, generate_access_token, TestApp};
 
-    // Make requests against app
-    let response = app.get("/api/channels").await;
+#[sqlx::test]
+async fn test_something(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
+    let (user_id, _) = create_test_user(&pool).await;
+    let token = generate_access_token(&app.config, user_id);
+
+    let response = app
+        .oneshot(
+            TestApp::request(Method::GET, "/api/users/me")
+                .header("Authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+
     assert_eq!(response.status(), 200);
 }
 ```
 
-### Test Fixtures Location
+Under the hood, `#[sqlx::test]` clones a template DB that already has
+all migrations applied, hands the test a fresh `PgPool` bound to that
+clone, and drops the clone after the test returns. There is **no shared
+state between tests**.
 
-SQL fixtures are in `server/seeds/` directory. Reference by name without extension.
+### Factory choice
 
-### Performance Considerations
+| Helper | When to use |
+|---|---|
+| `TestApp::with_pool(pool)` | Most tests — plain axum router against the injected pool. |
+| `TestApp::with_pool_and_screen_share_limiter(pool)` | Tests that hit `/screenshare/{check,start,stop}` — handlers need a `ScreenShareLimiter` wired against Redis, otherwise they return 500. |
+| `TestApp::with_pool_and_config(pool, config)` | Tests that need a non-default `Config` (e.g., custom rate limits, specific JWT expiries). |
+| `fresh_test_app_with_s3_and_pool(pool)` | Tests that exercise the file-upload handlers; returns `(TestApp, bucket_name)` with a unique RustFS bucket. Requires `canis-dev-rustfs` on `localhost:9000` and the `AWS_*` env vars. |
 
-- Integration tests are slower than unit tests
-- Run in parallel where possible
-- Use connection pooling
-- Clean up test data via transactions
+### Rules
+
+- Do **not** use `#[tokio::test]` for DB-using integration tests. The
+  handful of files that keep `#[tokio::test]` (`voice_rate_limit.rs`,
+  `voice_sfu.rs`, `voice_mute_enforcement.rs`, `screenshare.rs` pure-SFU
+  tests, `oidc.rs` pure in-memory tests, `ratelimit.rs` pure Redis
+  tests) are carve-outs that touch no DB and would waste a per-test DB.
+- Do **not** use `#[serial]` — per-test DB isolation is absolute, and
+  the `serial_test` dev-dep has been removed.
+- Do **not** reintroduce a shared `SHARED_POOL` / `shared_pool()` /
+  `shared_config()` helper. The `#[sqlx::test]` model replaces both.
+- Do **not** delete rows manually at test end — the test's DB is
+  dropped anyway.
+
+### SQL fixtures
+
+`#[sqlx::test(fixtures("users", "channels"))]` loads seed files from
+`server/tests/fixtures/`. Most tests build their state inline via
+helpers (`create_test_user`, `create_guild`, `insert_message`, …) and
+don't need fixture files.
 
 ## Dependencies
 
-- Test server infrastructure (PostgreSQL, Redis)
-- SQLx test framework
-- Server binary with test features enabled
+- PostgreSQL (`canis-dev-postgres`, port 5433)
+- Valkey / Redis (`canis-dev-valkey`, port 6379)
+- RustFS (`canis-dev-rustfs`, port 9000) — only for S3-enabled tests
+- SQLx's `#[sqlx::test]` macro

--- a/server/tests/integration/helpers/mod.rs
+++ b/server/tests/integration/helpers/mod.rs
@@ -3,9 +3,12 @@
 //! Provides `TestApp` for building and sending requests through the full axum router,
 //! plus utilities for user creation, admin grants, and JWT generation.
 //!
-//! ## Shared Resources
+//! ## Integration test pattern
 //!
-//! Use [`shared_pool()`] to avoid creating new connections per test.
+//! Integration tests use `#[sqlx::test]`; each test receives a fresh `PgPool`
+//! against an isolated database. Call [`TestApp::with_pool`] (or
+//! [`TestApp::with_pool_and_screen_share_limiter`] /
+//! [`TestApp::with_pool_and_config`]) to wire the axum router onto that pool.
 //!
 //! ## Cleanup Guards
 //!
@@ -28,7 +31,6 @@ use axum::http::{self, Method, Request, Response};
 use axum::Router;
 use http_body_util::BodyExt;
 use sqlx::PgPool;
-use tokio::sync::OnceCell;
 use tokio::task::JoinHandle;
 use tower::ServiceExt;
 use uuid::Uuid;
@@ -40,38 +42,6 @@ use vc_server::db;
 use vc_server::permissions::GuildPermissions;
 use vc_server::voice::screen_share::ScreenShareLimiter;
 use vc_server::voice::sfu::SfuServer;
-
-// ============================================================================
-// Shared resources (Issue #138)
-// ============================================================================
-
-/// Shared database pool across all tests in the same binary.
-static SHARED_POOL: OnceCell<PgPool> = OnceCell::const_new();
-
-/// Shared config across all tests in the same binary.
-static SHARED_CONFIG: OnceCell<Config> = OnceCell::const_new();
-
-/// Get or create a shared database pool.
-///
-/// Reuses a single pool across all test cases in the same binary,
-/// avoiding connection exhaustion from creating pools per-test.
-pub async fn shared_pool() -> &'static PgPool {
-    SHARED_POOL
-        .get_or_init(|| async {
-            let config = shared_config().await;
-            db::create_pool(&config.database_url)
-                .await
-                .expect("Failed to connect to test DB")
-        })
-        .await
-}
-
-/// Get or create a shared config.
-pub async fn shared_config() -> &'static Config {
-    SHARED_CONFIG
-        .get_or_init(|| async { Config::default_for_test() })
-        .await
-}
 
 // ============================================================================
 // Cleanup Guard (Issue #137)
@@ -262,7 +232,7 @@ impl TestApp {
     /// Pass a pool from `#[sqlx::test]`'s fixture. The returned `TestApp`
     /// owns `pool` for the duration of the test.
     pub async fn with_pool(pool: PgPool) -> Self {
-        let config = shared_config().await.clone();
+        let config = Config::default_for_test();
         let redis = db::create_redis_client(&config.redis_url)
             .await
             .expect("Failed to connect to test Redis");
@@ -291,19 +261,15 @@ impl TestApp {
         }
     }
 
-    /// Legacy no-arg constructor — delegates to [`Self::with_pool`] using the
-    /// shared process-global pool. Retained for tests not yet migrated to
-    /// `#[sqlx::test]`. Removed in Phase 5.
-    pub async fn new() -> Self {
-        Self::with_pool(shared_pool().await.clone()).await
-    }
-
-    /// Pool-injecting variant of [`Self::with_screen_share_limiter`].
+    /// Pool-injecting constructor wired with a real `ScreenShareLimiter`
+    /// backed by the shared Redis.
     ///
-    /// Pass a pool from `#[sqlx::test]`'s fixture; the returned `TestApp`
-    /// is wired with a real `ScreenShareLimiter` backed by the shared Redis.
+    /// Use this for screen share integration tests that call the
+    /// `/screenshare/check`, `/screenshare/start`, or `/screenshare/stop`
+    /// endpoints — those handlers return 500 when `screen_share_limiter`
+    /// is `None`.
     pub async fn with_pool_and_screen_share_limiter(pool: PgPool) -> Self {
-        let config = shared_config().await.clone();
+        let config = Config::default_for_test();
         let redis = db::create_redis_client(&config.redis_url)
             .await
             .expect("Failed to connect to test Redis");
@@ -338,21 +304,6 @@ impl TestApp {
         }
     }
 
-    /// Create a test app with a real `ScreenShareLimiter` backed by Redis.
-    ///
-    /// Use this for screen share integration tests that call the `/screenshare/check`,
-    /// `/screenshare/start`, or `/screenshare/stop` endpoints — those handlers return
-    /// 500 when `screen_share_limiter` is `None`.
-    ///
-    /// Legacy no-arg form — delegates to
-    /// [`Self::with_pool_and_screen_share_limiter`] using the shared
-    /// process-global pool. Removed in Phase 5.
-    pub async fn with_screen_share_limiter() -> Self {
-        Self::with_pool_and_screen_share_limiter(shared_pool().await.clone()).await
-    }
-
-    /// Pool-injecting variant of [`Self::with_config`].
-    ///
     /// Create a test app with a custom config and a caller-supplied pool
     /// (typically from `#[sqlx::test]`).
     pub async fn with_pool_and_config(pool: PgPool, config: Config) -> Self {
@@ -384,14 +335,6 @@ impl TestApp {
         }
     }
 
-    /// Create a test app with a custom config (for limit testing).
-    ///
-    /// Legacy no-arg form — delegates to [`Self::with_pool_and_config`]
-    /// using the shared process-global pool. Removed in Phase 5.
-    pub async fn with_config(config: Config) -> Self {
-        Self::with_pool_and_config(shared_pool().await.clone(), config).await
-    }
-
     /// Build an HTTP request with the given method and URI.
     pub fn request(method: Method, uri: &str) -> http::request::Builder {
         Request::builder().method(method).uri(uri)
@@ -415,18 +358,18 @@ impl TestApp {
 /// Build a [`TestApp`] with S3 connected to a local `RustFS` instance,
 /// using the provided pool.
 ///
-/// Pool-injecting variant of [`fresh_test_app_with_s3`] for tests that use
-/// `#[sqlx::test]` per-test database isolation.
+/// Pool-injecting helper for tests that use `#[sqlx::test]` per-test
+/// database isolation.
 ///
 /// Requires `canis-dev-rustfs` running on `localhost:9000`.
-/// Creates a unique test bucket per invocation and cleans it up on drop
-/// (via `CleanupGuard`).
+/// Creates a unique test bucket per invocation; callers are responsible
+/// for any bucket teardown they need.
 ///
 /// Environment variables must be set before calling:
 /// - `AWS_ACCESS_KEY_ID=rustfsdev`
 /// - `AWS_SECRET_ACCESS_KEY=rustfsdev_secret`
 pub async fn fresh_test_app_with_s3_and_pool(pool: PgPool) -> (TestApp, String) {
-    let mut config = shared_config().await.clone();
+    let mut config = Config::default_for_test();
     let bucket = format!("test-{}", Uuid::now_v7());
     config.s3_endpoint = Some("http://localhost:9000".to_string());
     config.s3_bucket = bucket.clone();
@@ -471,15 +414,6 @@ pub async fn fresh_test_app_with_s3_and_pool(pool: PgPool) -> (TestApp, String) 
     )
 }
 
-/// Build a [`TestApp`] with S3 connected to a local `RustFS` instance.
-///
-/// Legacy no-arg form — delegates to [`fresh_test_app_with_s3_and_pool`]
-/// using the shared process-global pool. Retained for tests not yet
-/// migrated to `#[sqlx::test]`. Removed in Phase 5.
-pub async fn fresh_test_app_with_s3() -> (TestApp, String) {
-    fresh_test_app_with_s3_and_pool(shared_pool().await.clone()).await
-}
-
 // ============================================================================
 // Test Server (Issue #139)
 // ============================================================================
@@ -503,11 +437,14 @@ pub struct TestServer {
 /// # Example
 ///
 /// ```ignore
-/// let app = TestApp::new().await;
-/// let server = spawn_test_server(app.router.clone()).await;
+/// #[sqlx::test]
+/// async fn my_server_test(pool: PgPool) {
+///     let app = TestApp::with_pool(pool.clone()).await;
+///     let server = spawn_test_server(app.router.clone()).await;
 ///
-/// let client = reqwest::Client::new();
-/// let resp = client.get(format!("{}/api/health", server.url)).send().await?;
+///     let client = reqwest::Client::new();
+///     let resp = client.get(format!("{}/api/health", server.url)).send().await?;
+/// }
 /// ```
 pub async fn spawn_test_server(router: Router) -> TestServer {
     use std::net::SocketAddr;

--- a/server/tests/integration/helpers/mod.rs
+++ b/server/tests/integration/helpers/mod.rs
@@ -10,19 +10,13 @@
 //! [`TestApp::with_pool_and_screen_share_limiter`] /
 //! [`TestApp::with_pool_and_config`]) to wire the axum router onto that pool.
 //!
-//! ## Cleanup Guards
-//!
-//! Use [`CleanupGuard`] for RAII-based cleanup that runs even if a test panics.
-//!
 //! ## Test Servers
 //!
 //! Use [`spawn_test_server()`] when you need stateful middleware testing
 //! (rate limiting, request IDs, etc.) instead of `tower::ServiceExt::oneshot`.
 #![allow(dead_code)]
 
-use std::future::Future;
 use std::net::SocketAddr;
-use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -42,169 +36,6 @@ use vc_server::db;
 use vc_server::permissions::GuildPermissions;
 use vc_server::voice::screen_share::ScreenShareLimiter;
 use vc_server::voice::sfu::SfuServer;
-
-// ============================================================================
-// Cleanup Guard (Issue #137)
-// ============================================================================
-
-/// Async cleanup action type.
-type CleanupAction = Box<dyn FnOnce(PgPool) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send>;
-
-/// RAII guard that runs cleanup actions on drop, even if the test panics.
-///
-/// # Example
-///
-/// ```ignore
-/// let mut guard = CleanupGuard::new(app.pool.clone());
-/// guard.delete_user(user_id);
-/// guard.restore_setup_complete(prev);
-///
-/// // Test assertions here — cleanup runs even if these panic
-/// assert_eq!(resp.status(), 200);
-/// // guard dropped here → cleanup runs
-/// ```
-pub struct CleanupGuard {
-    pool: PgPool,
-    actions: Vec<CleanupAction>,
-}
-
-impl CleanupGuard {
-    /// Create a new cleanup guard for the given pool.
-    pub fn new(pool: PgPool) -> Self {
-        Self {
-            pool,
-            actions: Vec::new(),
-        }
-    }
-
-    /// Register a generic async cleanup action.
-    pub fn add<F, Fut>(&mut self, action: F)
-    where
-        F: FnOnce(PgPool) -> Fut + Send + 'static,
-        Fut: Future<Output = ()> + Send + 'static,
-    {
-        self.actions
-            .push(Box::new(move |pool| Box::pin(action(pool))));
-    }
-
-    /// Register cleanup to delete a user by ID.
-    pub fn delete_user(&mut self, user_id: Uuid) {
-        self.add(move |pool| async move {
-            let _ = sqlx::query("DELETE FROM users WHERE id = $1")
-                .bind(user_id)
-                .execute(&pool)
-                .await;
-        });
-    }
-
-    /// Register cleanup to restore `setup_complete` to a previous value.
-    pub fn restore_setup_complete(&mut self, value: bool) {
-        self.add(move |pool| async move {
-            let _ = sqlx::query(
-                "UPDATE server_config SET value = $1::jsonb WHERE key = 'setup_complete'",
-            )
-            .bind(serde_json::json!(value))
-            .execute(&pool)
-            .await;
-        });
-    }
-
-    /// Register cleanup to restore default config values.
-    pub fn restore_config_defaults(&mut self) {
-        self.add(|pool| async move {
-            for (key, val) in [
-                ("server_name", serde_json::json!("Kaiku Server")),
-                ("registration_policy", serde_json::json!("open")),
-                ("terms_url", serde_json::Value::Null),
-                ("privacy_url", serde_json::Value::Null),
-            ] {
-                let _ = sqlx::query(
-                    "UPDATE server_config SET value = $1, updated_by = NULL WHERE key = $2",
-                )
-                .bind(val)
-                .bind(key)
-                .execute(&pool)
-                .await;
-            }
-        });
-    }
-
-    /// Run all registered cleanup actions on the caller's tokio runtime
-    /// and consume the guard.
-    ///
-    /// Tests MUST call this at the end of the test body. Forgetting it
-    /// triggers a runtime warning from the Drop fallback. The fallback
-    /// still runs the cleanup actions (so DB rows are not leaked), but
-    /// it does so on a fresh thread with a new tokio runtime — which
-    /// is the source of the original CI flake. After the migration
-    /// completes, the warning will be replaced with panic!() and any
-    /// forgotten cleanup will fail the test loudly.
-    pub async fn cleanup(mut self) {
-        let actions = std::mem::take(&mut self.actions);
-        let pool = self.pool.clone();
-        for action in actions {
-            action(pool.clone()).await;
-        }
-        // Drop runs after this returns, but `actions` is now empty so
-        // Drop is a no-op.
-    }
-}
-
-impl Drop for CleanupGuard {
-    fn drop(&mut self) {
-        let actions = std::mem::take(&mut self.actions);
-        if actions.is_empty() {
-            return;
-        }
-
-        // Migration signal: test forgot to call .cleanup().await. We still
-        // run cleanup so we don't leak DB rows, but the warning makes the
-        // unmigrated test visible. Replaced with panic!() in a follow-up
-        // commit after migration completes.
-        eprintln!(
-            "warning: CleanupGuard dropped with {} pending actions — \
-             test forgot to call .cleanup().await",
-            actions.len()
-        );
-
-        let pool = self.pool.clone();
-        let handle = std::thread::spawn(move || {
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("Failed to create cleanup runtime");
-            runtime.block_on(async move {
-                for action in actions {
-                    action(pool.clone()).await;
-                }
-            });
-        });
-
-        // Bounded join: poll for up to 30s, then detach if still running.
-        // Prevents flaky cleanup hangs from triggering nextest's 120s slow-timeout.
-        // Tradeoff: panics in the detached thread (timeout path) are silently
-        // discarded. Happy-path joins still propagate panics via .expect().
-        // Kept as a safety net for tests that panic before reaching
-        // .cleanup().await (RAII semantics). Removed only when the Drop
-        // fallback itself becomes panic!() (Layer 3 follow-up).
-        let timeout = std::time::Duration::from_secs(30);
-        let start = std::time::Instant::now();
-        loop {
-            if handle.is_finished() {
-                handle.join().expect("cleanup thread panicked");
-                return;
-            }
-            if start.elapsed() > timeout {
-                eprintln!(
-                    "warning: CleanupGuard did not complete within {timeout:?}, \
-                     detaching thread to allow test to finish"
-                );
-                return;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(50));
-        }
-    }
-}
 
 pub async fn rustfs_available() -> bool {
     tokio::time::timeout(
@@ -347,11 +178,6 @@ impl TestApp {
             .oneshot(request)
             .await
             .expect("oneshot request failed")
-    }
-
-    /// Create a [`CleanupGuard`] for this app's pool.
-    pub fn cleanup_guard(&self) -> CleanupGuard {
-        CleanupGuard::new(self.pool.clone())
     }
 }
 


### PR DESCRIPTION
## Summary

Final phase of the integration-test migration to `#[sqlx::test]`. Deletes the shared-pool legacy path now that every integration test uses per-test DB isolation.

Changes:
- Delete `SHARED_POOL`/`shared_pool()`, `SHARED_CONFIG`/`shared_config()`, and the legacy no-arg `TestApp::new()` / `TestApp::with_screen_share_limiter()` / `TestApp::with_config()` / `fresh_test_app_with_s3()` wrappers. The pool-injecting forms now build `Config::default_for_test()` per call.
- Delete `CleanupGuard` entirely. All its methods were DB-row cleanup (`delete_user`, `restore_setup_complete`, `restore_config_defaults`); with per-test DBs dropped after each test, they are redundant. Phase 2-4 already removed every caller.
- Remove `[test-groups].setup-state` from `.config/nextest.toml`. Previously needed to cross-process-serialize tests mutating the singleton `server_config.setup_complete` row (issue #509); per-test DBs obsolete the serialization.
- Drop the `serial_test` dev-dep. No test still imports it or uses `#[serial]`.
- Rewrite `server/tests/AGENTS.md` to document `#[sqlx::test]` as canonical, table the four `TestApp` factories, list the 6 `#[tokio::test]` carve-out files that do not touch the DB, and explicitly warn against reintroducing `SHARED_POOL` / `#[serial]`.
- CHANGELOG `### Changed` entry under `[Unreleased]`.

Spec: `docs/superpowers/specs/2026-04-18-sqlx-test-integration-migration-design.md` — Phase 5.
Plan: `docs/superpowers/plans/2026-04-18-phase5-legacy-deletion.md`.

## Test plan

- [x] `grep -rn 'shared_pool\|SHARED_POOL\|shared_config\|SHARED_CONFIG' server/tests/` returns only the "do not reintroduce" warnings in `server/tests/AGENTS.md` — no code references.
- [x] `grep -rn '#\[serial\]\|use serial_test' server/tests/` returns only the "do not use" warning in `server/tests/AGENTS.md`.
- [x] `.config/nextest.toml` no longer has `[test-groups]`.
- [x] `SQLX_OFFLINE=true cargo check -p vc-server --tests` green.
- [x] `cargo +nightly fmt --all -- --check` green.
- [x] `SQLX_OFFLINE=true cargo clippy --all-features --workspace --exclude vc-client -- -D warnings` green.
- [x] `cargo deny check advisories` and `cargo deny check licenses` green.
- [ ] Full integration test suite passes on CI under the project's standard `-j` parallelism.

## Expected post-merge outcome

- `test_guild_search_xss_content_returned_verbatim` (the most-frequently-observed flake in this workstream) runs cleanly under parallel execution.
- Zero `40P01` (deadlock_detected) occurrences in `main` CI logs going forward. To be verified by observing `main` for 1 week post-merge; any residual flake indicates a different shared resource (e.g. Redis) and should be tracked as a new issue rather than a revert of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)