### PR TITLE
fix(ci): correct Tauri build artifact paths to workspace target/

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
         if: matrix.platform == 'ubuntu-latest'
         env:
           BUILD_TARGET: ${{ matrix.target }}
-        working-directory: client/src-tauri/target
+        working-directory: target
         run: |
           cd "$BUILD_TARGET/release/bundle"
           if [ -d "deb" ]; then
@@ -149,7 +149,7 @@ jobs:
         if: matrix.platform == 'windows-latest'
         env:
           BUILD_TARGET: ${{ matrix.target }}
-        working-directory: client/src-tauri/target
+        working-directory: target
         shell: pwsh
         run: |
           cd "$env:BUILD_TARGET/release/bundle"
@@ -170,7 +170,7 @@ jobs:
         if: matrix.platform == 'macos-latest'
         env:
           BUILD_TARGET: ${{ matrix.target }}
-        working-directory: client/src-tauri/target
+        working-directory: target
         run: |
           cd "$BUILD_TARGET/release/bundle"
           if [ -d "dmg" ]; then
@@ -182,7 +182,7 @@ jobs:
         with:
           name: tauri-${{ matrix.platform }}-${{ matrix.target }}-${{ matrix.bundle }}
           path: |
-            client/src-tauri/target/${{ matrix.target }}/release/bundle/**/*
+            target/${{ matrix.target }}/release/bundle/**/*
           retention-days: 7
 
   # ===========================================================================

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -130,9 +130,9 @@ jobs:
         with:
           name: voicechat-${{ matrix.artifact }}
           path: |
-            client/src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb
-            client/src-tauri/target/${{ matrix.target }}/release/bundle/rpm/*.rpm
-            client/src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage
+            target/${{ matrix.target }}/release/bundle/deb/*.deb
+            target/${{ matrix.target }}/release/bundle/rpm/*.rpm
+            target/${{ matrix.target }}/release/bundle/appimage/*.AppImage
 
       - name: Upload Windows artifacts
         if: runner.os == 'Windows'
@@ -140,8 +140,8 @@ jobs:
         with:
           name: voicechat-${{ matrix.artifact }}
           path: |
-            client/src-tauri/target/${{ matrix.target }}/release/bundle/msi/*.msi
-            client/src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*.exe
+            target/${{ matrix.target }}/release/bundle/msi/*.msi
+            target/${{ matrix.target }}/release/bundle/nsis/*.exe
 
       - name: Upload macOS artifacts
         if: runner.os == 'macOS'
@@ -149,8 +149,8 @@ jobs:
         with:
           name: voicechat-${{ matrix.artifact }}
           path: |
-            client/src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
-            client/src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.app
+            target/${{ matrix.target }}/release/bundle/dmg/*.dmg
+            target/${{ matrix.target }}/release/bundle/macos/*.app
 
   # Create release when a tag is pushed
   release:


### PR DESCRIPTION
## Summary
**Bug:** `tauri-build.yml` and `release.yml` both reference `client/src-tauri/target/...` for artifact uploads, but the Cargo workspace's actual target directory is at the repo root (`target/...`). The `client/src-tauri` crate is a workspace member of the root workspace.

**Effect:**
- **Tauri Build workflow:** builds succeed and Tauri bundles all platform artifacts (`Kaiku_0.1.0_amd64.deb`/`.rpm`/`.AppImage`/`.msi`/`.exe`/`.dmg`/`.app`) at the real path — but the `actions/upload-artifact` glob never matches, silently producing **0 artifacts per run**. **No client downloads have ever been distributed via CI.**
- **Release workflow:** same paths plus `working-directory: client/src-tauri/target` for codesign/notarize. Latent bug — would have failed on the first `v*` tag push.

## What's actually built (from CI logs, run 25821667446)
```
target/x86_64-unknown-linux-gnu/release/bundle/deb/Kaiku_0.1.0_amd64.deb
target/x86_64-unknown-linux-gnu/release/bundle/rpm/Kaiku-0.1.0-1.x86_64.rpm
target/x86_64-unknown-linux-gnu/release/bundle/appimage/Kaiku_0.1.0_amd64.AppImage
```

What the workflow was looking for:
```
client/src-tauri/target/x86_64-unknown-linux-gnu/release/bundle/deb/*.deb
```

## Fix
Sed across the 10 occurrences in both files: `client/src-tauri/target/` → `target/`. Verified locally: `.cargo/config.toml` has no custom `target-dir` override; Tauri builds in past runs wrote artifacts to the workspace-root `target/`.

## Test plan
- [x] `grep -c "client/src-tauri/target"` in both files → 0 (verified after fix)
- [ ] CI passes on this PR
- [ ] After merge: trigger a fresh Tauri Build on `main` (e.g., `gh workflow run "Tauri Build" --ref main`) — artifacts should appear in the run's "Artifacts" section
- [ ] Then a `v0.1.0-beta.X` tag push exercises `release.yml` and creates a GitHub Release with binaries attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)