### PR TITLE
fix(client): Phase 2 — clear uuid + dompurify advisories via overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Self-muted users' audio is now actually dropped at the server rather than being forwarded to listeners
 - Voice signaling events are rate-limited per peer to prevent flooding
 - Removed legacy `rustls 0.21` / `rustls-webpki 0.101.7` from server dependencies by switching AWS SDK feature to `default-https-client`, fixing RUSTSEC-2026-0098, RUSTSEC-2026-0099, and RUSTSEC-2026-0104 (rustls-webpki name-constraint handling bugs and CRL parsing panic)
+- Frontend: bumped `dompurify` (XSS in HTML sanitization), `uuid` (buffer-bounds check via mermaid), and added transitive overrides for `postcss` (XSS) and `dompurify` (mermaid's nested copy). `bun audit` reduced from 12 → 6 advisories; the 6 remaining are vite dev-server paths via vitest, already accepted as dev-only exceptions per PR #517 and pending the vitest 4.x → 4.x compat work in Phase 6c of the dep-update sweep.
 
 ### Fixed
 - Android: `AuthState`'s `CoroutineScope` is now DI-provided via `@AuthCoroutineScope`, resolving 8 failing unit/integration tests (`AuthStateTest`, `AuthFlowTest`, `QrLoginFlowTest`) that previously read stale `StateFlow` values under `TestCoroutineScheduler`

--- a/client/bun.lock
+++ b/client/bun.lock
@@ -51,10 +51,13 @@
   "overrides": {
     "brace-expansion": "^1.1.13 || ^5.0.6",
     "defu": "^6.1.7",
+    "dompurify": "^3.4.2",
     "flatted": "^3.4.2",
     "lodash-es": "^4.18.1",
     "picomatch": "^4.0.4",
+    "postcss": "^8.5.10",
     "rollup": "^4.60.3",
+    "uuid": "^11.1.1",
   },
   "packages": {
     "@acemir/cssom": ["@acemir/cssom@0.9.31", "", {}, "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA=="],
@@ -1041,7 +1044,7 @@
 
     "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
-    "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
+    "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
@@ -1175,7 +1178,7 @@
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
-    "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+    "uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
 
     "vite": ["vite@8.0.0", "", { "dependencies": { "@oxc-project/runtime": "0.115.0", "lightningcss": "^1.32.0", "picomatch": "^4.0.3", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.9", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.0.0-alpha.31", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q=="],
 
@@ -1346,8 +1349,6 @@
     "typescript-eslint/@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.59.2", "", { "dependencies": { "@typescript-eslint/types": "8.59.2", "@typescript-eslint/visitor-keys": "8.59.2" } }, "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg=="],
 
     "typescript-eslint/@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.59.2", "", {}, "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q=="],
-
-    "vitest/vite/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "yargs/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 

--- a/client/package.json
+++ b/client/package.json
@@ -64,6 +64,9 @@
     "flatted": "^3.4.2",
     "brace-expansion": "^1.1.13 || ^5.0.6",
     "lodash-es": "^4.18.1",
-    "defu": "^6.1.7"
+    "defu": "^6.1.7",
+    "postcss": "^8.5.10",
+    "uuid": "^11.1.1",
+    "dompurify": "^3.4.2"
   }
 }


### PR DESCRIPTION
## Summary

Phase 2 of the dep-update sweep ([spec](docs/superpowers/specs/2026-05-08-dependency-update-design.md), [plan](docs/superpowers/plans/2026-05-08-dependency-update-implementation.md)). Builds on Phase 1 (#549).

- Adds 3 new transitive overrides to `client/package.json`:
  - `postcss ^8.5.10` — clears the postcss XSS advisory pulled via vite
  - `uuid ^11.1.1` — clears the buffer-bounds advisory pulled via mermaid
  - `dompurify ^3.4.2` — pins mermaid's transitive copy to match the direct dep
- **Drops the spec's planned `vite ^8.0.0` override** — forcing nested vite to 8.x breaks vitest 4.1.0's `@vitest/mocker` (537/581 tests fail with "Failed to parse source for import analysis"). This is the exact known issue documented in PR #517's `.osv-scanner.toml` exception comments. Phase 6c (vitest test-infra majors) is the unblock path.
- The 6 vite advisories that remain are all already accepted dev-only exceptions in `.osv-scanner.toml`; OSV Scanner CI gate is unchanged.
- `bun audit`: 8 → 6 advisories (uuid + dompurify-via-mermaid cleared in this PR; 4 cleared in Phase 1).

## What's NOT in this PR (and why)

The spec planned this Phase 2 to also bump direct deps for `dompurify`, `@sentry/browser`, `@vitejs/plugin-basic-ssl`. Those bumps already landed in Phase 1 (#549) via targeted `bun update`, since they were within the existing `^` ranges. This PR is just the override additions + the `### Security` CHANGELOG entry.

## Test plan

- [x] `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok`
- [x] `cargo audit` — exit 0 with established ignore list (no new RUSTSEC entries; this PR is npm-only)
- [x] `bun run test:run` — 32 files, 581/581 tests pass
- [x] `bun run build` — `tsc && vite build` green
- [x] `bun audit` — 8 → 6 advisories (the 6 remaining are vite paths under existing PR #517 exceptions)
- [x] No nested `vite@7.x` shenanigans — `bun pm ls --all | grep vite@` shows only `vite@8.0.0` (direct) + `vite@7.3.1` (vitest's nested, intentionally preserved until Phase 6c)
- [x] Mermaid's transitive `dompurify` now resolves to `3.4.2` (single copy across the tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)