### PR TITLE
refactor(infra): Phase 4c — bump zip 2 → 8 (server export)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10208,6 +10208,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10689,7 +10695,7 @@ dependencies = [
  "vc-crypto",
  "webrtc",
  "woothee",
- "zip 2.4.2",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -12535,23 +12541,6 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
-dependencies = [
- "arbitrary",
- "crc32fast",
- "crossbeam-utils",
- "displaydoc",
- "flate2",
- "indexmap 2.13.0",
- "memchr",
- "thiserror 2.0.18",
- "zopfli",
-]
-
-[[package]]
-name = "zip"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
@@ -12562,6 +12551,19 @@ dependencies = [
  "indexmap 2.13.0",
  "memchr",
  "zopfli",
+]
+
+[[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap 2.13.0",
+ "memchr",
+ "typed-path",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ blurhash = "0.2"
 aho-corasick = "1"
 
 # Archive
-zip = { version = "2", default-features = false, features = ["deflate"] }
+zip = { version = "8", default-features = false, features = ["deflate-flate2"] }
 tempfile = "3"
 
 # Lock-free concurrent data structures


### PR DESCRIPTION
## Summary

Phase 4c of the dep-update sweep ([spec](docs/superpowers/specs/2026-05-08-dependency-update-design.md), [plan](docs/superpowers/plans/2026-05-08-dependency-update-implementation.md)). Builds on Phase 4a (#552).

`zip` rewrote its 2.x → 3.x API but preserved the surface we use (`SimpleFileOptions`, `ZipWriter::new`, `start_file`, `finish`), so the bump is **zero source-change**.

### Workspace dep

```diff
- zip = { version = "2", default-features = false, features = ["deflate"] }
+ zip = { version = "8", default-features = false, features = ["deflate-flate2"] }
```

### Feature rename

`zip 8` split the old `deflate` umbrella into `deflate-flate2` (matches our prior behavior — flate2-based deflate with miniz_oxide) and `deflate-zopfli` (slow, output-optimal compression). We pick `deflate-flate2` to preserve write performance for the data-export endpoint.

### Single consumer

`server/src/governance/export.rs` (GDPR data export ZIP archive). 14 `start_file` calls + `finish()`. Round-trip behavior is covered by the existing `test_request_data_export_no_s3` integration test.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --tests -p vc-server -- -D warnings` — clean
- [x] `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok`
- [x] `cargo audit` — exit 0 with established ignore list
- [x] `cargo build --tests -p vc-server` — clean
- [x] `cargo check -p vc-server` after rebase onto main — clean
- [ ] `test_request_data_export_no_s3` integration test — runs in CI (DB-dependent, can't run locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)