### PR TITLE
fix(client): make UnoCSS alpha modifiers actually apply alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Typing indicators no longer trigger database permission queries on every keystroke
 - Desktop voice audio is now clear at session start (fixed RTP sequence number regression on reconnect)
 - Desktop screen share now actually reaches other participants (fixed VP8 payload type)
+- UI contrast: selected nav items, active state pills, and warning banners now render with their intended alpha tint instead of silently rendering as solid color. UnoCSS alpha-modifier classes (`bg-accent-primary/20` etc.) had been dropping their alpha because the underlying CSS variables held hex values; switched the affected tokens in `uno.config.ts` to consume new `-rgb` channel variants via the `rgb(var(...) / <alpha-value>)` pattern.
 
 ### Security
 - E2EE Megolm session cache is now cleared on logout — prevents stale session keys from persisting

--- a/client/uno.config.ts
+++ b/client/uno.config.ts
@@ -29,26 +29,29 @@ export default defineConfig({
     },
     colors: {
       // Theme System - CSS Variables (supports runtime theme switching)
+      // Tokens with -rgb variants use rgb(var(...) / <alpha-value>) so UnoCSS
+      // alpha modifiers like /20, /25 actually inject alpha. Tokens used as
+      // solid colors only (border, error, on-accent) keep the legacy var() form.
       surface: {
-        base: "var(--color-surface-base)",
-        layer1: "var(--color-surface-layer1)",
-        layer2: "var(--color-surface-layer2)",
-        highlight: "var(--color-surface-highlight)",
+        base: "rgb(var(--color-surface-base-rgb) / <alpha-value>)",
+        layer1: "rgb(var(--color-surface-layer1-rgb) / <alpha-value>)",
+        layer2: "rgb(var(--color-surface-layer2-rgb) / <alpha-value>)",
+        highlight: "rgb(var(--color-surface-highlight-rgb) / <alpha-value>)",
       },
       text: {
-        primary: "var(--color-text-primary)",
-        secondary: "var(--color-text-secondary)",
-        muted: "var(--color-text-muted)",
-        input: "var(--color-text-input)",
+        primary: "rgb(var(--color-text-primary-rgb) / <alpha-value>)",
+        secondary: "rgb(var(--color-text-secondary-rgb) / <alpha-value>)",
+        muted: "rgb(var(--color-text-muted-rgb) / <alpha-value>)",
+        input: "rgb(var(--color-text-input-rgb) / <alpha-value>)",
       },
       "on-accent": "var(--color-text-on-accent)",
       "on-success": "var(--color-text-on-success)",
       "on-danger": "var(--color-text-on-danger)",
       accent: {
-        primary: "var(--color-accent-primary)",
-        danger: "var(--color-accent-danger)",
-        success: "var(--color-accent-success)",
-        warning: "var(--color-accent-warning)",
+        primary: "rgb(var(--color-accent-primary-rgb) / <alpha-value>)",
+        danger: "rgb(var(--color-accent-danger-rgb) / <alpha-value>)",
+        success: "rgb(var(--color-accent-success-rgb) / <alpha-value>)",
+        warning: "rgb(var(--color-accent-warning-rgb) / <alpha-value>)",
       },
       error: {
         bg: "var(--color-error-bg)",
@@ -62,22 +65,22 @@ export default defineConfig({
       },
       // Legacy compatibility (maps to new theme system)
       primary: {
-        DEFAULT: "var(--color-accent-primary)",
+        DEFAULT: "rgb(var(--color-accent-primary-rgb) / <alpha-value>)",
         hover: "var(--color-accent-primary-hover)",
       },
       background: {
-        primary: "var(--color-surface-layer1)",
-        secondary: "var(--color-surface-layer2)",
-        tertiary: "var(--color-surface-base)",
+        primary: "rgb(var(--color-surface-layer1-rgb) / <alpha-value>)",
+        secondary: "rgb(var(--color-surface-layer2-rgb) / <alpha-value>)",
+        tertiary: "rgb(var(--color-surface-base-rgb) / <alpha-value>)",
       },
-      success: "var(--color-accent-success)",
-      warning: "var(--color-accent-warning)",
-      danger: "var(--color-accent-danger)",
-      // Status colors for admin panels
+      success: "rgb(var(--color-accent-success-rgb) / <alpha-value>)",
+      warning: "rgb(var(--color-accent-warning-rgb) / <alpha-value>)",
+      danger: "rgb(var(--color-accent-danger-rgb) / <alpha-value>)",
+      // Status colors for admin panels (alias to accent tokens with same alpha behavior)
       status: {
-        success: "var(--color-accent-success)",
-        error: "var(--color-accent-danger)",
-        warning: "var(--color-accent-warning)",
+        success: "rgb(var(--color-accent-success-rgb) / <alpha-value>)",
+        error: "rgb(var(--color-accent-danger-rgb) / <alpha-value>)",
+        warning: "rgb(var(--color-accent-warning-rgb) / <alpha-value>)",
       },
     },
   },


### PR DESCRIPTION
## Summary
- Switches `uno.config.ts` color bindings for tokens that get used with alpha modifiers from `var(--color-X)` to `rgb(var(--color-X-rgb) / <alpha-value>)`.
- Fixes ~30+ UI surfaces where `bg-accent-primary/20`-style classes were silently rendering as solid color.

## Visual outcome (estimated, verified post-deploy)
| Element | Pre | Target |
|---|---|---|
| Settings: selected nav tab | 1.74:1 | ≥7:1 |
| Settings: selected theme card | 2.00:1 | ≥7:1 |
| Active Sessions: "Current" pill | 1.76:1 | ≥7:1 |
| Admin: selected nav | 1.74:1 | ≥7:1 |
| Admin: "Session Not Elevated" banner | 1.35:1 | ≥6.5:1 |

## Spec
`docs/superpowers/specs/2026-05-10-ui-contrast-emoji-fixes-design.md` (PR #557, Phase B).

## Depends on
- ✅ PR #558 (`fix/theme-rgb-channel-vars`) — adds `-rgb` variants this PR consumes. Already on main.

## Test plan
- [x] `bun run build` clean, no new UnoCSS warnings
- [x] `bun run test:run` clean (581/581)
- [x] Static check on built CSS bundle: alpha syntax now emitted for accent/status tokens (`rgb(var(--color-accent-primary-rgb) / .2)` confirmed in `dist/assets/index-*.css`)
- [ ] Post-deploy programmatic contrast audit on the 5 anchor elements (≥7:1 for selected nav, ≥4.5:1 for status pill / warning banner)
- [ ] @mention contrast unchanged (~8.57:1 — uses color() syntax, separate path)
- [ ] Cycle all 4 themes — each renders soft-tint correctly
- [ ] 24h beta soak post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)