### PR TITLE
chore(client): Phase 6b — bump TypeScript 5.9 → 6.0

### DIFF
--- a/client/bun.lock
+++ b/client/bun.lock
@@ -39,7 +39,7 @@
         "jsdom": "^27.4.0",
         "lucide-solid": "^0.577.0",
         "prettier": "^3.8.3",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.2",
         "unocss": "^66.6.8",
         "vite": "^8.0.0",
@@ -1130,7 +1130,7 @@
 
     "type-level-regexp": ["type-level-regexp@0.1.17", "", {}, "sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "typescript-eslint": ["typescript-eslint@8.59.2", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.59.2", "@typescript-eslint/parser": "8.59.2", "@typescript-eslint/typescript-estree": "8.59.2", "@typescript-eslint/utils": "8.59.2" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ=="],
 

--- a/client/package.json
+++ b/client/package.json
@@ -51,7 +51,7 @@
     "jsdom": "^27.4.0",
     "lucide-solid": "^0.577.0",
     "prettier": "^3.8.3",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.2",
     "unocss": "^66.6.8",
     "vite": "^8.0.0",


### PR DESCRIPTION
## Summary

Phase 6b of the dep-update sweep ([spec](docs/superpowers/specs/2026-05-08-dependency-update-design.md), [plan](docs/superpowers/plans/2026-05-08-dependency-update-implementation.md)). Builds on Phase 6a (#554).

```diff
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
```

## Surprise outcome — zero source changes

The plan anticipated a "flood of new diagnostics that Phase 6b will have to fix in source" with a precursor PR escape hatch if the volume was unmanageable. In practice, **TypeScript 6.0.3 introduced no new diagnostics that fire on this codebase**. `bun run build` (which runs `tsc && vite build`) is green with zero source changes.

`tsconfig.json` strictness level is unchanged — no relaxation, no new ignore. The bump is just a single-line dep update.

## Test plan

- [x] `bun run build` — `tsc && vite build` green
- [x] `bun run test:run` — 32/32 files, 581/581 tests pass
- [x] `bun audit` — unchanged
- [ ] `bun run lint` — CI-only (pre-existing local resolver issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)