### PR TITLE
feat(client): system tray with unread badge and minimize-to-tray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release note structure source: `docs/project/RELEASE_NOTES_TEMPLATE.md`
 
 ### Added
+- Desktop system tray: Kaiku now lives in the tray with a Show/Quit menu, closing the window hides it to the tray instead of quitting (use the tray's "Quit Kaiku" to exit), and the tray shows your total unread count (tooltip everywhere, number badge on macOS and most Linux trays)
 - Desktop client now reports live voice connection quality (latency, packet loss, jitter) in the quality indicator, matching the browser client — previously the desktop always showed "unknown"
 - Responsive mobile layout: sidebar and server rail collapse into a slide-out drawer below 768px viewport width
 - Mobile header bar with hamburger menu, guild name, and channel name

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10169,6 +10169,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http 1.4.2",
+ "image",
  "jni",
  "libc",
  "log",

--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -25,7 +25,9 @@ vc-common.workspace = true
 vc-crypto = { workspace = true, features = ["megolm"] }
 
 # Tauri
-tauri = { version = "2", features = [] }
+# tray-icon: system tray with menu (src/tray.rs); image-png: decode the
+# bundled PNG icons for the tray at runtime
+tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-shell = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-global-shortcut = "2"

--- a/client/src-tauri/src/commands/mod.rs
+++ b/client/src-tauri/src/commands/mod.rs
@@ -18,6 +18,7 @@ pub mod roles;
 pub mod screen_share;
 pub mod settings;
 pub mod sound;
+pub mod tray;
 pub mod voice;
 pub mod webcam;
 pub mod websocket;

--- a/client/src-tauri/src/commands/tray.rs
+++ b/client/src-tauri/src/commands/tray.rs
@@ -1,0 +1,15 @@
+//! Tray Commands
+//!
+//! Frontend bridge for the system tray unread badge.
+
+use tauri::{command, AppHandle};
+
+/// Update the system tray's unread indicator (tooltip everywhere, text
+/// badge next to the icon where the platform supports tray titles).
+///
+/// Called by the frontend whenever the total unread count (guilds + DMs)
+/// changes.
+#[command]
+pub fn tray_set_unread(count: u64, app: AppHandle) {
+    crate::tray::update_unread_badge(&app, count);
+}

--- a/client/src-tauri/src/lib.rs
+++ b/client/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod commands;
 mod crypto;
 mod network;
 mod presence;
+mod tray;
 mod video;
 mod voice;
 mod webrtc;
@@ -90,7 +91,23 @@ pub fn run() {
             // Start presence polling service
             presence::start_presence_service(app.handle().clone());
 
+            // System tray: icon, menu, unread badge target
+            if let Err(err) = tray::setup_tray(app.handle()) {
+                tracing::error!(error = %err, "Failed to set up system tray");
+            }
+
             Ok(())
+        })
+        .on_window_event(|window, event| {
+            // Minimize-to-tray: closing the MAIN window hides it instead of
+            // quitting; "Quit Kaiku" in the tray menu exits for real. Other
+            // windows (screen-share pop-outs) must close normally.
+            if window.label() == "main" {
+                if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                    api.prevent_close();
+                    let _ = window.hide();
+                }
+            }
         })
         .invoke_handler(tauri::generate_handler![
             // Auth commands
@@ -134,6 +151,8 @@ pub fn run() {
             commands::voice::get_voice_channel,
             commands::voice::voice_connection_stats,
             commands::voice::subscribe_video_frames,
+            // Tray commands
+            commands::tray::tray_set_unread,
             // Screen share commands
             commands::screen_share::enumerate_capture_sources,
             commands::screen_share::start_screen_share,

--- a/client/src-tauri/src/tray.rs
+++ b/client/src-tauri/src/tray.rs
@@ -1,0 +1,82 @@
+//! System tray integration: tray icon with menu, unread badge, and
+//! minimize-to-tray behavior.
+//!
+//! - Left-clicking the tray icon (or the "Show Kaiku" menu item) restores
+//!   and focuses the main window.
+//! - Closing the main window hides it to the tray instead of quitting;
+//!   "Quit Kaiku" in the tray menu exits for real (see the window-event
+//!   handler in `lib.rs`).
+//! - The unread badge is driven by the frontend via the `tray_set_unread`
+//!   command: tooltip everywhere, plus a text badge next to the icon on
+//!   platforms that support tray titles (macOS, most Linux trays).
+
+use tauri::menu::{Menu, MenuItem};
+use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
+use tauri::{AppHandle, Manager, Runtime};
+
+/// Tray icon id, used to look the handle back up for badge updates.
+pub const TRAY_ID: &str = "kaiku-tray";
+
+/// Label of the primary application window (tauri.conf.json default).
+const MAIN_WINDOW_LABEL: &str = "main";
+
+/// Build the tray icon with its menu. Called once from the app setup hook.
+pub fn setup_tray<R: Runtime>(app: &AppHandle<R>) -> tauri::Result<()> {
+    let show = MenuItem::with_id(app, "show", "Show Kaiku", true, None::<&str>)?;
+    let quit = MenuItem::with_id(app, "quit", "Quit Kaiku", true, None::<&str>)?;
+    let menu = Menu::with_items(app, &[&show, &quit])?;
+
+    let mut builder = TrayIconBuilder::with_id(TRAY_ID)
+        .tooltip("Kaiku")
+        .menu(&menu)
+        .show_menu_on_left_click(false)
+        .on_menu_event(|app, event| match event.id.as_ref() {
+            "show" => show_main_window(app),
+            "quit" => app.exit(0),
+            _ => {}
+        })
+        .on_tray_icon_event(|tray, event| {
+            if let TrayIconEvent::Click {
+                button: MouseButton::Left,
+                button_state: MouseButtonState::Up,
+                ..
+            } = event
+            {
+                show_main_window(tray.app_handle());
+            }
+        });
+
+    if let Some(icon) = app.default_window_icon() {
+        builder = builder.icon(icon.clone());
+    }
+
+    builder.build(app)?;
+    Ok(())
+}
+
+/// Restore, un-minimize, and focus the main window.
+pub fn show_main_window<R: Runtime>(app: &AppHandle<R>) {
+    if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
+        let _ = window.show();
+        let _ = window.unminimize();
+        let _ = window.set_focus();
+    }
+}
+
+/// Update the tray's unread indicator.
+///
+/// Tooltip is supported on all platforms; `set_title` renders a text badge
+/// next to the icon on macOS and most Linux status trays, and is a no-op
+/// elsewhere.
+pub fn update_unread_badge<R: Runtime>(app: &AppHandle<R>, count: u64) {
+    let Some(tray) = app.tray_by_id(TRAY_ID) else {
+        return;
+    };
+    if count > 0 {
+        let _ = tray.set_tooltip(Some(format!("Kaiku — {count} unread")));
+        let _ = tray.set_title(Some(count.to_string()));
+    } else {
+        let _ = tray.set_tooltip(Some("Kaiku"));
+        let _ = tray.set_title(None::<String>);
+    }
+}

--- a/client/src-tauri/src/tray.rs
+++ b/client/src-tauri/src/tray.rs
@@ -1,14 +1,13 @@
 //! System tray integration: tray icon with menu, unread badge, and
 //! minimize-to-tray behavior.
 //!
-//! - Left-clicking the tray icon (or the "Show Kaiku" menu item) restores
-//!   and focuses the main window.
-//! - Closing the main window hides it to the tray instead of quitting;
-//!   "Quit Kaiku" in the tray menu exits for real (see the window-event
-//!   handler in `lib.rs`).
-//! - The unread badge is driven by the frontend via the `tray_set_unread`
-//!   command: tooltip everywhere, plus a text badge next to the icon on
-//!   platforms that support tray titles (macOS, most Linux trays).
+//! - Left-clicking the tray icon (or the "Show Kaiku" menu item) restores and focuses the main
+//!   window.
+//! - Closing the main window hides it to the tray instead of quitting; "Quit Kaiku" in the tray
+//!   menu exits for real (see the window-event handler in `lib.rs`).
+//! - The unread badge is driven by the frontend via the `tray_set_unread` command: tooltip
+//!   everywhere, plus a text badge next to the icon on platforms that support tray titles (macOS,
+//!   most Linux trays).
 
 use tauri::menu::{Menu, MenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -50,6 +50,7 @@ import { onShowBlockConfirm, onShowReport } from "./lib/contextMenuBuilders";
 
 import { fetchUploadLimits } from "./lib/tauri";
 import { initDrafts } from "./stores/drafts";
+import { initTrayBadge } from "./lib/trayBadge";
 
 // Global modal state
 const [blockTarget, setBlockTarget] = createSignal<{
@@ -79,6 +80,8 @@ onShowReport((target) =>
 const Layout: Component<ParentProps> = (props) => {
   onMount(() => {
     initDrafts();
+    // Sync total unread count to the system tray badge (desktop only)
+    initTrayBadge();
     // Fetch upload size limits from server (non-blocking)
     fetchUploadLimits().catch((err) =>
       console.warn("[App] Failed to fetch upload limits:", err),

--- a/client/src/lib/__tests__/trayBadge.test.ts
+++ b/client/src/lib/__tests__/trayBadge.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Tests for the system tray unread badge total (desktop tray feature).
+ */
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@/stores/guilds", () => ({
+  guildsState: { guildUnreadCounts: {} },
+}));
+vi.mock("@/stores/dms", () => ({
+  dmsState: { dms: [] },
+}));
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+import { computeTotalUnread } from "../trayBadge";
+
+describe("computeTotalUnread", () => {
+  it("returns 0 with no unreads anywhere", () => {
+    expect(computeTotalUnread({}, [])).toBe(0);
+  });
+
+  it("sums guild unread counts", () => {
+    expect(computeTotalUnread({ g1: 3, g2: 2 }, [])).toBe(5);
+  });
+
+  it("sums DM unread counts", () => {
+    expect(
+      computeTotalUnread({}, [{ unread_count: 1 }, { unread_count: 4 }]),
+    ).toBe(5);
+  });
+
+  it("combines guild and DM unreads", () => {
+    expect(
+      computeTotalUnread({ g1: 2 }, [{ unread_count: 3 }, { unread_count: 0 }]),
+    ).toBe(5);
+  });
+
+  it("tolerates missing counts", () => {
+    expect(
+      computeTotalUnread(
+        { g1: undefined as unknown as number },
+        [{ unread_count: undefined as unknown as number }],
+      ),
+    ).toBe(0);
+  });
+});

--- a/client/src/lib/trayBadge.ts
+++ b/client/src/lib/trayBadge.ts
@@ -1,0 +1,46 @@
+/**
+ * System tray unread badge (desktop only).
+ *
+ * Watches the guild and DM unread state and pushes the total to the native
+ * tray via the `tray_set_unread` command. Mounted once from the app layout;
+ * a no-op in the browser.
+ */
+import { createEffect } from "solid-js";
+import { invoke } from "@tauri-apps/api/core";
+import { guildsState } from "@/stores/guilds";
+import { dmsState } from "@/stores/dms";
+
+const isTauri = typeof window !== "undefined" && "__TAURI__" in window;
+
+/**
+ * Total unread across guilds and DMs. Pure and exported for tests.
+ */
+export function computeTotalUnread(
+  guildUnreadCounts: Record<string, number>,
+  dms: readonly { unread_count: number }[],
+): number {
+  const guildTotal = Object.values(guildUnreadCounts).reduce(
+    (sum, count) => sum + (count ?? 0),
+    0,
+  );
+  const dmTotal = dms.reduce((sum, dm) => sum + (dm.unread_count ?? 0), 0);
+  return guildTotal + dmTotal;
+}
+
+/**
+ * Start syncing the unread total to the tray badge. Must be called inside
+ * a component context (uses createEffect).
+ */
+export function initTrayBadge(): void {
+  if (!isTauri) return;
+
+  createEffect(() => {
+    const count = computeTotalUnread(
+      guildsState.guildUnreadCounts,
+      dmsState.dms,
+    );
+    invoke("tray_set_unread", { count }).catch((err) => {
+      console.warn("[Tray] Failed to update unread badge:", err);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes the fourth Goal 2 / Phase 6 desktop item: **system tray**. Uses Tauri 2's core tray support (`tray-icon` + `image-png` features) — no extra plugin needed.

## Behavior

- **Tray icon** with Show Kaiku / Quit Kaiku menu (right-click); left-click restores, un-minimizes, and focuses the main window
- **Minimize-to-tray**: closing the main window hides it to the tray instead of quitting — label-guarded so screen-share pop-out windows still close normally; the tray's Quit exits for real
- **Unread badge**: a new `lib/trayBadge.ts` effect sums guild + DM unread counts and pushes changes via the `tray_set_unread` command — tooltip ("Kaiku — N unread") on all platforms, plus a numeric text badge next to the icon where tray titles are supported (macOS, most Linux status trays). Browser mode is a no-op.

## Verification

- 5 new vitest cases for the unread total; client suite **606 passing**; `tsc --noEmit` + eslint clean
- Tray API usage verified against the vendored tauri 2.11.1 / tray-icon 0.23.1 sources (builder methods, `TrayIconEvent::Click` shape, `tray_by_id` `PartialEq<&str>` impl) since vc-client can't compile locally; CI validates the build on all platforms
- Manual check after merge (Linux): close window → app stays in tray with icon; click icon → window restores; unread badge updates when a message arrives in an unfocused channel

Goal 2 item from `docs/developer-guide/project/goals.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)