### PR TITLE
chore(db): bump sqlx 0.8.6 → 0.9, rusqlite 0.32 → 0.38 (#115)

### DIFF
--- a/.sqlx/query-037c6e3b43c4b89868377be2fa99505d52fa40b7f6647852678852e795df54cb.json
+++ b/.sqlx/query-037c6e3b43c4b89868377be2fa99505d52fa40b7f6647852678852e795df54cb.json
@@ -6,37 +6,74 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "username",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "username"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "display_name",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "display_name"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "email",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "email"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "avatar_url",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "avatar_url"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "created_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "created_at"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "is_banned!",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-0556d91140a4adeab05b7f6e603be7f9c9a6f903f452e440e61c7e9290bd9cbc.json
+++ b/.sqlx/query-0556d91140a4adeab05b7f6e603be7f9c9a6f903f452e440e61c7e9290bd9cbc.json
@@ -6,12 +6,24 @@
       {
         "ordinal": 0,
         "name": "is_bot",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "is_bot"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "bot_owner_id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "bot_owner_id"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-05cd7c6dff0e9f69bb1cfa0c40e06945b126be8b18a52edb84eb750b7e2cdfb5.json
+++ b/.sqlx/query-05cd7c6dff0e9f69bb1cfa0c40e06945b126be8b18a52edb84eb750b7e2cdfb5.json
@@ -6,7 +6,8 @@
       {
         "ordinal": 0,
         "name": "count!",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-0b885f9681a9e76bc29d22159aa7638ea23db230755503326be36630eb995398.json
+++ b/.sqlx/query-0b885f9681a9e76bc29d22159aa7638ea23db230755503326be36630eb995398.json
@@ -6,12 +6,24 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "guilds",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "name",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "guilds",
+            "name": "name"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-13047aa5be7a35b4f4c5cfa0de0444ebb67801bd890d9b37989b105164f15914.json
+++ b/.sqlx/query-13047aa5be7a35b4f4c5cfa0de0444ebb67801bd890d9b37989b105164f15914.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "last_read_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "dm_read_state",
+            "name": "last_read_at"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-15df6ca65b916dbfaf34234752d5e3f3e751b3dec3def80158862b806205020a.json
+++ b/.sqlx/query-15df6ca65b916dbfaf34234752d5e3f3e751b3dec3def80158862b806205020a.json
@@ -6,37 +6,74 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "username",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "username"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "display_name",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "display_name"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "email",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "email"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "avatar_url",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "avatar_url"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "created_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "created_at"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "is_banned!",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-214311595876d9a405e87449f28c739e7d21ac687573c612852d2c6a3cba1e14.json
+++ b/.sqlx/query-214311595876d9a405e87449f28c739e7d21ac687573c612852d2c6a3cba1e14.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "id"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-269505ba39f4b38101ee440ede9c328323ccb15f6b0ce6833ab5b0a40ec75fe0.json
+++ b/.sqlx/query-269505ba39f4b38101ee440ede9c328323ccb15f6b0ce6833ab5b0a40ec75fe0.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "user_id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "messages",
+            "name": "user_id"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-2b92e2fb52c2cc818aaba06bc30c9f251042439a0440a47e0ae187ed45d08e36.json
+++ b/.sqlx/query-2b92e2fb52c2cc818aaba06bc30c9f251042439a0440a47e0ae187ed45d08e36.json
@@ -6,7 +6,8 @@
       {
         "ordinal": 0,
         "name": "count!",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-358f243683ea759a066982024b15935c547aac60d82a4e5e2961dce893783853.json
+++ b/.sqlx/query-358f243683ea759a066982024b15935c547aac60d82a4e5e2961dce893783853.json
@@ -6,12 +6,24 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "username",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "username"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-395013381b6dbe27a2affb43c5ab73eba6167069f80476d16a83493c3e0285c1.json
+++ b/.sqlx/query-395013381b6dbe27a2affb43c5ab73eba6167069f80476d16a83493c3e0285c1.json
@@ -6,12 +6,24 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "slash_commands",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "created_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "slash_commands",
+            "name": "created_at"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-3a8ac4479b08a545b8150d043676d77a541cf58a78ead2ea8977f89e4e74565b.json
+++ b/.sqlx/query-3a8ac4479b08a545b8150d043676d77a541cf58a78ead2ea8977f89e4e74565b.json
@@ -6,7 +6,8 @@
       {
         "ordinal": 0,
         "name": "count!",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-3d6161d0b8b7b8187fac20fec1f8323c9167929b1826a09fdac312fed9af4b47.json
+++ b/.sqlx/query-3d6161d0b8b7b8187fac20fec1f8323c9167929b1826a09fdac312fed9af4b47.json
@@ -6,27 +6,52 @@
       {
         "ordinal": 0,
         "name": "guild_id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "guilds",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "guild_name",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "guilds",
+            "name": "name"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "guild_icon_url",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "guilds",
+            "name": "icon_url"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "joined_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "guild_members",
+            "name": "joined_at"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "is_owner!",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-412c3f0264109d8796a1b5820921a6f4c6029f27c59c3376f472fd2a7df3474b.json
+++ b/.sqlx/query-412c3f0264109d8796a1b5820921a6f4c6029f27c59c3376f472fd2a7df3474b.json
@@ -6,12 +6,24 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "guilds",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "suspended_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "guilds",
+            "name": "suspended_at"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-433e45b636fc0fb9dbf83d0bba98ab0544d5b77e8e0441b49e66e0c432c4dcbc.json
+++ b/.sqlx/query-433e45b636fc0fb9dbf83d0bba98ab0544d5b77e8e0441b49e66e0c432c4dcbc.json
@@ -6,37 +6,74 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "guilds",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "name",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "guilds",
+            "name": "name"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "owner_id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "guilds",
+            "name": "owner_id"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "icon_url",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "guilds",
+            "name": "icon_url"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "created_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "guilds",
+            "name": "created_at"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "suspended_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "guilds",
+            "name": "suspended_at"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "member_count!",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-435ade86c559fc20d307c6513509ab15c55e73c05d6c57a8ad1e19ba614c82db.json
+++ b/.sqlx/query-435ade86c559fc20d307c6513509ab15c55e73c05d6c57a8ad1e19ba614c82db.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "id"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-45252ecf54a7880823715b14d90311bef635a49b3b30e8a40d6473b8e5397101.json
+++ b/.sqlx/query-45252ecf54a7880823715b14d90311bef635a49b3b30e8a40d6473b8e5397101.json
@@ -6,7 +6,8 @@
       {
         "ordinal": 0,
         "name": "exists!",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-45726fa7808616e38eb00a09b5a06e0783748b8de182f7a2fde3ece27e1c2b59.json
+++ b/.sqlx/query-45726fa7808616e38eb00a09b5a06e0783748b8de182f7a2fde3ece27e1c2b59.json
@@ -6,7 +6,8 @@
       {
         "ordinal": 0,
         "name": "exists!",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-4b79edf3ff19a2bb132148d217b2c1b848e9ed95c292c8a01964d1feb21cd92e.json
+++ b/.sqlx/query-4b79edf3ff19a2bb132148d217b2c1b848e9ed95c292c8a01964d1feb21cd92e.json
@@ -6,17 +6,35 @@
       {
         "ordinal": 0,
         "name": "username",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "username"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "display_name",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "display_name"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "avatar_url",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "avatar_url"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-5901b0f1dbb8f97b17128328185a5513127dc3fa54f835a4f81ab62b612fb1aa.json
+++ b/.sqlx/query-5901b0f1dbb8f97b17128328185a5513127dc3fa54f835a4f81ab62b612fb1aa.json
@@ -6,22 +6,46 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "bot_applications",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "bot_applications",
+            "name": "name"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "bot_user_id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "bot_applications",
+            "name": "bot_user_id"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "owner_id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "bot_applications",
+            "name": "owner_id"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-594cb4757f2ee883dc4d26aa7d6e1ab74f37807620eb2eb1335bfc54aeb67fa7.json
+++ b/.sqlx/query-594cb4757f2ee883dc4d26aa7d6e1ab74f37807620eb2eb1335bfc54aeb67fa7.json
@@ -6,37 +6,74 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "guilds",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "name",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "guilds",
+            "name": "name"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "icon_url",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "guilds",
+            "name": "icon_url"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "owner_id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "guilds",
+            "name": "owner_id"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "created_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "guilds",
+            "name": "created_at"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "suspended_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "guilds",
+            "name": "suspended_at"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "member_count!",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-73a7fab5ca1115b081eec61e54fe3133dccf3435a95d864b13c7222265257a07.json
+++ b/.sqlx/query-73a7fab5ca1115b081eec61e54fe3133dccf3435a95d864b13c7222265257a07.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "username",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "username"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-76062a919b17d4118b602211bf3fc13759b184a078955e50596352687475dfe8.json
+++ b/.sqlx/query-76062a919b17d4118b602211bf3fc13759b184a078955e50596352687475dfe8.json
@@ -6,12 +6,24 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "bot_applications",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "token_hash",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "bot_applications",
+            "name": "token_hash"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-765220d3f660c34b260ac071536960b7a4172e1fa2e2f28277ece757eac92404.json
+++ b/.sqlx/query-765220d3f660c34b260ac071536960b7a4172e1fa2e2f28277ece757eac92404.json
@@ -6,7 +6,8 @@
       {
         "ordinal": 0,
         "name": "count!",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-7b769e63578ee41b0986badbc3aa7a8f73b5c6c19fa474ead03dbb3bac32b338.json
+++ b/.sqlx/query-7b769e63578ee41b0986badbc3aa7a8f73b5c6c19fa474ead03dbb3bac32b338.json
@@ -6,7 +6,8 @@
       {
         "ordinal": 0,
         "name": "last_login",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-8006ac0f32f25d5fbdeb2304bedb5b787b1ea99d75fa6e0550b82264be623bdc.json
+++ b/.sqlx/query-8006ac0f32f25d5fbdeb2304bedb5b787b1ea99d75fa6e0550b82264be623bdc.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "owner_id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "bot_applications",
+            "name": "owner_id"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-844ac2f2569dd242dc826c095509ee5cd7f95dc7878dbac7265a8bbabb6f9e25.json
+++ b/.sqlx/query-844ac2f2569dd242dc826c095509ee5cd7f95dc7878dbac7265a8bbabb6f9e25.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "name",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "guilds",
+            "name": "name"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-88f26472e41c0381a8945804164c12fdc502c55c9bb4f90d64fd38d953e0d5f5.json
+++ b/.sqlx/query-88f26472e41c0381a8945804164c12fdc502c55c9bb4f90d64fd38d953e0d5f5.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "id"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-89d44c941251452f6acbbc36e5493979b4d61a7eb648eb3c3f342e6b693d5543.json
+++ b/.sqlx/query-89d44c941251452f6acbbc36e5493979b4d61a7eb648eb3c3f342e6b693d5543.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "guild_bot_installations",
+            "name": "id"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-8bd3fedb4a21d2586bee0fbd20ea0156b00582f19fe2fb0babfdce4ef8ff7b2d.json
+++ b/.sqlx/query-8bd3fedb4a21d2586bee0fbd20ea0156b00582f19fe2fb0babfdce4ef8ff7b2d.json
@@ -6,22 +6,46 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "username",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "username"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "display_name",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "display_name"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "avatar_url",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "avatar_url"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-8dcfc0548122830abb75618cf39ea24b4bbe24fde4d2ce1bcd50a80ad3e3dffe.json
+++ b/.sqlx/query-8dcfc0548122830abb75618cf39ea24b4bbe24fde4d2ce1bcd50a80ad3e3dffe.json
@@ -6,7 +6,8 @@
       {
         "ordinal": 0,
         "name": "exists!",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-9ace6a54c39c16a99f452a49432bd8acebaf3c409fb8b2ec216b40848c865832.json
+++ b/.sqlx/query-9ace6a54c39c16a99f452a49432bd8acebaf3c409fb8b2ec216b40848c865832.json
@@ -6,22 +6,46 @@
       {
         "ordinal": 0,
         "name": "user_id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "elevated_sessions",
+            "name": "user_id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "elevated_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "elevated_sessions",
+            "name": "elevated_at"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "expires_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "elevated_sessions",
+            "name": "expires_at"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "reason",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "elevated_sessions",
+            "name": "reason"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-9bc8cce911ed1e936b53b596da3fb3551cb18ff7eb0237171a17bd9ca67e661d.json
+++ b/.sqlx/query-9bc8cce911ed1e936b53b596da3fb3551cb18ff7eb0237171a17bd9ca67e661d.json
@@ -6,7 +6,8 @@
       {
         "ordinal": 0,
         "name": "count!",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-9ca1dc2b7133662c59fc7e93960d7c94181381af2a14de4daf882fe69cda0b16.json
+++ b/.sqlx/query-9ca1dc2b7133662c59fc7e93960d7c94181381af2a14de4daf882fe69cda0b16.json
@@ -6,27 +6,57 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "username",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "username"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "display_name",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "display_name"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "email",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "email"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "password_hash",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "password_hash"
+          }
+        }
       },
       {
         "ordinal": 5,
@@ -41,17 +71,35 @@
               ]
             }
           }
+        },
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "auth_method"
+          }
         }
       },
       {
         "ordinal": 6,
         "name": "external_id",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "external_id"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "avatar_url",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "avatar_url"
+          }
+        }
       },
       {
         "ordinal": 8,
@@ -68,42 +116,90 @@
               ]
             }
           }
+        },
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "status"
+          }
         }
       },
       {
         "ordinal": 9,
         "name": "mfa_secret",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "mfa_secret"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "is_bot",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "is_bot"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "bot_owner_id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "bot_owner_id"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "deletion_requested_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "deletion_requested_at"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "deletion_scheduled_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "deletion_scheduled_at"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "created_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "created_at"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "updated_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "updated_at"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-a216ce1bd37d5da594b5212aafdbdf455f107b1c56fb013a4cb947fdf54836e3.json
+++ b/.sqlx/query-a216ce1bd37d5da594b5212aafdbdf455f107b1c56fb013a4cb947fdf54836e3.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "sessions",
+            "name": "id"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-a6ba1d7dae13fa12939db772fa93b53a132bca925e79a104a1e6819fdb66d1ff.json
+++ b/.sqlx/query-a6ba1d7dae13fa12939db772fa93b53a132bca925e79a104a1e6819fdb66d1ff.json
@@ -6,37 +6,79 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "slash_commands",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "application_id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "slash_commands",
+            "name": "application_id"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "guild_id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "slash_commands",
+            "name": "guild_id"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "slash_commands",
+            "name": "name"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "description",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "slash_commands",
+            "name": "description"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "options",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "slash_commands",
+            "name": "options"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "created_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "slash_commands",
+            "name": "created_at"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-a92a8729b14559eef65b1ea6d2accc4008098aec427296673266737307c608f5.json
+++ b/.sqlx/query-a92a8729b14559eef65b1ea6d2accc4008098aec427296673266737307c608f5.json
@@ -6,27 +6,57 @@
       {
         "ordinal": 0,
         "name": "user_id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "username",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "username"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "display_name",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "display_name"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "avatar_url",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "avatar_url"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "joined_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "dm_participants",
+            "name": "joined_at"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-abd97f672cc3a1108ce0143e6248ee77708a6280e928b5d98ce89d3209f1bd92.json
+++ b/.sqlx/query-abd97f672cc3a1108ce0143e6248ee77708a6280e928b5d98ce89d3209f1bd92.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "expires_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "elevated_sessions",
+            "name": "expires_at"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-af1a58cfbeb3532052f77dc1c24eb9e14a82229f61f1256d1c840ac18053d6d6.json
+++ b/.sqlx/query-af1a58cfbeb3532052f77dc1c24eb9e14a82229f61f1256d1c840ac18053d6d6.json
@@ -6,12 +6,24 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "username",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "username"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-b7c252a2e71bbf2d1f21fb035bf64cf7efce75e9b42a1c06198b37efedbf2ab8.json
+++ b/.sqlx/query-b7c252a2e71bbf2d1f21fb035bf64cf7efce75e9b42a1c06198b37efedbf2ab8.json
@@ -6,7 +6,8 @@
       {
         "ordinal": 0,
         "name": "exists",
-        "type_info": "Int4"
+        "type_info": "Int4",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-bcc6d74d4dac33cdae2b612289f39980f78f6c4762c14e2232ab672526c3f25d.json
+++ b/.sqlx/query-bcc6d74d4dac33cdae2b612289f39980f78f6c4762c14e2232ab672526c3f25d.json
@@ -6,7 +6,8 @@
       {
         "ordinal": 0,
         "name": "exists!",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-bf4b091eaecf1b1551ef90b316ea33bae1bc903148e86ab93f106baf9bdc7dc7.json
+++ b/.sqlx/query-bf4b091eaecf1b1551ef90b316ea33bae1bc903148e86ab93f106baf9bdc7dc7.json
@@ -6,7 +6,8 @@
       {
         "ordinal": 0,
         "name": "exists!",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-c61c6b3576c8d59b5386184070173c66f9a9cfb166f9206508ccdd85016c43d3.json
+++ b/.sqlx/query-c61c6b3576c8d59b5386184070173c66f9a9cfb166f9206508ccdd85016c43d3.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "username",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "username"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-c7a90ebde948e1306b2df58781e28e9a61268bc678f11b2de24c173519a65d3c.json
+++ b/.sqlx/query-c7a90ebde948e1306b2df58781e28e9a61268bc678f11b2de24c173519a65d3c.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "key",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "server_config",
+            "name": "key"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-c9dc5e48e863142d91752eff4b364723b6dc79f1943b700fe95b6e1e19565d7f.json
+++ b/.sqlx/query-c9dc5e48e863142d91752eff4b364723b6dc79f1943b700fe95b6e1e19565d7f.json
@@ -6,17 +6,35 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "bot_applications",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "bot_user_id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "bot_applications",
+            "name": "bot_user_id"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "owner_id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "bot_applications",
+            "name": "owner_id"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-ca2bcae403ee2e6359be8c679bef59ffdb7e6f4d5dbed29d57e3685224840afc.json
+++ b/.sqlx/query-ca2bcae403ee2e6359be8c679bef59ffdb7e6f4d5dbed29d57e3685224840afc.json
@@ -6,7 +6,8 @@
       {
         "ordinal": 0,
         "name": "count!",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-cf6c92fff07fb56b7438d594441d76a0d637c59ec882425204599d3f3e6fe5c5.json
+++ b/.sqlx/query-cf6c92fff07fb56b7438d594441d76a0d637c59ec882425204599d3f3e6fe5c5.json
@@ -6,7 +6,8 @@
       {
         "ordinal": 0,
         "name": "exists!",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-da1f58efea4c4a268e8f7e54b6b83dd768df9605e532e66b2821414e33b9d61c.json
+++ b/.sqlx/query-da1f58efea4c4a268e8f7e54b6b83dd768df9605e532e66b2821414e33b9d61c.json
@@ -6,27 +6,57 @@
       {
         "ordinal": 0,
         "name": "user_id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "username",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "username"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "display_name",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "display_name"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "avatar_url",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "avatar_url"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "joined_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "guild_members",
+            "name": "joined_at"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-db8153b591cf27523f42fed85f381cfa2ade9ec39d1ef8e5d8240fbb0c3d4b8a.json
+++ b/.sqlx/query-db8153b591cf27523f42fed85f381cfa2ade9ec39d1ef8e5d8240fbb0c3d4b8a.json
@@ -6,7 +6,8 @@
       {
         "ordinal": 0,
         "name": "count!",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-dd99e48b1572e25db38f03da95984fda1072913b29bb6b3753a0d351583dfff6.json
+++ b/.sqlx/query-dd99e48b1572e25db38f03da95984fda1072913b29bb6b3753a0d351583dfff6.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "id"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-de3230de507ca1e11d2ca40bef8a5b8470628ddbaa454af4f49f6fe6953f9014.json
+++ b/.sqlx/query-de3230de507ca1e11d2ca40bef8a5b8470628ddbaa454af4f49f6fe6953f9014.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "username",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "username"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-e4f5319507d8d32b97c903f7c2db5652b29ea9f22641959bc17e704ee4401fc2.json
+++ b/.sqlx/query-e4f5319507d8d32b97c903f7c2db5652b29ea9f22641959bc17e704ee4401fc2.json
@@ -6,7 +6,8 @@
       {
         "ordinal": 0,
         "name": "count!",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-e50a5b5caa08d972835c1dd9697fc94722e7f5a096b82f38c5b9475447eb2521.json
+++ b/.sqlx/query-e50a5b5caa08d972835c1dd9697fc94722e7f5a096b82f38c5b9475447eb2521.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "user_id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "dm_participants",
+            "name": "user_id"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-fa02aede97b0dec98d99a2175297bd0dbd7a36ab125c18ab1d28986fda441920.json
+++ b/.sqlx/query-fa02aede97b0dec98d99a2175297bd0dbd7a36ab125c18ab1d28986fda441920.json
@@ -6,17 +6,35 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "bot_applications",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "owner_id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "bot_applications",
+            "name": "owner_id"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "public",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "bot_applications",
+            "name": "public"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-fbad30da78f30f42ff9b0e79a83fc6d9e17fa502cab201f08bd5c1bbf3fc0690.json
+++ b/.sqlx/query-fbad30da78f30f42ff9b0e79a83fc6d9e17fa502cab201f08bd5c1bbf3fc0690.json
@@ -6,27 +6,57 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "username",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "username"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "display_name",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "display_name"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "email",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "email"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "password_hash",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "password_hash"
+          }
+        }
       },
       {
         "ordinal": 5,
@@ -41,17 +71,35 @@
               ]
             }
           }
+        },
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "auth_method"
+          }
         }
       },
       {
         "ordinal": 6,
         "name": "external_id",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "external_id"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "avatar_url",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "avatar_url"
+          }
+        }
       },
       {
         "ordinal": 8,
@@ -68,42 +116,90 @@
               ]
             }
           }
