### PR TITLE
feat(voice): make output device selection actually work (Phase 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Frontend: bumped `dompurify` (XSS in HTML sanitization), `uuid` (buffer-bounds check via mermaid), and added transitive overrides for `postcss` (XSS) and `dompurify` (mermaid's nested copy). `bun audit` reduced from 12 → 6 advisories; the 6 remaining are vite dev-server paths via vitest, already accepted as dev-only exceptions per PR #517 and pending the vitest 4.x → 4.x compat work in Phase 6c of the dep-update sweep.
 
 ### Fixed
+- Audio output device selection now actually works: the device chosen in settings is applied when joining voice (previously the system default was always used), switching devices mid-call moves audio to the new speaker immediately on desktop, and selections made in the voice panel are persisted across sessions
+- Browser client: output device selection (setSinkId) now reaches the remote-audio elements; previously the selection silently did nothing
+- Audio settings page now lists devices the voice stack can actually use on desktop (native device names instead of browser media ids)
 - Android: `AuthState`'s `CoroutineScope` is now DI-provided via `@AuthCoroutineScope`, resolving 8 failing unit/integration tests (`AuthStateTest`, `AuthFlowTest`, `QrLoginFlowTest`) that previously read stale `StateFlow` values under `TestCoroutineScheduler`
 - Android: `ChatRepository`'s `CoroutineScope` is now DI-provided via `@ChatCoroutineScope`, resolving 5 failing unit tests (`MessageFlowTest`) that previously missed WebSocket events emitted off-scheduler
 - Android: voice-layer `CoroutineScope` is now DI-provided, making the full `WebRtcManager` test suite runnable under `TestCoroutineScheduler` and unblocking CI coverage for dual-PC ICE state transitions

--- a/client/src-tauri/src/audio/handle.rs
+++ b/client/src-tauri/src/audio/handle.rs
@@ -63,6 +63,9 @@ enum CaptureControl {
 /// Control messages for playback task
 enum PlaybackControl {
     Stop,
+    /// Rebuild the output stream on a new device, keeping the same sample
+    /// buffer (mid-call speaker switching). Boxed: `cpal::Device` is large.
+    SwitchDevice(Box<Device>),
 }
 
 impl AudioHandle {
@@ -134,14 +137,36 @@ impl AudioHandle {
         Ok(AudioDeviceList { inputs, outputs })
     }
 
-    /// Set the input device by name
+    /// Set the input device by name.
+    ///
+    /// Takes effect when the next capture stream starts; an active capture
+    /// is not rebuilt (input switching mid-capture is not supported yet).
     pub fn set_input_device(&mut self, device_id: Option<String>) {
         self.input_device_name = device_id;
     }
 
-    /// Set the output device by name
-    pub fn set_output_device(&mut self, device_id: Option<String>) {
+    /// Set the output device by name.
+    ///
+    /// Stores the name for future playback starts AND live-switches any
+    /// running playback task: the task rebuilds its CPAL stream on the new
+    /// device while keeping the same sample buffer, so audio moves to the
+    /// new speaker mid-call without dropping frames.
+    ///
+    /// Errors if the named device doesn't exist (the stored name is still
+    /// updated, matching the lookup-or-default behavior at stream start).
+    pub async fn set_output_device(&mut self, device_id: Option<String>) -> Result<(), AudioError> {
         self.output_device_name = device_id;
+        if let Some(control) = &self.playback_control {
+            let device = self.get_device(self.output_device_name.as_deref(), false)?;
+            if control
+                .send(PlaybackControl::SwitchDevice(Box::new(device)))
+                .await
+                .is_err()
+            {
+                debug!("Playback task not running; output device applies on next start");
+            }
+        }
+        Ok(())
     }
 
     /// Get device by name
@@ -572,15 +597,6 @@ fn run_playback_task(
     mut input_rx: mpsc::Receiver<Vec<u8>>,
     control_rx: &mut mpsc::Receiver<PlaybackControl>,
 ) {
-    use cpal::traits::StreamTrait;
-    use cpal::{BufferSize, StreamConfig};
-
-    let config = StreamConfig {
-        channels: CHANNELS,
-        sample_rate: SAMPLE_RATE,
-        buffer_size: BufferSize::Default,
-    };
-
     let decoder = match Decoder::new(SAMPLE_RATE, OpusChannels::Stereo) {
         Ok(dec) => Arc::new(std::sync::Mutex::new(dec)),
         Err(e) => {
@@ -617,18 +633,43 @@ fn run_playback_task(
         }
     });
 
-    let playback_buffer_clone2 = playback_buffer;
-    let deafened_clone = deafened;
+    let Some(stream) = build_buffer_output_stream(&device, &deafened, &playback_buffer) else {
+        return;
+    };
+
+    playback_control_loop(stream, &deafened, &playback_buffer, control_rx);
+    info!("Playback task stopped");
+}
+
+/// Build and start a CPAL output stream that drains the shared sample
+/// buffer. Returns `None` (with the error logged) when the stream can't be
+/// created or started on the given device.
+fn build_buffer_output_stream(
+    device: &Device,
+    deafened: &Arc<AtomicBool>,
+    playback_buffer: &Arc<std::sync::Mutex<std::collections::VecDeque<f32>>>,
+) -> Option<cpal::Stream> {
+    use cpal::traits::StreamTrait;
+    use cpal::{BufferSize, StreamConfig};
+
+    let config = StreamConfig {
+        channels: CHANNELS,
+        sample_rate: SAMPLE_RATE,
+        buffer_size: BufferSize::Default,
+    };
+
+    let playback_buffer = playback_buffer.clone();
+    let deafened = deafened.clone();
 
     let stream = match device.build_output_stream(
         &config,
         move |data: &mut [f32], _| {
-            if deafened_clone.load(Ordering::Relaxed) {
+            if deafened.load(Ordering::Relaxed) {
                 data.fill(0.0);
                 return;
             }
 
-            if let Ok(mut buffer) = playback_buffer_clone2.lock() {
+            if let Ok(mut buffer) = playback_buffer.lock() {
                 let available = buffer.len().min(data.len());
                 #[allow(clippy::needless_range_loop)]
                 for i in 0..available {
@@ -650,24 +691,45 @@ fn run_playback_task(
         Ok(s) => s,
         Err(e) => {
             error!("Failed to build playback stream: {}", e);
-            return;
+            return None;
         }
     };
 
     if let Err(e) = stream.play() {
         error!("Failed to start playback stream: {}", e);
-        return;
+        return None;
     }
 
-    // Block until stop signal
+    Some(stream)
+}
+
+/// Block on control messages until Stop, rebuilding the output stream in
+/// place on `SwitchDevice`. The new stream is built BEFORE the old one is
+/// dropped so a failed switch keeps audio on the previous device.
+fn playback_control_loop(
+    mut stream: cpal::Stream,
+    deafened: &Arc<AtomicBool>,
+    playback_buffer: &Arc<std::sync::Mutex<std::collections::VecDeque<f32>>>,
+    control_rx: &mut mpsc::Receiver<PlaybackControl>,
+) {
     while let Some(msg) = control_rx.blocking_recv() {
         match msg {
             PlaybackControl::Stop => break,
+            PlaybackControl::SwitchDevice(new_device) => {
+                match build_buffer_output_stream(&new_device, deafened, playback_buffer) {
+                    Some(new_stream) => {
+                        stream = new_stream;
+                        info!("Playback switched to new output device");
+                    }
+                    None => {
+                        warn!("Output device switch failed; keeping previous device");
+                    }
+                }
+            }
         }
     }
 
     drop(stream);
-    info!("Playback task stopped");
 }
 
 /// Run PCM playback task — receives pre-decoded f32 samples from the mixer.
@@ -680,15 +742,6 @@ fn run_pcm_playback_task(
     mut input_rx: mpsc::Receiver<Vec<f32>>,
     control_rx: &mut mpsc::Receiver<PlaybackControl>,
 ) {
-    use cpal::traits::StreamTrait;
-    use cpal::{BufferSize, StreamConfig};
-
-    let config = StreamConfig {
-        channels: CHANNELS,
-        sample_rate: SAMPLE_RATE,
-        buffer_size: BufferSize::Default,
-    };
-
     let playback_buffer = Arc::new(std::sync::Mutex::new(std::collections::VecDeque::new()));
 
     // Spawn thread to receive PCM frames and push into the ring buffer.
@@ -710,56 +763,11 @@ fn run_pcm_playback_task(
         }
     });
 
-    let playback_buffer_clone2 = playback_buffer;
-    let deafened_clone = deafened;
-
-    let stream = match device.build_output_stream(
-        &config,
-        move |data: &mut [f32], _| {
-            if deafened_clone.load(Ordering::Relaxed) {
-                data.fill(0.0);
-                return;
-            }
-
-            if let Ok(mut buffer) = playback_buffer_clone2.lock() {
-                let available = buffer.len().min(data.len());
-                #[allow(clippy::needless_range_loop)]
-                for i in 0..available {
-                    data[i] = buffer.pop_front().unwrap();
-                }
-                #[allow(clippy::needless_range_loop)]
-                for i in available..data.len() {
-                    data[i] = 0.0;
-                }
-            } else {
-                data.fill(0.0);
-            }
-        },
-        |err| {
-            error!("PCM playback stream error: {}", err);
-        },
-        None,
-    ) {
-        Ok(s) => s,
-        Err(e) => {
-            error!("Failed to build PCM playback stream: {}", e);
-            return;
-        }
+    let Some(stream) = build_buffer_output_stream(&device, &deafened, &playback_buffer) else {
+        return;
     };
 
-    if let Err(e) = stream.play() {
-        error!("Failed to start PCM playback stream: {}", e);
-        return;
-    }
-
-    // Block until stop signal
-    while let Some(msg) = control_rx.blocking_recv() {
-        match msg {
-            PlaybackControl::Stop => break,
-        }
-    }
-
-    drop(stream);
+    playback_control_loop(stream, &deafened, &playback_buffer, control_rx);
     info!("PCM playback task stopped");
 }
 

--- a/client/src-tauri/src/commands/voice.rs
+++ b/client/src-tauri/src/commands/voice.rs
@@ -693,7 +693,11 @@ pub async fn set_output_device(
     let mut voice = state.voice.write().await;
     let voice_state = voice.as_mut().ok_or("Voice not initialized")?;
 
-    voice_state.audio.set_output_device(device_id);
+    voice_state
+        .audio
+        .set_output_device(device_id)
+        .await
+        .map_err(|e| e.to_string())?;
 
     Ok(())
 }

--- a/client/src/components/settings/AudioSettings.tsx
+++ b/client/src/components/settings/AudioSettings.tsx
@@ -1,24 +1,52 @@
 import { Component, createSignal, onMount, For, Show } from "solid-js";
 import { appSettings, updateAudioSetting, isSettingsLoading } from "@/stores/settings";
+import { createVoiceAdapter, getVoiceAdapter } from "@/lib/webrtc";
+import type { AudioDevice } from "@/lib/webrtc";
 import { Mic, Volume2 } from "lucide-solid";
 
 const AudioSettings: Component = () => {
-    const [inputDevices, setInputDevices] = createSignal<MediaDeviceInfo[]>([]);
-    const [outputDevices, setOutputDevices] = createSignal<MediaDeviceInfo[]>([]);
+    const [inputDevices, setInputDevices] = createSignal<AudioDevice[]>([]);
+    const [outputDevices, setOutputDevices] = createSignal<AudioDevice[]>([]);
 
     onMount(async () => {
         try {
-            // Request permission so labels are populated
-            const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-            stream.getTracks().forEach((track) => track.stop());
-
-            const devices = await navigator.mediaDevices.enumerateDevices();
-            setInputDevices(devices.filter((d) => d.kind === "audioinput"));
-            setOutputDevices(devices.filter((d) => d.kind === "audiooutput"));
+            // Enumerate through the voice adapter so device ids match what
+            // the voice stack expects: CPAL device names on desktop,
+            // MediaDevices ids in the browser. (navigator.mediaDevices ids
+            // would be meaningless to the native audio backend.)
+            const adapter = await createVoiceAdapter();
+            const result = await adapter.getAudioDevices();
+            if (result.ok) {
+                setInputDevices(result.value.inputs);
+                setOutputDevices(result.value.outputs);
+            } else {
+                console.error("Failed to enumerate audio devices:", result.error);
+            }
         } catch (err) {
             console.error("Failed to enumerate audio devices:", err);
         }
     });
+
+    // Persist the selection and live-apply it to an active voice session.
+    const changeDevice = async (kind: "input" | "output", value: string) => {
+        const deviceId = value === "default" ? null : value;
+        await updateAudioSetting(
+            kind === "input" ? "input_device" : "output_device",
+            deviceId,
+        );
+        // Live-apply only for concrete devices; "default" takes effect on
+        // the next voice join (the adapter API has no "reset to default").
+        const adapter = getVoiceAdapter();
+        if (adapter && deviceId) {
+            const result =
+                kind === "input"
+                    ? await adapter.setInputDevice(deviceId)
+                    : await adapter.setOutputDevice(deviceId);
+            if (!result.ok) {
+                console.warn(`Failed to apply ${kind} device:`, result.error);
+            }
+        }
+    };
 
     return (
         <div class="space-y-6">
@@ -41,7 +69,7 @@ const AudioSettings: Component = () => {
                                 <select
                                     class="w-full px-4 py-2 bg-surface-base border border-white/10 rounded-xl text-text-primary focus:outline-none focus:border-accent-primary focus:ring-1 focus:ring-accent-primary transition-colors appearance-none cursor-pointer"
                                     value={settings().audio.input_device || "default"}
-                                    onChange={(e) => updateAudioSetting("input_device", e.currentTarget.value === "default" ? null : e.currentTarget.value)}
+                                    onChange={(e) => changeDevice("input", e.currentTarget.value)}
                                 >
                                     <option value="default">Default Device</option>
                                     <For each={inputDevices()}>
@@ -78,7 +106,7 @@ const AudioSettings: Component = () => {
                                 <select
                                     class="w-full px-4 py-2 bg-surface-base border border-white/10 rounded-xl text-text-primary focus:outline-none focus:border-accent-primary focus:ring-1 focus:ring-accent-primary transition-colors appearance-none cursor-pointer"
                                     value={settings().audio.output_device || "default"}
-                                    onChange={(e) => updateAudioSetting("output_device", e.currentTarget.value === "default" ? null : e.currentTarget.value)}
+                                    onChange={(e) => changeDevice("output", e.currentTarget.value)}
                                 >
                                     <option value="default">Default Device</option>
                                     <For each={outputDevices()}>

--- a/client/src/components/voice/AudioDeviceSettings.tsx
+++ b/client/src/components/voice/AudioDeviceSettings.tsx
@@ -26,6 +26,7 @@ import { X, Mic, Headphones, Loader2 } from "lucide-solid";
 import { createVoiceAdapter } from "@/lib/webrtc";
 import type { AudioDeviceList, VoiceError, VoiceAdapter } from "@/lib/webrtc";
 import { setSpeaking } from "@/stores/voice";
+import { updateAudioSetting } from "@/stores/settings";
 import { showToast } from "@/components/ui/Toast";
 
 interface AudioDeviceSettingsProps {
@@ -239,6 +240,9 @@ const AudioDeviceSettings: Component<AudioDeviceSettingsProps> = (props) => {
           duration: 8000,
         });
         console.error("Set input device failed:", result.error);
+      } else {
+        // Persist so the selection survives leave/rejoin and app restart
+        await updateAudioSetting("input_device", deviceId || null);
       }
     } catch (err) {
       console.error("Failed to set input device:", err);
@@ -268,6 +272,9 @@ const AudioDeviceSettings: Component<AudioDeviceSettingsProps> = (props) => {
           duration: 8000,
         });
         console.error("Set output device failed:", result.error);
+      } else {
+        // Persist so the selection survives leave/rejoin and app restart
+        await updateAudioSetting("output_device", deviceId || null);
       }
     } catch (err) {
       console.error("Failed to set output device:", err);

--- a/client/src/stores/__tests__/voice.test.ts
+++ b/client/src/stores/__tests__/voice.test.ts
@@ -19,6 +19,8 @@ const mockAdapter = {
   handleSubscriberOffer: vi.fn(),
   handleIceCandidate: vi.fn(),
   setVadConfig: vi.fn(),
+  setInputDevice: vi.fn().mockResolvedValue({ ok: true }),
+  setOutputDevice: vi.fn().mockResolvedValue({ ok: true }),
 };
 
 vi.mock("@/lib/webrtc", () => ({
@@ -89,7 +91,10 @@ import {
   handleVoiceUserStats,
   updateVadFromSettings,
   isPttActive,
+  applyStoredAudioDevices,
 } from "../voice";
+import { appSettings } from "@/stores/settings";
+import type { VoiceAdapter } from "@/lib/webrtc/types";
 
 describe("voice store", () => {
   beforeEach(() => {
@@ -392,6 +397,75 @@ describe("voice store", () => {
 
     it("isPttActive returns false when no PTT controller", () => {
       expect(isPttActive()).toBe(false);
+    });
+  });
+
+  describe("applyStoredAudioDevices", () => {
+    const voiceSettings = {
+      push_to_talk: false,
+      push_to_talk_key: null,
+      push_to_talk_release_delay: 200,
+      push_to_mute: false,
+      push_to_mute_key: null,
+      push_to_mute_release_delay: 200,
+      voice_activity_detection: false,
+      vad_threshold: 0.5,
+    };
+
+    beforeEach(() => {
+      mockAdapter.setInputDevice.mockClear();
+      mockAdapter.setOutputDevice.mockClear();
+    });
+
+    it("applies stored input and output devices to the adapter", async () => {
+      vi.mocked(appSettings).mockReturnValueOnce({
+        voice: voiceSettings,
+        audio: { input_device: "Mic A", output_device: "Speakers B" },
+      } as unknown as ReturnType<typeof appSettings>);
+
+      await applyStoredAudioDevices(mockAdapter as unknown as VoiceAdapter);
+
+      expect(mockAdapter.setInputDevice).toHaveBeenCalledWith("Mic A");
+      expect(mockAdapter.setOutputDevice).toHaveBeenCalledWith("Speakers B");
+    });
+
+    it("skips adapter calls when no devices are stored (system default)", async () => {
+      vi.mocked(appSettings).mockReturnValueOnce({
+        voice: voiceSettings,
+        audio: { input_device: null, output_device: null },
+      } as unknown as ReturnType<typeof appSettings>);
+
+      await applyStoredAudioDevices(mockAdapter as unknown as VoiceAdapter);
+
+      expect(mockAdapter.setInputDevice).not.toHaveBeenCalled();
+      expect(mockAdapter.setOutputDevice).not.toHaveBeenCalled();
+    });
+
+    it("does not throw when applying a device fails", async () => {
+      vi.mocked(appSettings).mockReturnValueOnce({
+        voice: voiceSettings,
+        audio: { input_device: null, output_device: "Unplugged" },
+      } as unknown as ReturnType<typeof appSettings>);
+      mockAdapter.setOutputDevice.mockResolvedValueOnce({
+        ok: false,
+        error: { type: "device_not_found", message: "gone" },
+      });
+
+      await expect(
+        applyStoredAudioDevices(mockAdapter as unknown as VoiceAdapter),
+      ).resolves.toBeUndefined();
+    });
+
+    it("joinVoice applies stored devices after a successful join", async () => {
+      mockAdapter.join.mockResolvedValue({ ok: true });
+      vi.mocked(appSettings).mockReturnValue({
+        voice: voiceSettings,
+        audio: { input_device: null, output_device: "Headset" },
+      } as unknown as ReturnType<typeof appSettings>);
+
+      await joinVoice("ch-1");
+
+      expect(mockAdapter.setOutputDevice).toHaveBeenCalledWith("Headset");
     });
   });
 });

--- a/client/src/stores/voice.ts
+++ b/client/src/stores/voice.ts
@@ -13,7 +13,11 @@ import {
   type ParticipantMetrics,
   type QualityLevel,
 } from "@/lib/webrtc";
-import type { ScreenShareInfo, ScreenShareQuality } from "@/lib/webrtc/types";
+import type {
+  ScreenShareInfo,
+  ScreenShareQuality,
+  VoiceAdapter,
+} from "@/lib/webrtc/types";
 import type { VoiceParticipant, WebcamServerInfo } from "@/lib/types";
 import { channelsState } from "@/stores/channels";
 import { appSettings } from "@/stores/settings";
@@ -398,6 +402,37 @@ export async function cleanupVoice(): Promise<void> {
 /**
  * Join a voice channel.
  */
+/**
+ * Apply the input/output devices stored in settings to the voice adapter.
+ * Called on every voice join; failures are non-fatal (the system default
+ * device keeps working) but are logged for diagnosis. Exported for tests.
+ */
+export async function applyStoredAudioDevices(
+  adapter: VoiceAdapter,
+): Promise<void> {
+  const audio = appSettings()?.audio;
+  if (!audio) return;
+
+  if (audio.input_device) {
+    const result = await adapter.setInputDevice(audio.input_device);
+    if (!result.ok) {
+      console.warn(
+        "[Voice] Failed to apply stored input device:",
+        result.error,
+      );
+    }
+  }
+  if (audio.output_device) {
+    const result = await adapter.setOutputDevice(audio.output_device);
+    if (!result.ok) {
+      console.warn(
+        "[Voice] Failed to apply stored output device:",
+        result.error,
+      );
+    }
+  }
+}
+
 export async function joinVoice(channelId: string): Promise<void> {
   if (isJoining) {
     console.warn("[Voice] Join already in progress, ignoring duplicate call");
@@ -446,10 +481,24 @@ export async function joinVoice(channelId: string): Promise<void> {
         if (!remoteTrack.stream) return;
 
         console.log("[Voice] Remote audio track received:", remoteTrack.userId);
-        // Create an audio element to play the remote user's audio
+        // Create an audio element to play the remote user's audio.
+        // It must be in the DOM with data-stream-id so the browser
+        // adapter's setOutputDevice() can find it for setSinkId.
         const audio = new Audio();
         audio.srcObject = remoteTrack.stream;
         audio.autoplay = true;
+        audio.dataset.streamId = remoteTrack.stream.id;
+        audio.style.display = "none";
+        document.body.appendChild(audio);
+        // Route to the configured output device (default sink otherwise)
+        const outputDevice = appSettings()?.audio.output_device;
+        if (outputDevice && "setSinkId" in audio) {
+          (audio as HTMLAudioElement & { setSinkId(id: string): Promise<void> })
+            .setSinkId(outputDevice)
+            .catch((err) => {
+              console.warn("[Voice] Failed to set audio sink:", err);
+            });
+        }
         // Remove old element for this user if exists
         const old = remoteAudioElements.get(remoteTrack.userId);
         if (old) {
@@ -528,6 +577,11 @@ export async function joinVoice(channelId: string): Promise<void> {
       });
       throw new Error(getErrorMessage(result.error));
     }
+
+    // Apply the audio devices configured in settings — without this the
+    // stored selection never reaches the adapter and voice always uses
+    // the system default devices.
+    await applyStoredAudioDevices(adapter);
 
     // Start session tracking and metrics collection
     setVoiceState("sessionId", crypto.randomUUID());


### PR DESCRIPTION
## Summary

Closes the second Goal 2 / Phase 6 desktop item: **output device selection**. The roadmap said the `setOutputDevice()` command "exists but untested/incomplete" — investigation found the CPAL plumbing was fine but **nothing connected the pieces**:

| Broken | Now |
|---|---|
| Stored `output_device` setting never applied on voice join — system default always used | `applyStoredAudioDevices()` applies stored input+output devices on every join |
| Mid-call device change was a silent no-op (`set_output_device` only stored the name) | `PlaybackControl::SwitchDevice`: the playback task rebuilds its CPAL stream on the new device in place, keeping the shared sample buffer — audio moves to the new speaker immediately. New stream is built **before** the old one is dropped, so a failed switch keeps audio working |
| Settings page enumerated via `navigator.mediaDevices` — browser ids that can never match CPAL device names on desktop | Enumerates through the voice adapter: native names on desktop, MediaDevices in browser; changes live-apply to an active session |
| Voice-panel device picker applied but never persisted (lost on rejoin) | Persists via `updateAudioSetting` after successful apply |
| Browser `setSinkId` targeted `audio[data-stream-id]` elements that never had that attribute nor were in the DOM | Elements get the attribute, are attached hidden, and receive the configured sink at creation |

Bonus cleanup: the Opus and PCM playback tasks had byte-identical stream-building tails — now one shared `build_buffer_output_stream` + `playback_control_loop`.

## Tests

- 4 new vitest cases: stored devices applied on join, skipped when default, non-fatal on failure, `joinVoice` integration. Client suite **597 passing**, `tsc --noEmit` clean, eslint 0 errors.
- Rust changes compile-verified by CI (local vc-client build blocked by the known clang-22/bindgen env issue). Manual verification on this Linux machine after merge: switch output between speakers/headset mid-call.

Goal 2 item from `docs/developer-guide/project/goals.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)