### PR TITLE
fix(client): silence UnoCSS shortcut warnings (& fix input-field bg)

### DIFF
--- a/client/uno.config.ts
+++ b/client/uno.config.ts
@@ -90,12 +90,10 @@ export default defineConfig({
     "btn-primary": "btn bg-accent-primary hover:bg-accent-primary/80 text-on-accent",
     "btn-danger": "btn bg-accent-danger hover:bg-accent-danger/80 text-white",
 
-    // Input fields
-    "input-field": "w-full px-3 py-2 bg-surface-layer2 rounded-lg text-text-input placeholder-text-secondary outline-none focus:ring-2 focus:ring-accent-primary/70 focus:border-accent-primary/50 border border-white/5",
-
-    // Panels and Cards
-    "panel": "bg-surface-layer2 rounded-lg border border-white/5",
-    "card": "bg-surface-layer1 rounded-lg p-4 hover:bg-surface-highlight transition-colors",
+    // Input fields — uses arbitrary-value bg to bypass UnoCSS's trailing-digit
+    // parsing issue with `surface-layer2` inside shortcuts (the same class
+    // resolves correctly when written directly on an element).
+    "input-field": "w-full px-3 py-2 bg-[rgb(var(--color-surface-layer2-rgb))] rounded-lg text-text-input placeholder-text-secondary outline-none focus:ring-2 focus:ring-accent-primary/70 focus:border-accent-primary/50 border border-white/5",
 
     // Interactive items
     "item-hover": "rounded-lg px-2 py-1 hover:bg-white/5 transition-colors cursor-pointer",


### PR DESCRIPTION
## Summary
- Three pre-existing UnoCSS build warnings were **real bugs**, not false positives: `bg-surface-layer{1,2}` fails to compile inside shortcuts (trailing digit creates a parse ambiguity in UnoCSS's color resolver). The same class works correctly when written directly on an element.
- Concrete impact: `.input-field` was rendering with **no background color** (admin settings inputs, MFA setup, register/login forms — 10+ usages).
- `.panel` and `.card` shortcuts had the same issue but had **zero callsites** in the codebase.

## Fix
- Delete unused `panel` and `card` shortcuts (dead code).
- For `input-field`, switch `bg-surface-layer2` to its arbitrary-value equivalent `bg-[rgb(var(--color-surface-layer2-rgb))]` which bypasses the parser. This restores the intended background.

## Verification
- `bun run build` now clean — zero unmatched-utility warnings (was 3).
- Compiled `.input-field` CSS now contains `background-color: rgb(var(--color-surface-layer2-rgb) / var(--un-bg-opacity))` (was missing entirely).

## Test plan
- [x] `bun run build` clean — zero new warnings
- [x] Diff against built CSS confirms `.input-field` now has its background
- [ ] Manual: open admin settings / login / register / MFA setup on beta — input fields visibly have backgrounds
- [ ] Manual: confirm no visual regression elsewhere (`.panel` / `.card` had zero usages so nothing should change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)