### PR TITLE
docs: reconcile tech-debt and roadmap with verified code state

### DIFF
--- a/docs/developer-guide/project/roadmap.md
+++ b/docs/developer-guide/project/roadmap.md
@@ -16,7 +16,7 @@ This roadmap outlines the development path from the current prototype to a produ
 | **Foundation** | **Phase 3** | ✅ Complete | 100% | Guild system, Friends, DMs, Home View, Rate Limiting, Permission System + UI, Information Pages, DM Voice Calls |
 | **Foundation** | **Phase 4** | ✅ Complete | 100% | E2EE DM Messaging, User Connectivity Monitor, Rich Presence, First User Setup, Context Menus, Emoji Picker Polish, Unread Aggregator, Content Spoilers, Forgot Password, SSO/OIDC, User Blocking & Reports |
 | **Expansion** | **Phase 5** | ✅ Complete | 100% (17/17) | E2E suite, CI hardening, bot platform, search upgrades, threads, multi-stream partial, slash command reliability, production-scale polish, content filters, webhooks, bulk read management, guild discovery & onboarding, guild resource limits, progressive image loading, data governance |
-| **Expansion** | **Phase 6** | 🔄 Near complete | ~98% | Personal workspaces, digital library, focus engine, custom status, session management, QA polish, multi-stream screen sharing, guild bans, PTT/PTM, channel pins, simulcast, desktop session persistence, dual-PC voice, unread tracking redesign, VAD noise gate, VP8 desktop decode, RNNoise VAD + speaking indicator + noise suppression on Tauri. Remaining: mobile parity completion, desktop niceties (connection metrics, system tray, auto-update, output-device, WS reconnect refresh) |
+| **Expansion** | **Phase 6** | ✅ Desktop complete | ~99% | Personal workspaces, digital library, focus engine, custom status, session management, QA polish, multi-stream screen sharing, guild bans, PTT/PTM, channel pins, simulcast (server side), desktop session persistence, dual-PC voice, unread tracking redesign, VAD noise gate, VP8 desktop decode, RNNoise VAD + speaking indicator + noise suppression on Tauri, connection metrics, output device selection, WS reconnect refresh, system tray, auto-update (PRs #575–#579, 2026-06-10/11). Remaining: mobile parity completion (native Android app exists in `mobile/android` — needs its own milestone definition) |
 | **Scale and Trust** | **Phase 7** | 📋 Planned | 0% | Billing, accessibility, identity trust, observability |
 | **Scale and Trust** | **Phase 8** | 📋 Planned | 0% | Performance budgets, chaos drills, upgrade safety, FinOps, isolation testing, live session toolkits |
 | **Scale and Trust** | **Phase 10** | 📋 Planned | 0% | SaaS scaling architecture |
@@ -647,18 +647,18 @@ This section is the canonical high-level roadmap view. Detailed implementation c
   - RNNoise (`nnnoiseless` pure-Rust port) integrated into capture pipeline. ML-based VAD with configurable threshold and 300ms hold-open. The previously-no-op `setVadConfig` now drives gating. Pipeline rewritten around 480-sample mono frames, `Arc<Mutex<Vec<f32>>>` removed in favor of in-closure processing.
 - [x] **[Voice] Local Speaking Indicator** ✅ (PR #507)
   - `voice:speaking` Tauri events now emitted from the Rust capture pipeline based on RNNoise VAD probability. Local user's speaking ring animates on desktop.
-- [ ] **[Voice] Connection Metrics** `Priority: Medium`
-  - `getConnectionMetrics()` always returns null on desktop. Needs Tauri command to fetch RTCStatsReport equivalent from webrtc-rs PeerConnections (latency, packet loss, jitter).
-- [ ] **[Voice] Output Device Selection** `Priority: Low`
-  - `setOutputDevice()` Tauri command exists but implementation is unclear/untested. Needs verification and potential CPAL integration.
+- [x] **[Voice] Connection Metrics** ✅ (PR #575, 2026-06-10)
+  - `voice_connection_stats` command: native RTT from publisher RTCP receiver reports (webrtc-rs reports ms, not W3C seconds), receive-side packet loss and RFC 3550 jitter measured in the audio decode loop (webrtc-rs `get_stats()` exposes neither). Quality thresholds shared between browser and Tauri adapters.
+- [x] **[Voice] Output Device Selection** ✅ (PR #576, 2026-06-10)
+  - The CPAL path worked but nothing connected it: stored setting now applied on join, mid-call switching rebuilds the playback stream in place (`PlaybackControl::SwitchDevice`), settings page enumerates via the adapter (native names), browser `setSinkId` path fixed (elements now in DOM with `data-stream-id`).
 - [x] **[Voice] Noise Suppression Backend** ✅ (PR #507)
   - RNNoise denoises audio in real-time. The toggle now controls whether denoised or original audio is sent.
-- [ ] **[Client] WebSocket Reconnect Channel Refresh** `Priority: Low`
-  - WebSocket reconnect doesn't re-fetch channel list metadata (`last_read_message_id`, `last_message_id`). Stale unread dots until guild switch. Add `loadChannelsForGuild` call on reconnect.
-- [ ] **[Client] System Tray** `Priority: Low`
-  - Minimize to tray, tray icon with unread badge. Uses `tauri-plugin-tray`.
-- [ ] **[Client] Auto-Update** `Priority: Low`
-  - Tauri updater plugin integration with server-side update endpoint.
+- [x] **[Client] WebSocket Reconnect Channel Refresh** ✅ (PR #577, 2026-06-10)
+  - Reconnect recovery now refreshes the active guild's channel metadata and the DM list in parallel with re-subscription. NB: implemented via a new selection-preserving `refreshChannelsForGuild()` — the originally suggested `loadChannelsForGuild` auto-selects the first text channel and must not be used for background refreshes.
+- [x] **[Client] System Tray** ✅ (PR #578, 2026-06-11)
+  - Tauri 2 core tray (`tray-icon` feature — `tauri-plugin-tray` doesn't exist in v2): Show/Quit menu, left-click restore, close-to-tray (main window only), unread badge (tooltip + `set_title` text badge) driven by a reactive guild+DM unread sum.
+- [x] **[Client] Auto-Update** ✅ (PR #579, 2026-06-11)
+  - `tauri-plugin-updater` against GitHub Releases (`latest.json` manifest assembled in release.yml with per-platform signed artifact URLs). Check 10s after startup, background download, "Restart now" toast. Release builds require `TAURI_SIGNING_PRIVATE_KEY` secrets. End-to-end verification pending first release tag after merge.
 
 ### Chat Improvements (Delivered 2026-03-25)
 

--- a/docs/developer-guide/project/tech-debt.md
+++ b/docs/developer-guide/project/tech-debt.md
@@ -1,7 +1,6 @@
 # Tech Debt Inventory
 
-**Last audited:** 2026-02-19
-**Branch:** `chore/tech-debt`
+**Last audited:** 2026-06-11 (code-verified sweep of all open items)
 
 This document catalogs all known tech debt across the Kaiku codebase, sourced from:
 - In-code markers (TODO, FIXME, HACK)
@@ -150,23 +149,19 @@ Three `#[ignore]` tests waiting on:
 
 ---
 
-### TD-15: Tauri native webcam capture not implemented
+### TD-15: Tauri native webcam capture not implemented ✅ RESOLVED
 
 **Source:** `docs/project/roadmap.md:418`
 
-Multi-stream works in browser but Tauri has no native webcam commands (`start_webcam`/`stop_webcam`).
+**Resolved:** before 2026-06-11 (entry was stale) — `client/src-tauri/src/commands/webcam.rs` implements `start_webcam`/`stop_webcam` with a native nokhwa capture pipeline (`WebcamPipeline`); both commands are registered in `lib.rs`.
 
 ---
 
-### TD-16: Tauri WebRTC connection metrics stub
+### TD-16: Tauri WebRTC connection metrics stub ✅ RESOLVED
 
 **File:** `client/src/lib/webrtc/tauri.ts:194`
 
-```typescript
-// TODO: Add Tauri command to fetch native WebRTC connection stats
-```
-
-`getConnectionMetrics()` returns null — connectivity monitor is broken in Tauri.
+**Resolved:** 2026-06-10 (PR #575) — `voice_connection_stats` command returns native RTT (publisher RTCP receiver reports; NB: webrtc-rs reports it in ms, not W3C seconds), receive-side packet loss and RFC 3550 jitter measured in the audio decode loop (webrtc-rs `get_stats()` exposes neither). The desktop quality indicator now shows live data.
 
 ---
 
@@ -241,11 +236,11 @@ Password reset emails are plain text. HTML alternative with `lettre::message::Mu
 
 ---
 
-### TD-25: Windows Tauri build broken
+### TD-25: Windows Tauri build broken ✅ RESOLVED
 
 **Source:** `docs/project/roadmap.md:397`
 
-`libvpx` not available via choco. CI job marked `continue-on-error: true`.
+**Resolved:** before 2026-06-10 (entry was stale) — Windows builds use `vcpkg install libvpx:x64-windows-static-md` (not choco) and pass in CI; PR #571 additionally fixed a CMake 4.x runner-image regression (`CMAKE_POLICY_VERSION_MINIMUM=3.5` now set on Windows). All Windows CI jobs (Build, Tauri) green as of PRs #571–#578.
 
 ---
 
@@ -281,11 +276,11 @@ Threads feature is complete but there's no guild-level setting to enable/disable
 
 ---
 
-### TD-29: Simulcast not implemented
+### TD-29: Simulcast not implemented (rescoped — server side is done)
 
 **Source:** `docs/project/roadmap.md:419`
 
-No quality tier switching for bandwidth management in voice/video streams.
+**Rescoped 2026-06-11 after code verification:** server-side layer negotiation is implemented — `server/src/voice/track_types.rs` defines `Layer`/`LayerPreference` with bitrate tiers (High 4 Mbps / Medium 800 kbps / Low 200 kbps) and `ws_handler.rs::handle_set_layer_preference` applies receiver preferences via the track router. What remains is the **publishing** side: webrtc-rs only annotates simulcast RIDs in SDP without producing actual multi-layer streams (see comment in `client/src-tauri/src/webrtc/mod.rs`), so desktop clients can't send multiple quality tiers. Blocked upstream on webrtc-rs; browser clients could implement true simulcast independently.
 
 ---
 
@@ -300,11 +295,12 @@ No quality tier switching for bandwidth management in voice/video streams.
 
 | Status | Count |
 |--------|-------|
-| ✅ Resolved | 16 |
-| Open | 14 |
+| ✅ Resolved | 19 |
+| Open | 11 |
 | **Total** | 30 |
 
-**Resolved items:** TD-01, TD-02, TD-04, TD-05, TD-06, TD-08, TD-09, TD-10, TD-11, TD-12, TD-13, TD-17, TD-20, TD-22, TD-30
+**Resolved items:** TD-01, TD-02, TD-03, TD-04, TD-05, TD-06, TD-08, TD-09, TD-10, TD-11, TD-12, TD-13, TD-15, TD-16, TD-17, TD-20, TD-22, TD-25, TD-30
+**Open items:** TD-07, TD-14, TD-18, TD-19, TD-21, TD-23, TD-24, TD-26, TD-27, TD-28, TD-29 (rescoped)
 
 ## Code Quality Summary
 


### PR DESCRIPTION
## Summary

Goal 3 ("truthful docs") sweep — every open tech-debt item was re-verified against current code on 2026-06-11. Three entries turned out to be stale or already fixed, one needed honest rescoping:

| Item | Finding |
|---|---|
| **TD-15** Tauri webcam "not implemented" | Stale — `commands/webcam.rs` has `start_webcam`/`stop_webcam` with a native nokhwa pipeline, registered in lib.rs |
| **TD-16** connection metrics stub | Resolved by PR #575 |
| **TD-25** "Windows build broken (choco libvpx)" | Stale — builds use vcpkg and are green; PR #571 fixed the actual (different) CMake 4.x regression |
| **TD-29** "simulcast not implemented" | Rescoped — server-side layer negotiation IS implemented (`track_types.rs`, `handle_set_layer_preference`); the real gap is multi-layer publishing, blocked upstream on webrtc-rs |

Resolution summary: **19 resolved / 11 open** (was 16/14 with wrong contents).

roadmap.md: all five Phase 6 desktop items checked off with PR references and implementation notes (incl. the `loadChannelsForGuild` auto-select trap and the v2 tray-plugin correction); status table updated — remaining Phase 6 scope is mobile parity, noting the native Android app in `mobile/android` needs its own milestone definition.

`python3 scripts/check_docs_governance.py` passes.

Note: merge **after** PR #579 (the roadmap marks auto-update done referencing it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)