+        },
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "status"
+          }
         }
       },
       {
         "ordinal": 9,
         "name": "mfa_secret",
-        "type_info": "Varchar"
+        "type_info": "Varchar",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "mfa_secret"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "is_bot",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "is_bot"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "bot_owner_id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "bot_owner_id"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "deletion_requested_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "deletion_requested_at"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "deletion_scheduled_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "deletion_scheduled_at"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "created_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "created_at"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "updated_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "users",
+            "name": "updated_at"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-fe517be1e52bb60e268bb68460ae8b1ee14852eb09fee4c8d91f63484f41bbbd.json
+++ b/.sqlx/query-fe517be1e52bb60e268bb68460ae8b1ee14852eb09fee4c8d91f63484f41bbbd.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Uuid"
+        "type_info": "Uuid",
+        "origin": {
+          "Table": {
+            "table": "bot_applications",
+            "name": "id"
+          }
+        }
       }
     ],
     "parameters": {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -208,18 +208,6 @@ dependencies = [
  "ctr",
  "ghash",
  "subtle",
-]
-
-[[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if 1.0.4",
- "once_cell",
- "version_check",
- "zerocopy",
 ]
 
 [[package]]
@@ -829,14 +817,14 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
  "lru 0.12.5",
  "percent-encoding",
  "regex-lite",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
  "url",
 ]
@@ -880,11 +868,11 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
  "percent-encoding",
- "sha2",
+ "sha2 0.10.9",
  "time",
  "tracing",
 ]
