### PR TITLE
chore(client): Phase 6d — bump lucide-solid + @solidjs/router majors

### DIFF
--- a/client/bun.lock
+++ b/client/bun.lock
@@ -6,7 +6,7 @@
       "name": "voicechat-client",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",
-        "@solidjs/router": "^0.15.4",
+        "@solidjs/router": "^0.16.1",
         "@tanstack/solid-virtual": "^3.13.24",
         "@tauri-apps/api": "^2.11.0",
         "@tauri-apps/plugin-global-shortcut": "^2.3.1",
@@ -37,7 +37,7 @@
         "eslint": "^10.3.0",
         "eslint-plugin-solid": "^0.14.5",
         "jsdom": "^29.1.1",
-        "lucide-solid": "^0.577.0",
+        "lucide-solid": "^1.14.0",
         "prettier": "^3.8.3",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.2",
@@ -390,7 +390,7 @@
 
     "@sentry/core": ["@sentry/core@10.52.0", "", {}, "sha512-VA/kAqLhkMnRWY2RXdBLyTemR9D4m7MVRy/gyapoq9yvllVPx9WXbvKgnMP2LQp7mFgT/oLFvw58aQKaYTGn3A=="],
 
-    "@solidjs/router": ["@solidjs/router@0.15.4", "", { "peerDependencies": { "solid-js": "^1.8.6" } }, "sha512-WOpgg9a9T638cR+5FGbFi/IV4l2FpmBs1GpIMSPa0Ce9vyJN7Wts+X2PqMf9IYn0zUj2MlSJtm1gp7/HI/n5TQ=="],
+    "@solidjs/router": ["@solidjs/router@0.16.1", "", { "peerDependencies": { "solid-js": "^1.8.6" } }, "sha512-IhyjedgC6LRpw/8CPGGI89FrV+r0xTHzOl2c4CRyzYQ1bLepJxbVI1LLKvsavMWY5TRBRacV7hAeOhuTXkjiqg=="],
 
     "@solidjs/testing-library": ["@solidjs/testing-library@0.8.10", "", { "dependencies": { "@testing-library/dom": "^10.4.0" }, "peerDependencies": { "@solidjs/router": ">=0.9.0", "solid-js": ">=1.0.0" }, "optionalPeers": ["@solidjs/router"] }, "sha512-qdeuIerwyq7oQTIrrKvV0aL9aFeuwTd86VYD3afdq5HYEwoox1OBTJy4y8A3TFZr8oAR0nujYgCzY/8wgHGfeQ=="],
 
@@ -940,7 +940,7 @@
 
     "lru-cache": ["lru-cache@11.3.6", "", {}, "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A=="],
 
