### PR TITLE
chore(crypto): Phase 7 — bump vodozemac 0.9 → 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6093,7 +6093,7 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost 0.14.3",
+ "prost",
  "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tokio",
@@ -6109,7 +6109,7 @@ checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost 0.14.3",
+ "prost",
  "tonic",
  "tonic-prost",
 ]
@@ -6860,35 +6860,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
-dependencies = [
- "bytes",
- "prost-derive 0.13.5",
-]
-
-[[package]]
-name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive 0.14.3",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "prost-derive",
 ]
 
 [[package]]
@@ -9935,7 +9912,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
- "prost 0.14.3",
+ "prost",
  "tonic",
 ]
 
@@ -10718,9 +10695,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vodozemac"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c022a277687e4e8685d72b95a7ca3ccfec907daa946678e715f8badaa650883d"
+checksum = "b98bf83c0992966775b8012f194b07b44928996163e5a05b741b43891571ae5b"
 dependencies = [
  "aes",
  "arrayvec",
@@ -10734,7 +10711,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "matrix-pickle",
- "prost 0.13.5",
+ "prost",
  "rand 0.8.5",
  "serde",
  "serde_bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ hkdf = "0.12"
 sha1 = "0.10"
 sha2 = "0.10"
 hmac = "0.12"
-vodozemac = "0.9"
+vodozemac = { version = "0.10", features = ["experimental-session-config"] }
 
 # Random
 rand = "0.8"

--- a/client/src-tauri/src/crypto/manager.rs
+++ b/client/src-tauri/src/crypto/manager.rs
@@ -357,7 +357,8 @@ impl CryptoManager {
                 });
             };
 
-            let session = account.create_outbound_session(&recipient_identity_key, &one_time_key);
+            let session =
+                account.create_outbound_session(&recipient_identity_key, &one_time_key)?;
 
             // Save the updated account (one-time keys may have been consumed)
             store.save_account(&account)?;
@@ -366,7 +367,7 @@ impl CryptoManager {
         };
 
         // Encrypt the message
-        let ciphertext = session.encrypt(plaintext);
+        let ciphertext = session.encrypt(plaintext)?;
 
         // Save the updated session (ratchet has advanced)
         store.save_session(&session_key, &session)?;

