### PR TITLE
fix(client): refresh unread state after WebSocket reconnect (Phase 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Frontend: bumped `dompurify` (XSS in HTML sanitization), `uuid` (buffer-bounds check via mermaid), and added transitive overrides for `postcss` (XSS) and `dompurify` (mermaid's nested copy). `bun audit` reduced from 12 → 6 advisories; the 6 remaining are vite dev-server paths via vitest, already accepted as dev-only exceptions per PR #517 and pending the vitest 4.x → 4.x compat work in Phase 6c of the dep-update sweep.
 
 ### Fixed
+- Unread indicators no longer go stale after a connection drop: reconnecting now refreshes channel and DM unread state, picking up messages that arrived (or were read on another device) while offline
 - Audio output device selection now actually works: the device chosen in settings is applied when joining voice (previously the system default was always used), switching devices mid-call moves audio to the new speaker immediately on desktop, and selections made in the voice panel are persisted across sessions
 - Browser client: output device selection (setSinkId) now reaches the remote-audio elements; previously the selection silently did nothing
 - Audio settings page now lists devices the voice stack can actually use on desktop (native device names instead of browser media ids)

--- a/client/src/stores/__tests__/websocket.test.ts
+++ b/client/src/stores/__tests__/websocket.test.ts
@@ -64,17 +64,23 @@ vi.mock("@/stores/channels", () => ({
   channelsState: { selectedChannelId: null },
   handleChannelReadEvent: vi.fn(),
   incrementUnreadCount: vi.fn(),
+  updateChannelLastMessageId: vi.fn(),
+  refreshChannelsForGuild: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("@/stores/guilds", () => ({
-  guildsState: { activeGuildId: null },
+  guildsState: { activeGuildId: null as string | null },
   getGuildIdForChannel: vi.fn(),
   incrementGuildUnread: vi.fn(),
+  DISCOVERY_SENTINEL: "__discovery__",
 }));
 
 vi.mock("@/stores/dms", () => ({
+  dmsState: { selectedDMId: null, isShowingFriends: false },
   handleDMReadEvent: vi.fn(),
   handleDMNameUpdated: vi.fn(),
+  updateDMLastMessage: vi.fn(),
+  loadDMs: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("@/lib/sound", () => ({
@@ -95,7 +101,11 @@ import {
   getTypingUsers,
   isConnected,
   cleanupWebSocket,
+  refreshUnreadStateAfterReconnect,
 } from "../websocket";
+import { refreshChannelsForGuild } from "@/stores/channels";
+import { guildsState } from "@/stores/guilds";
+import { loadDMs } from "@/stores/dms";
 
 describe("websocket store", () => {
   beforeEach(() => {
@@ -255,6 +265,51 @@ describe("websocket store", () => {
   describe("cleanupWebSocket", () => {
     it("does not throw", async () => {
       await expect(cleanupWebSocket()).resolves.not.toThrow();
+    });
+  });
+
+  describe("refreshUnreadStateAfterReconnect", () => {
+    const mutableGuilds = guildsState as { activeGuildId: string | null };
+
+    beforeEach(() => {
+      mutableGuilds.activeGuildId = null;
+      vi.mocked(refreshChannelsForGuild).mockClear().mockResolvedValue();
+      vi.mocked(loadDMs).mockClear().mockResolvedValue();
+    });
+
+    it("refreshes the active guild's channels and the DM list", async () => {
+      mutableGuilds.activeGuildId = "g1";
+
+      await refreshUnreadStateAfterReconnect();
+
+      expect(refreshChannelsForGuild).toHaveBeenCalledWith("g1");
+      expect(loadDMs).toHaveBeenCalled();
+    });
+
+    it("skips guild refresh when on home (no active guild)", async () => {
+      await refreshUnreadStateAfterReconnect();
+
+      expect(refreshChannelsForGuild).not.toHaveBeenCalled();
+      expect(loadDMs).toHaveBeenCalled();
+    });
+
+    it("skips guild refresh on the discovery view", async () => {
+      mutableGuilds.activeGuildId = "__discovery__";
+
+      await refreshUnreadStateAfterReconnect();
+
+      expect(refreshChannelsForGuild).not.toHaveBeenCalled();
+      expect(loadDMs).toHaveBeenCalled();
+    });
+
+    it("does not reject when a refresh fails", async () => {
+      mutableGuilds.activeGuildId = "g1";
+      vi.mocked(refreshChannelsForGuild).mockRejectedValueOnce(
+        new Error("network"),
+      );
+      vi.mocked(loadDMs).mockRejectedValueOnce(new Error("network"));
+
+      await expect(refreshUnreadStateAfterReconnect()).resolves.toBeUndefined();
     });
   });
 });

--- a/client/src/stores/channels.ts
+++ b/client/src/stores/channels.ts
@@ -144,6 +144,22 @@ export async function loadChannelsForGuild(guildId: string): Promise<void> {
 }
 
 /**
+ * Refresh the channel list for a guild WITHOUT touching the current
+ * selection or subscriptions.
+ *
+ * Used after a WebSocket reconnect to pick up unread metadata
+ * (`last_read_message_id`, `last_message_id`) that changed while offline —
+ * `loadChannelsForGuild` is unsuitable there because it auto-selects the
+ * first text channel, which would yank the user out of their current one.
+ *
+ * Errors propagate to the caller (reconnect recovery logs and continues).
+ */
+export async function refreshChannelsForGuild(guildId: string): Promise<void> {
+  const channels = await tauri.getGuildChannels(guildId);
+  setChannelsState({ channels });
+}
+
+/**
  * Load DM channels (for Home view).
  * Uses the dedicated /api/dm endpoint which returns DMListItem[].
  */

--- a/client/src/stores/guilds.ts
+++ b/client/src/stores/guilds.ts
@@ -36,7 +36,7 @@ interface GuildStoreState {
 }
 
 // Sentinel value representing the discovery view in activeGuildId
-const DISCOVERY_SENTINEL = "__discovery__";
+export const DISCOVERY_SENTINEL = "__discovery__";
 
 // Create the store
 const [guildsState, setGuildsState] = createStore<GuildStoreState>({

--- a/client/src/stores/websocket/index.ts
+++ b/client/src/stores/websocket/index.ts
@@ -51,18 +51,21 @@ import {
   handleChannelReadEvent,
   incrementUnreadCount,
   updateChannelLastMessageId,
+  refreshChannelsForGuild,
 } from "../channels";
 import { currentUser } from "../auth";
 import {
   guildsState,
   getGuildIdForChannel,
   incrementGuildUnread,
+  DISCOVERY_SENTINEL,
 } from "../guilds";
 import {
   dmsState,
   handleDMReadEvent,
   handleDMNameUpdated,
   updateDMLastMessage,
+  loadDMs,
 } from "../dms";
 import { handlePinAdded, handlePinRemoved } from "../channelPins";
 
@@ -1428,6 +1431,37 @@ export async function reinitWebSocketListeners(): Promise<void> {
  * Handle post-reconnect recovery: re-subscribe channels, reload messages, dismiss toast.
  * Snapshots current subscribed channels before resetting state, then re-subscribes and reloads.
  */
+/**
+ * Refresh channel/DM unread metadata after a reconnect. Exported for tests.
+ *
+ * - Active guild: re-fetch its channel list (selection-preserving) so the
+ *   sidebar unread dots reflect what happened while offline.
+ * - DMs: reload the DM list, which carries per-conversation unread state.
+ *
+ * Failures are logged and swallowed — reconnect recovery must not abort
+ * because one refresh call failed.
+ */
+export async function refreshUnreadStateAfterReconnect(): Promise<void> {
+  const tasks: Promise<unknown>[] = [];
+
+  const guildId = guildsState.activeGuildId;
+  if (guildId && guildId !== DISCOVERY_SENTINEL) {
+    tasks.push(
+      refreshChannelsForGuild(guildId).catch((err) =>
+        console.error("[WS] Failed to refresh guild channels", guildId, err),
+      ),
+    );
+  }
+
+  tasks.push(
+    loadDMs().catch((err) =>
+      console.error("[WS] Failed to refresh DM list", err),
+    ),
+  );
+
+  await Promise.all(tasks);
+}
+
 async function handleReconnect(): Promise<void> {
   const channelsToResubscribe = [...wsState.subscribedChannels];
   const channelsToReload = Object.keys(messagesState.byChannel).filter(
@@ -1438,7 +1472,11 @@ async function handleReconnect(): Promise<void> {
   setWsState("subscribedChannels", new Set());
   setWsState({ status: "connected", reconnectAttempt: 0, error: null });
 
-  // Re-subscribe and reload in parallel
+  // Re-subscribe, reload messages, and refresh unread metadata in parallel.
+  // The metadata refresh is what clears stale unread dots: messages that
+  // arrived (or were read on another device) while disconnected changed
+  // last_read_message_id / last_message_id server-side, and no WS event
+  // replays them after reconnect.
   await Promise.all([
     Promise.all(
       channelsToResubscribe.map((id) =>
@@ -1454,6 +1492,7 @@ async function handleReconnect(): Promise<void> {
         ),
       ),
     ),
+    refreshUnreadStateAfterReconnect(),
   ]);
 
   console.info(


### PR DESCRIPTION
## Summary

Closes the third Goal 2 / Phase 6 item: **WebSocket reconnect channel refresh**. After a connection drop, `handleReconnect` re-subscribed channels and reloaded open message lists but never re-fetched channel metadata — so `last_read_message_id`/`last_message_id` changes that happened while offline (new messages, reads on another device) left **stale unread dots** until a manual guild switch.

## Changes

- **`refreshChannelsForGuild()`** (channels.ts): selection-preserving channel-list refresh. The roadmap suggested calling `loadChannelsForGuild` on reconnect, but that function auto-selects the first text channel — it would yank the user out of whatever channel they're reading. The new function updates the list only.
- **`refreshUnreadStateAfterReconnect()`** (websocket): runs in parallel with re-subscription and message reload; refreshes the active guild's channels (skipping home and the discovery view) and reloads the DM list (which carries DM unread state). Each refresh failure logs and continues — reconnect recovery never aborts.
- `DISCOVERY_SENTINEL` exported from guilds.ts for the guard.

## Tests

4 new vitest cases: refresh with active guild, skip on home, skip on discovery view, resolves despite refresh failures. Client suite **601 passing**, `tsc --noEmit` clean. (One pre-existing eslint `no-case-declarations` error in websocket/index.ts:1362 exists on main, untouched.)

Goal 2 item from `docs/developer-guide/project/goals.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)