-    "lucide-solid": ["lucide-solid@0.577.0", "", { "peerDependencies": { "solid-js": "^1.4.7" } }, "sha512-r/rsauBlyNjFlUhXCkD544tOH1GgcFFupw9oP2zZT4BiFkHoO3MTr12QfKBrS5zCRIhktc/qY2tRr925hFlNuQ=="],
+    "lucide-solid": ["lucide-solid@1.14.0", "", { "peerDependencies": { "solid-js": "^1.4.7" } }, "sha512-OeuC91agcJS3CyneSo96VpdkUAQdQO8c8r0QO5/FIkGnlfJ7Gd0fw3Z6CcdKnG94P0Ydwt+He2ar3oeTzbuNnw=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@floating-ui/dom": "^1.7.6",
-    "@solidjs/router": "^0.15.4",
+    "@solidjs/router": "^0.16.1",
     "@tanstack/solid-virtual": "^3.13.24",
     "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-global-shortcut": "^2.3.1",
@@ -49,7 +49,7 @@
     "eslint": "^10.3.0",
     "eslint-plugin-solid": "^0.14.5",
     "jsdom": "^29.1.1",
-    "lucide-solid": "^0.577.0",
+    "lucide-solid": "^1.14.0",
     "prettier": "^3.8.3",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.2",

--- a/client/src/components/admin/AdminSettings.tsx
+++ b/client/src/components/admin/AdminSettings.tsx
@@ -9,14 +9,13 @@ import { createStore } from "solid-js/store";
 import {
   Plus,
   Trash2,
-  Github,
-  Chrome,
   KeyRound,
   AlertTriangle,
   Check,
   X,
   Loader2,
 } from "lucide-solid";
+import { Github, Chrome } from "@/components/icons/BrandIcons";
 import {
   adminGetAuthSettings,
   adminUpdateAuthSettings,

--- a/client/src/components/icons/BrandIcons.tsx
+++ b/client/src/components/icons/BrandIcons.tsx
@@ -1,0 +1,58 @@
+/**
+ * Brand icons removed from `lucide-solid` v1.0 for trademark reasons.
+ * Re-implemented locally to preserve UX for OIDC provider login buttons
+ * (the original path data from lucide-solid v0.577.0, ISC licensed).
+ *
+ * Shape matches lucide's icon component prop surface (size, color, stroke-width
+ * via class, etc.) — drop-in replacement for the original imports.
+ */
+
+import type { JSX, Component } from "solid-js";
+
+type IconProps = {
+  size?: number | string;
+  color?: string;
+  class?: string;
+} & Omit<JSX.SvgSVGAttributes<SVGSVGElement>, "color">;
+
+function makeIcon(name: string, children: JSX.Element): Component<IconProps> {
+  return (props) => {
+    const { size = 24, color = "currentColor", class: cls, ...rest } = props;
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke={color}
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        class={`lucide lucide-${name} ${cls ?? ""}`}
+        {...rest}
+      >
+        {children}
+      </svg>
+    );
+  };
+}
+
+export const Github = makeIcon(
+  "github",
+  <>
+    <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
+    <path d="M9 18c-4.51 2-5-2-7-2" />
+  </>,
+);
+
+export const Chrome = makeIcon(
+  "chrome",
+  <>
+    <path d="M10.88 21.94 15.46 14" />
+    <path d="M21.17 8H12" />
+    <path d="M3.95 6.06 8.54 14" />
+    <circle cx="12" cy="12" r="10" />
+    <circle cx="12" cy="12" r="4" />
+  </>,
+);

--- a/client/src/views/Login.tsx
+++ b/client/src/views/Login.tsx
@@ -9,7 +9,8 @@ import {
 } from "@/stores/auth";
 import { fetchServerSettings, oidcAuthorize } from "@/lib/tauri";
 import type { OidcProvider } from "@/lib/types";
-import { Github, Chrome, KeyRound, ShieldCheck } from "lucide-solid";
+import { KeyRound, ShieldCheck } from "lucide-solid";
+import { Github, Chrome } from "@/components/icons/BrandIcons";
 import PasswordInput from "@/components/ui/PasswordInput";
 import { getThemeImage } from "@/lib/themeImage";
 

--- a/client/src/views/Register.tsx
+++ b/client/src/views/Register.tsx
@@ -3,7 +3,8 @@ import { A, useNavigate } from "@solidjs/router";
 import { register, loginWithOidc, authState, clearError } from "@/stores/auth";
 import { fetchServerSettings, oidcAuthorize } from "@/lib/tauri";
 import type { OidcProvider } from "@/lib/types";
-import { Github, Chrome, KeyRound, ShieldAlert } from "lucide-solid";
+import { KeyRound, ShieldAlert } from "lucide-solid";
+import { Github, Chrome } from "@/components/icons/BrandIcons";
 import PasswordInput from "@/components/ui/PasswordInput";
 import { getThemeImage } from "@/lib/themeImage";
 


### PR DESCRIPTION
## Summary
Phase 6d of the dependency-update sweep (`docs/superpowers/plans/2026-05-08-dependency-update-implementation.md`). Two UI majors:

| Package | From | To | Risk |
|---|---|---|---|
| `lucide-solid` | `^0.577.0` | `^1.14.0` | Post-1.0 stable; 2 brand icons removed |
| `@solidjs/router` | `^0.15.4` | `^0.16.1` | Pre-1.0 minor; API stable on our surface |

## Lucide brand-icon migration
Lucide v1.0 dropped brand-specific icons for trademark reasons. The 2 we used (`Github`, `Chrome` — `Chrome` was already an alias for `Chromium` in 0.577) are now provided locally at `client/src/components/icons/BrandIcons.tsx` as small SolidJS components with the **exact SVG path data from lucide-solid 0.577** (ISC-licensed). Drop-in replacement.

| Icon | New source | Used at |
|---|---|---|
| `Github` | `@/components/icons/BrandIcons` | OIDC provider buttons (AdminSettings, Login, Register) |
| `Chrome` | `@/components/icons/BrandIcons` | OIDC provider buttons (AdminSettings, Login, Register) |

131 other lucide icons unaffected.

## Router migration
Zero source changes needed. Our usage surface (`A`, `Route`, `Router`, `useNavigate`, `useParams`, `useLocation`, `useSearchParams`) is unchanged across v0.15 → v0.16.

## Spec
`docs/superpowers/specs/2026-05-08-dependency-update-design.md` (Phase 6d).

## Test plan
- [x] `bun run build` clean (tsc + vite, 6.29s)
- [x] `bun run test:run` — 581/581 passing
- [x] Brand-icon SVG output verified byte-identical to lucide's Icon wrapper
- [ ] Manual: render login screen on beta — GitHub + Google OIDC provider buttons show their brand icons
- [ ] Manual: render admin settings → auth methods — same icons visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)