### PR TITLE
feat(infra): RustFS backups, restore runbook, missing compose service

### DIFF
--- a/docs/ops/backup-restore-runbook.md
+++ b/docs/ops/backup-restore-runbook.md
@@ -1,0 +1,109 @@
+# Backup & Restore Runbook
+
+> Companion to `infra/scripts/backup.sh`. Covers what is backed up, how to
+> restore each piece, the periodic restore drill, and the one-time VPS
+> verification checklist.
+>
+> Created 2026-06-12 (Goal 4, beta ops hardening). Deploys and all commands
+> on the VPS are run by the operator — never automated.
+
+## What is backed up
+
+| Data | Mechanism | File pattern | Default retention |
+|---|---|---|---|
+| PostgreSQL (`voicechat` DB — all messages, guilds, users, keys metadata) | `pg_dump \| gzip` via the `canis-postgres` container | `kaiku-<ts>.sql.gz` | 7 days |
+| RustFS object data (uploads, avatars, custom emoji) | tar of the docker volume | `kaiku-rustfs-<ts>.tar.gz` | 7 days |
+
+Backups land in `/var/lib/kaiku/backups` on the VPS. Both archives are
+integrity-checked (`gzip -t`) at creation time — an empty or truncated
+archive fails the run loudly instead of rotting silently.
+
+**Not covered:** Valkey (ephemeral: sessions/presence/rate-limit state —
+acceptable loss), Caddy certs (re-issued via ACME), monitoring data
+(Prometheus/Tempo/Loki — operational, not user data).
+
+> ⚠️ Off-host copies: `/var/lib/kaiku/backups` lives on the same disk as the
+> data it protects. Until off-host sync exists (e.g. rclone to external
+> storage), a disk failure loses both. Tracked as a follow-up below.
+
+## One-time VPS verification checklist (operator)
+
+The repo cannot see the VPS; verify these once and tick them off:
+
+- [ ] Backup cron installed: `crontab -l` shows
+      `0 3 * * * /opt/kaiku/infra/scripts/backup.sh >> /var/log/kaiku-backup.log 2>&1`
+- [ ] Recent backups exist and are non-trivial:
+      `ls -lah /var/lib/kaiku/backups | tail` (a fresh `.sql.gz` from last
+      night, plausible size)
+- [ ] RustFS volume name matches the script default:
+      `docker volume ls | grep rustfs` — if it isn't `compose_rustfs_data`,
+      set `RUSTFS_VOLUME=<actual>` in the cron line
+- [ ] Compose drift: `docker inspect canis-rustfs --format '{{.Config.Image}} {{.Mounts}}'`
+      matches the `rustfs` service added to `infra/compose/docker-compose.yml`
+      on 2026-06-12 (that service was reconstructed from the dev template
+      because the live container predated its compose definition)
+
+## Restore: PostgreSQL
+
+```bash
+# 1. Stop the app server so nothing writes mid-restore
+docker stop canis-server
+
+# 2. Recreate the database from the dump
+gunzip -c /var/lib/kaiku/backups/kaiku-<ts>.sql.gz | \
+  docker exec -i canis-postgres psql -U voicechat -d postgres \
+    -c "DROP DATABASE IF EXISTS voicechat_restore;" \
+    -c "CREATE DATABASE voicechat_restore OWNER voicechat;"
+gunzip -c /var/lib/kaiku/backups/kaiku-<ts>.sql.gz | \
+  docker exec -i canis-postgres psql -U voicechat -d voicechat_restore
+
+# 3. Sanity-check the restored DB (counts should be plausible)
+docker exec canis-postgres psql -U voicechat -d voicechat_restore \
+  -c "SELECT count(*) FROM users;" -c "SELECT count(*) FROM messages;"
+
+# 4. Swap: rename old DB aside, promote the restore
+docker exec canis-postgres psql -U voicechat -d postgres -c \
+  "ALTER DATABASE voicechat RENAME TO voicechat_old; \
+   ALTER DATABASE voicechat_restore RENAME TO voicechat;"
+
+# 5. Restart and verify health
+docker start canis-server
+curl -sf http://localhost:8080/health
+```
+
+Drop `voicechat_old` only after a day of verified operation.
+
+## Restore: RustFS objects
+
+```bash
+docker stop canis-rustfs
+docker run --rm \
+  -v compose_rustfs_data:/data \
+  -v /var/lib/kaiku/backups:/backup:ro \
+  alpine sh -c "rm -rf /data/* && tar xzf /backup/kaiku-rustfs-<ts>.tar.gz -C /data"
+docker start canis-rustfs
+# Verify: open any older uploaded image in the app
+```
+
+## Restore drill (quarterly — ~20 minutes)
+
+The backup you have never restored is a hope, not a backup.
+
+1. Pick yesterday's `.sql.gz`; restore it into `voicechat_drill`
+   (steps 2–3 above with the drill name — **skip the swap, step 4**).
+2. Verify counts and spot-check one recent message:
+   `SELECT content FROM messages ORDER BY created_at DESC LIMIT 1;`
+3. Extract one file from the RustFS archive to /tmp and open it:
+   `tar tzf kaiku-rustfs-<ts>.tar.gz | head` then extract one entry.
+4. `DROP DATABASE voicechat_drill;` and delete the /tmp extraction.
+5. Record the drill date below.
+
+| Drill date | Backup used | Result | Operator |
+|---|---|---|---|
+| _none yet_ | | | |
+
+## Follow-ups
+
+- [ ] Off-host backup sync (rclone/restic target) — single-disk risk above
+- [ ] Encrypt backups at rest (the spec promises "encrypted backups";
+      today's archives are plaintext gzip on the VPS disk)

--- a/infra/compose/docker-compose.yml
+++ b/infra/compose/docker-compose.yml
@@ -103,6 +103,32 @@ services:
       retries: 5
 
   # ==========================================================================
+  # RustFS — S3-compatible object storage (uploads, avatars, emoji)
+  # ==========================================================================
+  # NOTE: added 2026-06-12 from the dev template because the live VPS runs
+  # canis-rustfs but this file never defined it — a fresh VPS could not be
+  # rebuilt from the repo. Before relying on this definition, verify it
+  # against the running container (image tag, env, volume):
+  #   docker inspect canis-rustfs --format '{{.Config.Image}} {{.Mounts}}'
+  rustfs:
+    image: rustfs/rustfs:latest
+    container_name: canis-rustfs
+    restart: unless-stopped
+    command: /data
+    environment:
+      - RUSTFS_ACCESS_KEY=${S3_ACCESS_KEY}
+      - RUSTFS_SECRET_KEY=${S3_SECRET_KEY}
+    volumes:
+      - rustfs_data:/data
+    networks:
+      - voicechat
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9000/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # ==========================================================================
   # Caddy — Reverse Proxy & SPA Server
   # ==========================================================================
   caddy:
@@ -257,6 +283,7 @@ networks:
 volumes:
   postgres_data:
   valkey_data:
+  rustfs_data:
   caddy_data:
   caddy_config:
   client_dist:

--- a/infra/scripts/backup.sh
+++ b/infra/scripts/backup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Daily PostgreSQL backup for Kaiku
+# Daily backup for Kaiku: PostgreSQL dump + (optional) RustFS object data.
 #
 # Usage:
 #   ./infra/scripts/backup.sh
@@ -7,12 +7,18 @@
 # Crontab (daily at 03:00):
 #   0 3 * * * /opt/kaiku/infra/scripts/backup.sh >> /var/log/kaiku-backup.log 2>&1
 #
+# Restore procedure + drill checklist: docs/ops/backup-restore-runbook.md
+#
 # Environment variables (all optional, defaults shown):
 #   BACKUP_DIR=/var/lib/kaiku/backups
 #   POSTGRES_CONTAINER=canis-postgres
 #   POSTGRES_USER=voicechat
 #   POSTGRES_DB=voicechat
 #   RETENTION_DAYS=7
+#   BACKUP_RUSTFS=true            # also archive the RustFS data volume
+#   RUSTFS_VOLUME=compose_rustfs_data   # docker volume holding object data
+#                                       # (verify: docker volume ls | grep rustfs)
+#   RUSTFS_RETENTION_DAYS=7
 
 set -euo pipefail
 
@@ -21,27 +27,60 @@ CONTAINER="${POSTGRES_CONTAINER:-canis-postgres}"
 DB_USER="${POSTGRES_USER:-voicechat}"
 DB_NAME="${POSTGRES_DB:-voicechat}"
 RETENTION_DAYS="${RETENTION_DAYS:-7}"
+BACKUP_RUSTFS="${BACKUP_RUSTFS:-true}"
+RUSTFS_VOLUME="${RUSTFS_VOLUME:-compose_rustfs_data}"
+RUSTFS_RETENTION_DAYS="${RUSTFS_RETENTION_DAYS:-7}"
 TIMESTAMP=$(date +%Y-%m-%d_%H%M%S)
 BACKUP_FILE="${BACKUP_DIR}/kaiku-${TIMESTAMP}.sql.gz"
+RUSTFS_FILE="${BACKUP_DIR}/kaiku-rustfs-${TIMESTAMP}.tar.gz"
 
 mkdir -p "$BACKUP_DIR"
 
 echo "[$(date)] Starting backup..."
 
-# Dump and compress
+# --- PostgreSQL ------------------------------------------------------------
+
 docker exec "$CONTAINER" pg_dump -U "$DB_USER" "$DB_NAME" | gzip > "$BACKUP_FILE"
 
-# Verify
-if [ -s "$BACKUP_FILE" ]; then
+# Verify: non-empty AND the gzip stream is intact (a truncated dump from a
+# mid-backup failure would otherwise look like a valid backup until restore
+# day).
+if [ -s "$BACKUP_FILE" ] && gzip -t "$BACKUP_FILE" 2>/dev/null; then
     SIZE=$(du -h "$BACKUP_FILE" | cut -f1)
-    echo "[$(date)] Backup complete: $BACKUP_FILE ($SIZE)"
+    echo "[$(date)] Postgres backup complete: $BACKUP_FILE ($SIZE)"
 else
-    echo "[$(date)] ERROR: Backup file is empty!" >&2
+    echo "[$(date)] ERROR: Postgres backup missing or corrupt!" >&2
     rm -f "$BACKUP_FILE"
     exit 1
 fi
 
-# Prune old backups
-find "$BACKUP_DIR" -name "kaiku-*.sql.gz" -mtime +"$RETENTION_DAYS" -delete
-REMAINING=$(find "$BACKUP_DIR" -name "kaiku-*.sql.gz" | wc -l)
-echo "[$(date)] Retained $REMAINING backup(s)"
+# --- RustFS object data (uploads, avatars, emoji) ---------------------------
+# Archives the docker volume contents. RustFS keeps running during the tar;
+# for the beta's traffic level a live snapshot is acceptable (worst case: a
+# file uploaded mid-backup lands in the next day's archive).
+
+if [ "$BACKUP_RUSTFS" = "true" ]; then
+    if docker volume inspect "$RUSTFS_VOLUME" >/dev/null 2>&1; then
+        docker run --rm \
+            -v "${RUSTFS_VOLUME}:/data:ro" \
+            -v "${BACKUP_DIR}:/backup" \
+            alpine tar czf "/backup/$(basename "$RUSTFS_FILE")" -C /data .
+        if [ -s "$RUSTFS_FILE" ] && gzip -t "$RUSTFS_FILE" 2>/dev/null; then
+            SIZE=$(du -h "$RUSTFS_FILE" | cut -f1)
+            echo "[$(date)] RustFS backup complete: $RUSTFS_FILE ($SIZE)"
+        else
+            echo "[$(date)] ERROR: RustFS backup missing or corrupt!" >&2
+            rm -f "$RUSTFS_FILE"
+            exit 1
+        fi
+    else
+        echo "[$(date)] WARN: RustFS volume '$RUSTFS_VOLUME' not found, skipping object backup" >&2
+    fi
+fi
+
+# --- Retention ---------------------------------------------------------------
+
+find "$BACKUP_DIR" -name "kaiku-2*.sql.gz" -mtime +"$RETENTION_DAYS" -delete
+find "$BACKUP_DIR" -name "kaiku-rustfs-*.tar.gz" -mtime +"$RUSTFS_RETENTION_DAYS" -delete
+REMAINING=$(find "$BACKUP_DIR" -name "kaiku-*.gz" | wc -l)
+echo "[$(date)] Retained $REMAINING backup file(s)"


### PR DESCRIPTION
## Summary

Goal 4 (beta ops hardening) — backups were the highest operational risk in `goals.md`. Three changes:

1. **`backup.sh` now covers object data**: previously postgres-only — a disk loss would have kept messages but lost every upload/avatar/emoji. The RustFS docker volume is archived alongside the DB dump (optional via `BACKUP_RUSTFS`), and both archives get `gzip -t` integrity checks so a truncated backup fails loudly at creation, not on restore day.
2. **Missing compose service found and fixed**: the live VPS runs `canis-rustfs`, but `infra/compose/docker-compose.yml` never defined it — **a fresh VPS could not be rebuilt from the repo**. Service + volume added (reconstructed from the dev template; inline note says to verify against the live container, since prod SSH inspection needs operator access).
3. **`docs/ops/backup-restore-runbook.md`**: restore procedures for both stores, a quarterly restore-drill checklist (with drill log), the one-time VPS verification checklist (backup cron present? volume name matches? compose drift?), and honest follow-ups: off-host sync (backups currently share the data disk) and at-rest encryption (the spec promises encrypted backups; today's are plaintext gzip).

## Operator actions after merge (~10 min, on the VPS)

Run the "One-time VPS verification checklist" in the runbook, then schedule the first restore drill. The drill itself is deliberately operator-run — never automated.

## Verification

`bash -n` clean, compose YAML parses, docs governance passes. No application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)