### PR TITLE
fix(client): emoji picker positioning at viewport (0,0)

### DIFF
--- a/client/src/components/emoji/PositionedEmojiPicker.tsx
+++ b/client/src/components/emoji/PositionedEmojiPicker.tsx
@@ -102,26 +102,23 @@ const PositionedEmojiPicker: Component<PositionedEmojiPickerProps> = (
     };
   });
 
-  const pos = position();
-  const height = maxHeight();
-
   return (
     <Portal>
       <div
         ref={pickerRef}
         style={{
           position: "fixed",
-          left: `${pos.x}px`,
-          top: `${pos.y}px`,
+          left: `${position().x}px`,
+          top: `${position().y}px`,
           "z-index": "9999",
-          ...(height ? { "max-height": `${height}px` } : {}),
+          ...(maxHeight() ? { "max-height": `${maxHeight()}px` } : {}),
         }}
       >
         <EmojiPicker
           onSelect={props.onSelect}
           onClose={props.onClose}
           guildId={props.guildId}
-          maxHeight={height}
+          maxHeight={maxHeight()}
         />
       </div>
     </Portal>


### PR DESCRIPTION
## Summary
- 4-line change to `PositionedEmojiPicker.tsx`: inline the SolidJS signal accessors (`position()`, `maxHeight()`) inside the JSX `style` prop instead of capturing them into consts before the return.
- Fixes the emoji picker rendering at viewport `(0, 0)` regardless of trigger location.

## Why
Capturing `position()` / `maxHeight()` into `const`s outside the JSX defeats SolidJS reactivity — the `style` prop never subscribes to the signals, so when `floating-ui` produces real coordinates the picker doesn't re-render.

## Spec
`docs/superpowers/specs/2026-05-10-ui-contrast-emoji-fixes-design.md` (landing in PR #557, Phase C).

## Test plan
- [x] `bun run build` clean
- [x] `bun run test:run` clean
- [ ] Manual on dev/beta: open emoji picker on a text channel — appears anchored to trigger, not at (0, 0)
- [ ] Manual: viewport-edge handling (composer near bottom/right) — picker flips/shifts to stay in view
- [ ] Manual: close behaviors — Escape, click-outside, scroll all still close picker

Generated with [Claude Code](https://claude.com/claude-code)