### PR TITLE
fix(infra): drop legacy rustls 0.21 chain via aws-sdk-s3 default-https-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Android: TLS 1.3 provider failure now prompts users to update Play Services instead of failing silently on every network call
 - Self-muted users' audio is now actually dropped at the server rather than being forwarded to listeners
 - Voice signaling events are rate-limited per peer to prevent flooding
+- Removed legacy `rustls 0.21` / `rustls-webpki 0.101.7` from server dependencies by switching AWS SDK feature to `default-https-client`, fixing RUSTSEC-2026-0098, RUSTSEC-2026-0099, and RUSTSEC-2026-0104 (rustls-webpki name-constraint handling bugs and CRL parsing panic)
 
 ### Fixed
 - Android: `AuthState`'s `CoroutineScope` is now DI-provided via `@AuthCoroutineScope`, resolving 8 failing unit/integration tests (`AuthStateTest`, `AuthFlowTest`, `QrLoginFlowTest`) that previously read stale `StateFlow` values under `TestCoroutineScheduler`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,23 +987,17 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "h2 0.3.27",
- "h2 0.4.13",
- "http 0.2.12",
+ "h2",
  "http 1.4.0",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper 1.8.1",
- "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.21.12",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower",
  "tracing",
 ]
@@ -1151,7 +1145,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -3810,25 +3804,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.13.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
@@ -4067,30 +4042,6 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -4099,7 +4050,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -4114,33 +4065,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "log",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
  "webpki-roots",
 ]
@@ -4151,7 +4087,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -4166,7 +4102,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -4186,7 +4122,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -7047,7 +6983,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.37",
+ "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
@@ -7068,7 +7004,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -7414,12 +7350,12 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -7429,7 +7365,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -7437,7 +7373,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -7460,12 +7396,12 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -7475,7 +7411,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -7483,7 +7419,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -7735,18 +7671,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
@@ -7756,7 +7680,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -7794,10 +7718,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.37",
+ "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
@@ -7809,16 +7733,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -7938,16 +7852,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "sdp"
@@ -9812,21 +9716,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls",
  "tokio",
 ]
 
@@ -9995,7 +9889,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -10725,7 +10619,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "reqwest 0.12.28",
- "rustls 0.23.37",
+ "rustls",
  "serde",
  "serde_json",
  "sha1",
@@ -11131,7 +11025,7 @@ dependencies = [
  "ring",
  "rtcp",
  "rtp",
- "rustls 0.23.37",
+ "rustls",
  "sdp",
  "serde",
  "serde_json",
@@ -11193,7 +11087,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rcgen",
  "ring",
- "rustls 0.23.37",
+ "rustls",
  "sec1",
  "serde",
  "sha1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,8 +97,8 @@ tracing-opentelemetry = { version = "0.32" }
 tracing-opentelemetry-instrumentation-sdk = { version = "0.32" }
 
 # S3
-aws-sdk-s3 = { version = "1", default-features = false, features = ["behavior-version-latest", "rustls"] }
-aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "rustls"] }
+aws-sdk-s3 = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client"] }
+aws-config = { version = "1", default-features = false, features = ["behavior-version-latest", "default-https-client"] }
 aws-smithy-async = { version = "1", features = ["rt-tokio"] }
 aws-smithy-types = { version = "1", features = ["rt-tokio"] }
 

--- a/deny.toml
+++ b/deny.toml
@@ -24,18 +24,6 @@ ignore = [
     # would not remove the transitive 0.8.5 and would require breaking API
     # changes (thread_rng → rng, gen_range → random_range).
     "RUSTSEC-2026-0097",
-    # rustls-webpki 0.101.7 vulnerabilities (name-constraint handling bugs and
-    # CRL parsing panic) - pulled transitively via aws-smithy-http-client 1.1.12
-    # → rustls 0.21.12 → rustls-webpki 0.101.7. Upstream fixes exist only in
-    # rustls-webpki >=0.103.13; no 0.101.x patch is available. Our modern
-    # rustls 0.23.x chain (Tauri, reqwest, sentry, rustls-native-certs,
-    # rustls-platform-verifier) is on 0.103.13 (see Cargo.lock). RUSTSEC-2026-0104
-    # specifically requires CRL parsing, which the AWS S3 client does not perform.
-    # The 0.101.7 instance will remain until aws-smithy-http-client upgrades to
-    # rustls 0.23.x; revisit when that upgrade lands.
-    "RUSTSEC-2026-0098",
-    "RUSTSEC-2026-0099",
-    "RUSTSEC-2026-0104",
 ]
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Switches `aws-sdk-s3` and `aws-config` workspace deps from feature `rustls` (legacy alias → `aws-smithy-runtime/tls-rustls` → `legacy-rustls-ring`) to feature `default-https-client` (modern path → `rustls-aws-lc` on rustls 0.23.x), eliminating the entire `rustls 0.21.12` / `rustls-webpki 0.101.7` chain from the dependency tree.
- Resolves the three rustls-webpki advisories that have been failing the **Rust Security Audit** job on `main` since 2026-04-19 (RUSTSEC-2026-0098, 0099, 0104) — name-constraint handling bugs and CRL parsing panic. Per the comment added in #536, this was the planned remediation once an upgrade path opened up; `default-https-client` is exactly that path, exposed as a stable feature on the AWS SDK.
- Removes the now-obsolete `deny.toml` ignores for those three advisories. Keeps `RUSTSEC-2026-0097` (rand) and `RUSTSEC-2023-0071` (rsa) — those are unchanged.

### Crates dropped from `Cargo.lock`
`rustls 0.21.12`, `rustls-webpki 0.101.7`, `hyper 0.14.32`, `hyper-rustls 0.24.2`, `tokio-rustls 0.24.1`, `h2 0.3.27`, `sct 0.7.1`.

### Crypto provider note
The modern path activates `rustls/aws_lc_rs` (via `rustls-aws-lc`) in addition to the workspace's existing `rustls/ring` direct dep. The server explicitly installs `ring` as the default provider in `server/src/main.rs:16`, and AWS Smithy's modern HTTPS client constructs its own configs against `aws_lc_rs` directly — so both providers coexist as designed in rustls 0.23. Binary size grows modestly to accommodate the additional provider; no runtime config change required.

## Test plan
- [x] `cargo tree -i rustls-webpki:0.101.7` returns no matches (legacy chain gone)
- [x] `SQLX_OFFLINE=true cargo check -p vc-server` passes
- [x] `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo audit --ignore RUSTSEC-2025-0008 --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0002 --ignore RUSTSEC-2026-0009` exits 0 with no hard vulnerabilities (only the 26 expected unmaintained-crate warnings)
- [x] `cargo deny check advisories` → `advisories ok`
- [x] `cargo deny check licenses` → `licenses ok`
- [ ] Smoke-test S3 path post-merge against RustFS in `kaiku.pmind.de` staging (worth a deliberate avatar/attachment upload to confirm the modern AWS HTTP client behaves identically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)