--- a/client/src-tauri/src/crypto/store.rs
+++ b/client/src-tauri/src/crypto/store.rs
@@ -645,7 +645,9 @@ mod tests {
         let bob_otk = bob.one_time_keys().pop().unwrap().1;
         let bob_otk_key = Curve25519PublicKey::from_base64(&bob_otk).unwrap();
 
-        let session = alice.create_outbound_session(&bob.curve25519_key(), &bob_otk_key);
+        let session = alice
+            .create_outbound_session(&bob.curve25519_key(), &bob_otk_key)
+            .unwrap();
         let session_id = session.session_id();
 
         let session_key = SessionKey {
@@ -689,7 +691,9 @@ mod tests {
         bob.generate_one_time_keys(1);
         let bob_otk = bob.one_time_keys().pop().unwrap().1;
         let bob_otk_key = Curve25519PublicKey::from_base64(&bob_otk).unwrap();
-        let session = alice.create_outbound_session(&bob.curve25519_key(), &bob_otk_key);
+        let session = alice
+            .create_outbound_session(&bob.curve25519_key(), &bob_otk_key)
+            .unwrap();
         let session_id = session.session_id();
         let serialized = session.serialize(&key).unwrap();
 
@@ -865,7 +869,9 @@ mod tests {
         let bob_otk = bob.one_time_keys().pop().unwrap().1;
         let bob_otk_key = Curve25519PublicKey::from_base64(&bob_otk).unwrap();
 
-        let mut session = alice.create_outbound_session(&bob.curve25519_key(), &bob_otk_key);
+        let mut session = alice
+            .create_outbound_session(&bob.curve25519_key(), &bob_otk_key)
+            .unwrap();
         let session_id = session.session_id();
 
         let session_key = SessionKey {
@@ -877,7 +883,7 @@ mod tests {
         store.save_session(&session_key, &session).unwrap();
 
         // Advance the ratchet by encrypting a message
-        let _ciphertext = session.encrypt("test message");
+        let _ciphertext = session.encrypt("test message").unwrap();
 
         // Save updated session with the same SessionKey (should overwrite)
         store.save_session(&session_key, &session).unwrap();

--- a/shared/vc-crypto/src/olm.rs
+++ b/shared/vc-crypto/src/olm.rs
@@ -220,11 +220,7 @@ impl OlmAccount {
     ) -> Result<(OlmSession, String)> {
         let result = self
             .inner
-            .create_inbound_session(
-                SessionConfig::version_2(),
-                *sender_identity_key,
-                message,
-            )
+            .create_inbound_session(SessionConfig::version_2(), *sender_identity_key, message)
             .map_err(|e| CryptoError::Vodozemac(e.to_string()))?;
 
         let plaintext = String::from_utf8(result.plaintext)

--- a/shared/vc-crypto/src/olm.rs
+++ b/shared/vc-crypto/src/olm.rs
@@ -185,17 +185,25 @@ impl OlmAccount {
     ///
     /// Uses the recipient's identity key and one-time key to establish
     /// a new encrypted session.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if vodozemac rejects the session config or keys
+    /// (e.g., a malformed one-time key).
     pub fn create_outbound_session(
         &mut self,
         recipient_identity_key: &Curve25519PublicKey,
         recipient_one_time_key: &Curve25519PublicKey,
-    ) -> OlmSession {
-        let session = self.inner.create_outbound_session(
-            SessionConfig::version_2(),
-            *recipient_identity_key,
-            *recipient_one_time_key,
-        );
-        OlmSession::new(session)
+    ) -> Result<OlmSession> {
+        let session = self
+            .inner
+            .create_outbound_session(
+                SessionConfig::version_2(),
+                *recipient_identity_key,
+                *recipient_one_time_key,
+            )
+            .map_err(|e| CryptoError::Vodozemac(e.to_string()))?;
+        Ok(OlmSession::new(session))
     }
 
     /// Create an inbound session from a prekey message.
@@ -212,7 +220,11 @@ impl OlmAccount {
     ) -> Result<(OlmSession, String)> {
         let result = self
             .inner
-            .create_inbound_session(*sender_identity_key, message)
+            .create_inbound_session(
+                SessionConfig::version_2(),
+                *sender_identity_key,
+                message,
+            )
             .map_err(|e| CryptoError::Vodozemac(e.to_string()))?;
 
         let plaintext = String::from_utf8(result.plaintext)
@@ -244,9 +256,17 @@ impl OlmSession {
     /// Encrypt a message.
     ///
     /// Returns an `EncryptedMessage` that can be serialized and transmitted.
-    pub fn encrypt(&mut self, plaintext: &str) -> EncryptedMessage {
-        let olm_message = self.inner.encrypt(plaintext);
-        EncryptedMessage::from_olm_message(olm_message)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if vodozemac's sending ratchet fails (e.g., on
+    /// internal state corruption).
+    pub fn encrypt(&mut self, plaintext: &str) -> Result<EncryptedMessage> {
+        let olm_message = self
+            .inner
+            .encrypt(plaintext)
+            .map_err(|e| CryptoError::Vodozemac(e.to_string()))?;
+        Ok(EncryptedMessage::from_olm_message(olm_message))
     }
 
     /// Decrypt a message.
@@ -360,11 +380,13 @@ mod tests {
         let bob_otk_key = Curve25519PublicKey::from_base64(&bob_otk).unwrap();
 
         // Alice creates outbound session to Bob
-        let mut alice_session = alice.create_outbound_session(&bob.curve25519_key(), &bob_otk_key);
+        let mut alice_session = alice
+            .create_outbound_session(&bob.curve25519_key(), &bob_otk_key)
+            .unwrap();
 
         // Alice encrypts a message
         let plaintext = "Hello, Bob!";
-        let ciphertext = alice_session.encrypt(plaintext);
+        let ciphertext = alice_session.encrypt(plaintext).unwrap();
 
         // Verify it's a prekey message
         assert!(ciphertext.is_prekey());
@@ -380,7 +402,7 @@ mod tests {
 
         // Bob can now respond
         let response = "Hello, Alice!";
-        let response_ciphertext = bob_session.encrypt(response);
+        let response_ciphertext = bob_session.encrypt(response).unwrap();
 
         // Normal message (not prekey)
         assert!(!response_ciphertext.is_prekey());
@@ -399,13 +421,15 @@ mod tests {
             .expect("valid base64 key");
 
         let mut bob = OlmAccount::new();
-        let mut session = bob.create_outbound_session(&alice_identity_key, &alice_otk);
+        let mut session = bob
+            .create_outbound_session(&alice_identity_key, &alice_otk)
+            .unwrap();
 
         let encryption_key = [42u8; 32];
         let session_id = session.session_id();
 
         // Encrypt a message to advance ratchet state
-        let _ = session.encrypt("test message");
+        let _ = session.encrypt("test message").unwrap();
 
         let serialized = session.serialize(&encryption_key).unwrap();
         let restored = OlmSession::deserialize(&serialized, &encryption_key).unwrap();


### PR DESCRIPTION
## Summary
Phase 7 of the dep-update sweep — **Critical risk** (E2EE cryptographic core).

| Crate | From | To |
|---|---|---|
| `vodozemac` | 0.9.0 | 0.10.0 |
| `prost` (transitive) | 0.13.5 | 0.14.3 |
| `base64ct` (transitive) | 1.6.0 | 1.8.3 |

Plus patch-level cleanup of serde, serde_bytes, serde_json, sha2, thiserror, zeroize. **No cryptographic primitive crates change at M.m level.**

## API changes in `vc-crypto`
vodozemac 0.10 hardened three Olm methods and gated `SessionConfig::version_2` behind the `experimental-session-config` feature. To preserve wire-format and pickle continuity with sessions created under v0.9, this PR enables that feature on the vodozemac dep.

| API | Change |
|---|---|
| `OlmAccount::create_outbound_session` | now returns `Result<OlmSession>` (became fallible) |
| `OlmAccount::create_inbound_session` | now requires `SessionConfig::version_2()` first arg |
| `OlmSession::encrypt` | now returns `Result<EncryptedMessage>` (became fallible) |

Internal-only changes. Only consumer (`megolm.rs`) unaffected — MegolmSession API is unchanged in 0.10.

## Wire-format compatibility
Existing user Olm sessions were created with `SessionConfig::version_2()`. Falling back to `version_1()` (the new vodozemac 0.10 default) would change the on-wire format and risk breaking historical session deserialization. The `experimental-session-config` flag is documented stable behavior; this is the safety-first choice.

## Verification
- [x] `cargo test -p vc-crypto` — **22/22 passing**, including:
  - `test_session_encrypt_decrypt` — Alice/Bob Olm encrypt+decrypt round-trip
  - `test_session_serialization` — pickle round-trip via encrypted storage path
- [x] `cargo build -p vc-server` — clean
- [x] `cargo clippy -p vc-server -p vc-crypto -- -D warnings` — clean
- [x] `cargo deny check` — advisories/bans/licenses/sources all ok
- [ ] CI Rust Tests pass (integration tests with real PostgreSQL/Redis)
- [ ] Manual on beta: encrypted DM round-trip after deploy; session restoration after server restart

## Spec
`docs/superpowers/specs/2026-05-08-dependency-update-design.md` (Phase 7).

## Plan deviations
1. Pre-flight delta gate was broader than spec (extra patch-level bumps on serde/sha2/zeroize/etc) — spirit of gate (M.m primitive parity) preserved.
2. Phase 7 round-trip test from plan was a literal duplicate of existing `test_session_serialization` in olm.rs — relied on the existing test suite instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)