@@ -913,10 +901,10 @@ dependencies = [
  "hex",
  "http 0.2.12",
  "http-body 0.4.6",
- "md-5",
+ "md-5 0.10.6",
  "pin-project-lite",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "tracing",
 ]
 
@@ -1154,7 +1142,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite 0.28.0",
@@ -1448,7 +1436,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1464,6 +1452,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1893,7 +1890,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
@@ -1966,6 +1963,12 @@ checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cocoa"
@@ -2393,7 +2396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
 dependencies = [
  "crc",
- "digest",
+ "digest 0.10.7",
  "rand 0.9.4",
  "regex",
  "rustversion",
@@ -2506,6 +2509,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.29.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2571,6 +2583,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2579,7 +2600,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "serde",
@@ -2741,11 +2762,11 @@ dependencies = [
  "cbc",
  "dbus",
  "fastrand",
- "hkdf",
+ "hkdf 0.12.4",
  "num",
  "once_cell",
  "openssl",
- "sha2",
+ "sha2 0.10.9",
  "zeroize",
 ]
 
@@ -2857,10 +2878,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -2981,7 +3013,7 @@ dependencies = [
  "ccm",
  "chacha20poly1305",
  "der-parser",
- "hmac",
+ "hmac 0.12.1",
  "log",
  "p256",
  "p384",
@@ -2993,8 +3025,8 @@ dependencies = [
  "rkyv",
  "rustls",
  "sec1",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
  "webrtc-util",
@@ -3064,7 +3096,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -3092,7 +3124,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -3114,11 +3146,11 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
- "hkdf",
+ "hkdf 0.12.4",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -3263,13 +3295,12 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "etcetera"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if 1.0.4",
- "home",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3436,6 +3467,17 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
+ "spin",
+]
+
+[[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "futures-core",
+ "futures-sink",
  "spin",
 ]
 
@@ -4163,9 +4205,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hashbrown"
@@ -4197,20 +4236,11 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
- "hashbrown 0.14.5",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
-dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -4243,7 +4273,16 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -4252,7 +4291,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4369,6 +4417,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -4932,7 +4989,7 @@ dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
+ "hmac 0.12.1",
  "js-sys",
  "p256",
  "p384",
@@ -4941,7 +4998,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "simple_asn1",
 ]
@@ -5157,10 +5214,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags 2.11.0",
  "libc",
- "plain",
- "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -5193,9 +5247,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "95b4103cffefa72eb8428cb6b47d6627161e51c2739fc5e3b734584157bc642a"
 dependencies = [
  "cc",
  "pkg-config",
@@ -5456,7 +5510,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if 1.0.4",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if 1.0.4",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5843,7 +5907,7 @@ version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cae50786bfa1214ed441f98addbea51ca1b9aaa9e4bf5369cda36654b3efaa"
 dependencies = [
- "flume",
+ "flume 0.11.1",
  "image",
  "nokhwa-bindings-linux",
  "nokhwa-bindings-macos",
@@ -5874,7 +5938,7 @@ dependencies = [
  "core-foundation 0.10.1",
  "core-media-sys",
  "core-video-sys",
- "flume",
+ "flume 0.11.1",
  "nokhwa-core",
  "objc",
  "once_cell",
@@ -6099,7 +6163,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "url",
 ]
@@ -6478,7 +6542,7 @@ dependencies = [
  "chrono",
  "dyn-clone",
  "ed25519-dalek",
- "hmac",
+ "hmac 0.12.1",
  "http 1.4.0",
  "itertools 0.10.5",
  "log",
@@ -6493,7 +6557,7 @@ dependencies = [
  "serde_path_to_error",
  "serde_plain",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "thiserror 1.0.69",
  "url",
@@ -6745,7 +6809,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -6757,7 +6821,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -6818,7 +6882,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if 1.0.4",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -7153,12 +7217,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -7634,9 +7692,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.0",
  "getrandom 0.4.2",
@@ -7713,7 +7771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.10.0",
+ "rand 0.10.1",
 ]
 
 [[package]]
@@ -7820,15 +7878,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -8007,7 +8056,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -8083,7 +8132,7 @@ dependencies = [
  "cpal 0.17.1",
  "dasp_sample",
  "num-rational",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rand_distr",
  "rtrb",
  "symphonia",
@@ -8132,7 +8181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
  "const-oid",
- "digest",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -8143,6 +8192,16 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8189,16 +8248,17 @@ checksum = "7204ed6420f698836b76d4d5c2ec5dec7585fd5c3a788fd1cde855d1de598239"
 
 [[package]]
 name = "rusqlite"
-version = "0.32.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
 dependencies = [
  "bitflags 2.11.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink 0.9.1",
+ "hashlink",
  "libsqlite3-sys",
  "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -8231,7 +8291,7 @@ version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
  "walkdir",
 ]
 
@@ -8558,11 +8618,11 @@ dependencies = [
  "futures-util",
  "generic-array",
  "getrandom 0.2.17",
- "hkdf",
+ "hkdf 0.12.4",
  "num",
  "once_cell",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "zbus",
 ]
 
@@ -8985,7 +9045,18 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -9002,7 +9073,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -9094,7 +9176,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -9217,7 +9299,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -9270,10 +9352,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlx"
-version = "0.8.6"
+name = "sqlite-wasm-rs"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -9284,12 +9378,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "cfg-if 1.0.4",
  "chrono",
  "crc",
  "crossbeam-queue",
@@ -9299,16 +9394,15 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.5",
- "hashlink 0.10.0",
+ "hashbrown 0.16.1",
+ "hashlink",
  "indexmap 2.13.0",
  "log",
  "memchr",
- "once_cell",
  "percent-encoding",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -9320,9 +9414,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9333,78 +9427,63 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
 dependencies = [
+ "cfg-if 1.0.4",
  "dotenvy",
  "either",
  "heck 0.5.0",
  "hex",
- "once_cell",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn 2.0.117",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "atoi",
- "base64 0.22.1",
  "bitflags 2.11.0",
  "byteorder",
  "bytes",
  "chrono",
  "crc",
- "digest",
+ "digest 0.11.3",
  "dotenvy",
  "either",
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "generic-array",
- "hex",
- "hkdf",
- "hmac",
- "itoa",
  "log",
- "md-5",
- "memchr",
- "once_cell",
  "percent-encoding",
- "rand 0.8.5",
- "rsa",
  "serde",
- "sha1",
- "sha2",
- "smallvec",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "sqlx-core",
- "stringprep",
  "thiserror 2.0.18",
  "tracing",
  "uuid",
- "whoami",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64 0.22.1",
@@ -9418,18 +9497,16 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "hkdf",
- "hmac",
- "home",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.11.0",
  "memchr",
- "once_cell",
- "rand 0.8.5",
+ "rand 0.10.1",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -9441,13 +9518,14 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
  "chrono",
- "flume",
+ "flume 0.12.0",
+ "form_urlencoded",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -9457,7 +9535,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
- "serde_urlencoded",
  "sqlx-core",
  "thiserror 2.0.18",
  "tracing",
@@ -9574,7 +9651,7 @@ dependencies = [
  "base64 0.22.1",
  "crc",
  "lazy_static",
- "md-5",
+ "md-5 0.10.6",
  "rand 0.9.4",
  "ring",
  "subtle",
@@ -10169,7 +10246,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "syn 2.0.117",
  "tauri-utils",
  "thiserror 2.0.18",
@@ -10790,11 +10867,11 @@ checksum = "a2b36a9dd327e9f401320a2cb4572cc76ff43742bcfc3291f871691050f140ba"
 dependencies = [
  "base32",
  "constant_time_eq",
- "hmac",
+ "hmac 0.12.1",
  "qrcodegen-image",
  "rand 0.9.4",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "url",
  "urlencoding",
 ]
@@ -11021,7 +11098,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "utf-8",
 ]
@@ -11038,7 +11115,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
 ]
 
@@ -11052,7 +11129,7 @@ dependencies = [
  "base64 0.22.1",
  "futures",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "portable-atomic",
  "rand 0.9.4",
  "ring",
@@ -11272,9 +11349,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typetag"
@@ -11433,7 +11510,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -11652,7 +11729,7 @@ dependencies = [
  "cpal 0.17.1",
  "futures",
  "getrandom 0.2.17",
- "hmac",
+ "hmac 0.12.1",
  "image",
  "kaiku-vp8-decoder",
  "keyring",
@@ -11670,7 +11747,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smol_str",
  "sysinfo 0.39.0",
  "tauri",
@@ -11712,11 +11789,11 @@ dependencies = [
  "argon2",
  "bs58",
  "getrandom 0.2.17",
- "hmac",
+ "hmac 0.12.1",
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "vodozemac",
  "zeroize",
@@ -11747,7 +11824,7 @@ dependencies = [
  "fred",
  "futures",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http-body-util",
  "image",
  "infer",
@@ -11767,8 +11844,8 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "sqlx",
  "tempfile",
  "thiserror 2.0.18",
@@ -11829,15 +11906,15 @@ dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "hkdf",
- "hmac",
+ "hkdf 0.12.4",
+ "hmac 0.12.1",
  "matrix-pickle",
  "prost",
  "rand 0.8.5",
  "serde",
  "serde_bytes",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "thiserror 2.0.18",
  "x25519-dalek",
@@ -11937,12 +12014,6 @@ checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
-
-[[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -12168,7 +12239,7 @@ dependencies = [
  "sdp",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smol_str",
  "stun",
  "thiserror 1.0.69",
@@ -12282,11 +12353,11 @@ dependencies = [
  "byteorder",
  "bytes",
  "ctr",
- "hmac",
+ "hmac 0.12.1",
  "log",
  "rtcp",
  "rtp",
- "sha1",
+ "sha1 0.10.6",
  "subtle",
  "thiserror 1.0.69",
  "tokio",
@@ -12369,13 +12440,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite",
-]
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
 name = "winapi"
@@ -12764,15 +12831,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -12820,21 +12878,6 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -12905,12 +12948,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -12929,12 +12966,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -12950,12 +12981,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -12989,12 +13014,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -13010,12 +13029,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -13037,12 +13050,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -13058,12 +13065,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -13239,7 +13240,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
- "sha2",
+ "sha2 0.10.9",
  "soup3",
  "tao-macros",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ webrtc = "0.17"
 smol_str = "0.2"
 
 # Database
-sqlx = { version = "0.8.6", default-features = false, features = ["postgres", "runtime-tokio", "uuid", "chrono", "json", "macros", "migrate"] }
+sqlx = { version = "0.9.0", default-features = false, features = ["postgres", "runtime-tokio", "uuid", "chrono", "json", "macros", "migrate"] }
 
 # Redis
 fred = { version = "10", features = ["i-scripts"] }

--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -65,13 +65,10 @@ url = "2"
 # `Entry::new` — see lib.rs setup callback.
 keyring = "4"
 keyring-core = "1"
-# rusqlite stays on 0.32: cargo's `links = "sqlite3"` namespace conflicts
-# with sqlx 0.8.x's transitive sqlx-sqlite (which pins libsqlite3-sys 0.30).
-# rusqlite >= 0.33 requires libsqlite3-sys >= 0.31 and refuses to coexist —
-# even though sqlx-sqlite is optional and unactivated in our config, cargo's
-# resolver enforces `links` constraints globally across optional deps.
-# Unblock requires sqlx 0.9 (currently only 0.9.0-alpha.1).
-rusqlite = { version = "0.32", features = ["bundled"] }
+# rusqlite ≥ 0.33 requires sqlx ≥ 0.9 in the workspace: both link the native
+# sqlite3 (cargo `links` key) via libsqlite3-sys, and sqlx 0.8's sqlx-sqlite
+# pinned an incompatible version (#115). Keep the two in step when bumping.
+rusqlite = { version = "0.38", features = ["bundled"] }
 
 # Audio denoising + VAD
 nnnoiseless = { version = "0.5", default-features = false }

--- a/server/src/admin/queries.rs
+++ b/server/src/admin/queries.rs
@@ -1048,7 +1048,7 @@ pub(super) async fn list_audit_log(
     });
 
     // Shared WHERE-clause builder used by both the count and main queries.
-    let push_filters = |builder: &mut QueryBuilder<'_, sqlx::Postgres>| {
+    let push_filters = |builder: &mut QueryBuilder<sqlx::Postgres>| {
         let mut has_condition = false;
         if let Some(ref pattern) = action_pattern {
             builder.push(" WHERE ");

--- a/server/src/guild/queries/core.rs
+++ b/server/src/guild/queries/core.rs
@@ -197,7 +197,7 @@ pub async fn fetch_guild_owner_required(pool: &PgPool, guild_id: Uuid) -> Result
 /// the updated `Guild`.
 pub async fn update_guild_dynamic(
     pool: &PgPool,
-    mut builder: QueryBuilder<'_, Postgres>,
+    mut builder: QueryBuilder<Postgres>,
     guild_id: Uuid,
 ) -> Result<Guild, GuildError> {
     builder.push(" WHERE id = ");
@@ -478,7 +478,7 @@ pub async fn fetch_guild_settings(
 /// updated `(threads_enabled, discoverable, tags, banner_url)` tuple.
 pub async fn update_guild_settings_dynamic(
     pool: &PgPool,
-    mut builder: QueryBuilder<'_, Postgres>,
+    mut builder: QueryBuilder<Postgres>,
     guild_id: Uuid,
 ) -> Result<(bool, bool, Vec<String>, Option<String>), GuildError> {
     builder

--- a/server/src/observability/ingestion.rs
+++ b/server/src/observability/ingestion.rs
@@ -725,7 +725,7 @@ pub fn spawn_ingestion_workers(
                 }
             }
             // Flush batch
-            let mut qb: sqlx::QueryBuilder<'_, sqlx::Postgres> = sqlx::QueryBuilder::new(
+            let mut qb: sqlx::QueryBuilder<sqlx::Postgres> = sqlx::QueryBuilder::new(
                 "INSERT INTO telemetry_log_events \
                  (ts, level, service, domain, event, message, trace_id, span_id, attrs) ",
             );
@@ -761,7 +761,7 @@ pub fn spawn_ingestion_workers(
                     Err(_) => break,
                 }
             }
-            let mut qb: sqlx::QueryBuilder<'_, sqlx::Postgres> = sqlx::QueryBuilder::new(
+            let mut qb: sqlx::QueryBuilder<sqlx::Postgres> = sqlx::QueryBuilder::new(
                 "INSERT INTO telemetry_trace_index \
                  (trace_id, span_name, domain, route, status_code, duration_ms, ts, service) ",
             );
@@ -795,7 +795,7 @@ pub fn spawn_ingestion_workers(
                     Err(_) => break,
                 }
             }
-            let mut qb: sqlx::QueryBuilder<'_, sqlx::Postgres> = sqlx::QueryBuilder::new(
+            let mut qb: sqlx::QueryBuilder<sqlx::Postgres> = sqlx::QueryBuilder::new(
                 "INSERT INTO telemetry_metric_samples \
                  (ts, metric_name, scope, labels, value_count, value_sum, value_p50, value_p95, value_p99) ",
             );

--- a/server/src/observability/retention.rs
+++ b/server/src/observability/retention.rs
@@ -123,7 +123,7 @@ async fn purge_old_trace_index(pool: &PgPool) -> i64 {
 /// Deletes up to [`DELETE_BATCH_SIZE`] rows per iteration until no more rows
 /// match the retention cutoff. The SQL must accept `$1` (retention days) and
 /// `$2` (batch size limit).
-async fn purge_in_batches(pool: &PgPool, sql: &str, table_label: &str) -> i64 {
+async fn purge_in_batches(pool: &PgPool, sql: &'static str, table_label: &str) -> i64 {
     let mut total_deleted: i64 = 0;
     loop {
         match sqlx::query(sql)

--- a/server/src/observability/storage.rs
+++ b/server/src/observability/storage.rs
@@ -433,7 +433,9 @@ pub async fn query_top_routes(
         format!("{BASE}{ORDER_BY_P95}")
     };
 
-    sqlx::query_as::<_, TopRouteEntry>(&sql)
+    // SQL is concatenated from two const fragments above; all user input is
+    // bound via $1..$3. AssertSqlSafe is required by sqlx 0.9's SqlSafeStr.
+    sqlx::query_as::<_, TopRouteEntry>(sqlx::AssertSqlSafe(sql))
         .bind(from)
         .bind(to)
         .bind(limit)


### PR DESCRIPTION
## Summary

Closes out the dependency sweep by resolving its last blocked item. **sqlx 0.9.0 stable** (released 2026-05-06) lifts the cargo `links = "sqlite3"` conflict that hard-blocked rusqlite ≥ 0.33 since February (#115) — sqlx-sqlite now specifies `libsqlite3-sys` as a version range, so rusqlite 0.38 (libsqlite3-sys 0.36) coexists.

## sqlx 0.9 migration surface (small)

- `QueryBuilder` lost its lifetime parameter — 6 sites updated (`guild/queries/core.rs`, `admin/queries.rs`, `observability/ingestion.rs`)
- New `SqlSafeStr` bound on `query*()`: `purge_in_batches()` now takes `&'static str` (all callers pass literals); the one `format!()`-built query (`observability/storage.rs`, const fragments + bound params) wrapped in `AssertSqlSafe` with a justification comment
- `.sqlx/` offline cache regenerated with sqlx-cli 0.9 (`--workspace --all-targets`): 56 of 79 entries updated by 0.9's improved generic-plan nullability inference, none lost
- rusqlite comment in `client/src-tauri/Cargo.toml` rewritten: the constraint is now "keep sqlx and rusqlite in step", not "blocked"

## Verification

- ✅ `cargo test -p vc-server` — **948 passed, 0 failed** (incl. all `#[sqlx::test]` per-test-DB modules — the main 0.9 compat risk)
- ✅ rusqlite 0.38 (bundled, sqlite 3.51.1) runtime smoke test mirroring `crypto/store.rs` patterns (`params!`, prepared statements, `QueryReturnedNoRows`) — passed
- ✅ `cargo clippy -p vc-server -p vc-crypto -- -D warnings` — clean
- ✅ `cargo deny check` — advisories/bans/licenses/sources all ok
- ⚠ vc-client compile validated by CI (local build blocked by pre-existing clang-22/bindgen env issue in vpx/libspa, unrelated to this change)

Closes #115. Goal 1 item from `docs/developer-guide/project/goals.md` (dependency sweep close-out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)