### PR TITLE
chore(infra): dep-update sweep cleanup (Phase 10, partial)

### DIFF
--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -71,9 +71,11 @@ nnnoiseless = { version = "0.5", default-features = false }
 # adapts the Linux backend to the new enum structure plus a Windows typo fix.
 #
 # Upstream tracking:
-# - CapSoftware/scap#178 — broader fix, open since 2025-10-26, no updates
-# - Last re-check 2026-04-12: upstream main HEAD still fails Linux build
-#   (see closed PR #520 for the test run)
+# - CapSoftware/scap#178 — broader fix, still open (last upstream update
+#   2025-10-26)
+# - Last re-check 2026-05-13: upstream latest release is still v0.1.0-beta.1
+#   (2025-08-04). No new releases or merged Linux Frame enum fixes.
+# - Previous re-check 2026-04-12: see closed PR #520 for the test run
 # - Issue #521 tracks periodic re-checks — drop this git dep when upstream
 #   publishes a new release with the Linux fix
 scap = { git = "https://github.com/Detair/scap.git", branch = "fix/linux-frame-enum" }

--- a/deny.toml
+++ b/deny.toml
@@ -14,15 +14,18 @@ unmaintained = "workspace"
 ignore = [
     # rsa crate Marvin Attack - no safe upgrade available, used by openidconnect
     "RUSTSEC-2023-0071",
-    # rand 0.8.5 unsoundness with custom `log` logger - not exploitable in Kaiku
-    # because we use `tracing`/`tracing-subscriber`, not the `log` facade.
-    # The exploitable configuration requires a `log::Log` implementation that
-    # calls `rand::thread_rng()` during logging, which does not exist in this
-    # codebase. Transitive deps (fred, jsonwebtoken, openidconnect, webrtc,
-    # sqlx-postgres, vodozemac, etc.) pin rand 0.8, so the crate will stay in
-    # the tree until upstreams migrate to 0.9. Bumping our direct deps to 0.9
-    # would not remove the transitive 0.8.5 and would require breaking API
-    # changes (thread_rng → rng, gen_range → random_range).
+    # rand unsoundness with custom `log` logger — flagged against rand 0.7.3,
+    # 0.8.5, 0.9.2, AND 0.10.0 (all versions; the underlying API contract
+    # hasn't changed). Not exploitable in Kaiku because we use `tracing` /
+    # `tracing-subscriber`, not the `log` facade. The exploitable
+    # configuration requires a `log::Log` implementation that calls
+    # `rand::thread_rng()` (or its v0.9+ equivalent `rand::rng()`) during
+    # logging, which does not exist in this codebase. Transitive deps (fred,
+    # jsonwebtoken, openidconnect, webrtc, sqlx-postgres, vodozemac, etc.)
+    # pin various rand majors across the tree; bumping our direct rand
+    # version wouldn't drop the transitive copies. The ignore stays
+    # version-agnostic because the rationale (no log facade in our code) is
+    # invariant across rand majors.
     "RUSTSEC-2026-0097",
 ]
 


### PR DESCRIPTION
## Summary
Phase 10 of the dep-update sweep — small, low-risk cleanup. Tasks that depend on the other 4 in-flight PRs landing first are deferred to a follow-up PR.

## Done in this PR

### Task 10.1 — `deny.toml` RUSTSEC-2026-0097 comment rewrite
Original comment said "rand 0.8.5", but the advisory now flags **0.7.3, 0.8.5, 0.9.2, and 0.10.0** — all major versions of rand. The underlying API contract for the exploit (custom `log::Log` impl calling `rand::thread_rng()` during logging) didn't change. Our rationale (we use `tracing`, not the `log` facade) is invariant across rand versions, so the new comment reflects that.

### Task 10.2 — Advisory gate snapshot

```
cargo audit:   1 vulnerability  (RUSTSEC-2026-0097, already ignored)
               24 allowed warnings (other ignored RUSTSECs)
cargo deny:    advisories ok, bans ok, licenses ok, sources ok
bun audit:     10 vulnerabilities (4 high, 6 moderate) — all in mermaid <= 11.14.0
               (CSS/HTML injection in diagram rendering, pre-existing, fix
               requires mermaid major-version bump — out of scope here)
```

### Task 10.4 — scap upstream re-check
- Latest scap release: still **v0.1.0-beta.1** (2025-08-04)
- Issue [#178](https://github.com/CapSoftware/scap/issues/178) (Linux Frame enum fix): still open, last upstream update 2025-10-26
- No new releases since. **Detair/scap fork stays pinned.** Updated inline re-check date in `client/src-tauri/Cargo.toml`.

## Deferred to a follow-up cleanup PR

These tasks expect the rest of the sweep to be merged first; running them now would produce premature snapshots:

- **Task 10.3** (LICENSE_COMPLIANCE.md tree diff) — depends on a pre-Phase-0 baseline cargo-tree dump that doesn't exist. Out of scope.
- **Task 10.5** (THIRD_PARTY_NOTICES.md) — no new license categories surfaced in `cargo deny check`, so no edit needed.
- **Task 10.6** (CLAUDE.md memory updates: `feedback_webrtc_rs_rtcp`, `project_webrtc_screen_share`, new `project_dep_update_2026_05`) — **deferred** until #565, #566, #567, #568 finish merging so the memory reflects shipped state, not forecast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)