### PR TITLE
fix(client): document innerHTML safety at 3 sites for solid/no-innerhtml

### DIFF
--- a/client/src/components/messages/MessageItem.tsx
+++ b/client/src/components/messages/MessageItem.tsx
@@ -737,7 +737,12 @@ const MessageItem: Component<MessageItemProps> = (props) => {
               {(block) => (
                 <Show
                   when={block.type === "code"}
-                  fallback={<div innerHTML={(block as TextBlock).html} />}
+                  fallback={
+                    <div
+                      // eslint-disable-next-line solid/no-innerhtml -- TextBlock.html is produced by sanitizeHtml() (DOMPurify with PURIFY_CONFIG); see contentBlocks createMemo above
+                      innerHTML={(block as TextBlock).html}
+                    />
+                  }
                 >
                   <CodeBlock language={(block as CodeBlockData).language}>
                     {(block as CodeBlockData).code}

--- a/client/src/components/pages/MarkdownPreview.tsx
+++ b/client/src/components/pages/MarkdownPreview.tsx
@@ -384,6 +384,7 @@ export default function MarkdownPreview(props: MarkdownPreviewProps) {
       <div
         ref={containerRef}
         class="prose prose-invert prose-sm max-w-none"
+        // eslint-disable-next-line solid/no-innerhtml -- sanitized via DOMPurify with MARKDOWN_PURIFY_CONFIG, see setHtml call above
         innerHTML={html()}
       />
     </div>

--- a/client/src/components/search/SearchPanel.tsx
+++ b/client/src/components/search/SearchPanel.tsx
@@ -532,6 +532,7 @@ const SearchPanel: Component<SearchPanelProps> = (props) => {
                           {/* Content Preview with server-side highlighting */}
                           <p
                             class="text-sm text-text-secondary line-clamp-2 [&_mark]:bg-accent-primary/30 [&_mark]:text-text-primary [&_mark]:rounded [&_mark]:px-0.5"
+                            // eslint-disable-next-line solid/no-innerhtml -- sanitizeHeadline() runs DOMPurify with ALLOWED_TAGS: ["mark"] only; defined above
                             innerHTML={sanitizeHeadline(r().headline)}
                           />
                         </button>


### PR DESCRIPTION
## Summary
Surfaces 3 JSX `innerHTML` usages that `solid/no-innerhtml` flags as XSS risks (these became visible after PR #563 restored runnable lint). All three are safely sanitized — this PR adds `eslint-disable-next-line` directives with per-site justification pointing at the DOMPurify call, so the rule stays active for the rest of the codebase to catch new unsafe innerHTML.

## Per-site safety analysis

| File:line | Sanitization |
|---|---|
| `MarkdownPreview.tsx:387` | `html()` signal only set via `DOMPurify.sanitize(rawHtml, MARKDOWN_PURIFY_CONFIG)` (strict allowlist) |
| `MessageItem.tsx:740` | `TextBlock.html` produced by `sanitizeHtml()` (`DOMPurify.sanitize` with `PURIFY_CONFIG`) on every path in `contentBlocks` memo; fallback uses `ALLOWED_TAGS: []` |
| `SearchPanel.tsx:535` | Wrapped in `sanitizeHeadline()` running DOMPurify with `ALLOWED_TAGS: ["mark"]` only — exactly matching ts_headline's output |

## Why disable rather than rewrite
Each site renders trusted-sanitized HTML where the alternative (using `textContent` or rebuilding the DOM tree) would lose the markdown-rendered formatting that's the whole point. The disable directives keep the rule active for new code while explicitly documenting the existing safety contract.

## Test plan
- [x] `bun run build` clean
- [x] `bun run test:run` — 581/581 passing
- [ ] After #563 lands and lint is runnable: `bun run lint` reports 0 `solid/no-innerhtml` errors (3 → 0)
- [ ] Manual smoke: render a markdown message with bold/italic/mention, view in chat, view in MarkdownPreview, search for a term — verify no XSS regression

## Stacking notes
- Conceptually depends on #563 (which makes `bun run lint` runnable so these directives get exercised) but doesn't require #563 to merge first — directives are syntactically valid eslint directives regardless of whether lint is currently running.
- Doesn't conflict with #562 (Phase 6c) — different files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)