### PR TITLE
feat(ci): performance budgets as CI gates (Phase 8, Goal 5 item 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,6 +311,10 @@ jobs:
       - name: Build
         run: bun run build
 
+      - name: Bundle size budget
+        working-directory: .
+        run: python3 scripts/check_bundle_budget.py
+
   # ===========================================================================
   # Build Server Docker Image
   # ===========================================================================

--- a/docs/developer-guide/development/performance-budgets.md
+++ b/docs/developer-guide/development/performance-budgets.md
@@ -1,0 +1,33 @@
+# Performance Budgets
+
+> Phase 8 reliability gate (Goal 5 item 2). Budgets exist to catch
+> order-of-magnitude regressions in CI — lost indexes, N+1 queries,
+> dependencies landing in the startup-critical path — not to micro-optimize.
+> Raise a budget only in a PR that explains the cost.
+
+## Enforced in CI
+
+| Budget | Threshold | Gate | Baseline (2026-06-12) |
+|---|---|---|---|
+| Initial JS payload (gzipped, all assets referenced by `index.html`) | ≤ 300 KB | `scripts/check_bundle_budget.py` (Frontend job, after build) | 237 KB |
+| Initial CSS payload (gzipped) | ≤ 25 KB | same | 16 KB |
+| Largest entry chunk (gzipped) | ≤ 170 KB | same | 130 KB |
+| Message history page (50 of 1,000 msgs) | best-of-3 < 500 ms | `performance_budgets.rs` (Rust Tests job) | ~5 ms local |
+| Guild full-text search (1,000 msgs) | best-of-3 < 750 ms | same | ~10 ms local |
+
+Bundle budgets are the practical proxy for the **<3 s startup** target:
+lazy chunks don't block startup, so only the `index.html`-referenced
+payload is counted. Server budgets use best-of-3 timing with generous
+thresholds to stay deterministic on shared CI runners.
+
+## Not yet automatable (manual / future instrumentation)
+
+| Target (CLAUDE.md / roadmap) | Why not in CI | How to measure today |
+|---|---|---|
+| Client startup < 3 s | Needs a real Tauri window; headless CI can't render | Stopwatch on a release build; Tauri instrumentation later |
+| Voice join < 2 s | Needs real WebRTC peers + SFU media path | Beta server smoke test with two clients |
+| Client RAM idle < 80 MB / < 50 MB per 1,000 messages | OS-level process measurement of a running app | `ps`/Task Manager against a release build |
+| Message list render (50 items) < 100 ms | jsdom timing is noise, not signal | Browser devtools profiling on the real app |
+
+When the desktop client gains startup instrumentation (e.g. a timing event
+at first-paint), the startup and render budgets should migrate into CI.

--- a/scripts/check_bundle_budget.py
+++ b/scripts/check_bundle_budget.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Frontend bundle-size budget gate (Phase 8 performance budgets).
+
+Measures the gzipped size of the INITIAL payload — every asset referenced
+from ``client/dist/index.html`` (entry scripts, modulepreloads, stylesheets).
+Lazy-loaded route/feature chunks are deliberately excluded: they don't block
+startup, and the <3s startup target is what these budgets proxy.
+
+Budgets fail CI loudly when exceeded. They carry ~25% headroom over the
+2026-06-12 baseline (236 KB JS / 16 KB CSS gz) — a breach means a dependency
+or import graph change moved real weight into the critical path, not normal
+feature growth. Raise a budget only with a PR that explains the cost.
+
+Run after `bun run build`:
+    python3 scripts/check_bundle_budget.py
+"""
+
+from __future__ import annotations
+
+import gzip
+import re
+import sys
+from pathlib import Path
+
+DIST = Path("client/dist")
+
+# Budgets (gzipped bytes)
+INITIAL_JS_BUDGET = 300_000
+INITIAL_CSS_BUDGET = 25_000
+LARGEST_CHUNK_BUDGET = 170_000
+
+
+def gz_size(path: Path) -> int:
+    return len(gzip.compress(path.read_bytes(), 6))
+
+
+def main() -> int:
+    index = DIST / "index.html"
+    if not index.exists():
+        print(f"ERROR: {index} not found — run `bun run build` in client/ first")
+        return 1
+
+    assets = re.findall(r'(?:src|href)="/?(assets/[^"]+)"', index.read_text())
+    if not assets:
+        print("ERROR: no assets referenced from index.html — build layout changed?")
+        return 1
+
+    total_js = 0
+    total_css = 0
+    largest_chunk = (0, "")
+    for ref in assets:
+        path = DIST / ref
+        if not path.exists():
+            print(f"ERROR: index.html references missing asset {ref}")
+            return 1
+        size = gz_size(path)
+        if ref.endswith(".js"):
+            total_js += size
+            if size > largest_chunk[0]:
+                largest_chunk = (size, ref)
+        elif ref.endswith(".css"):
+            total_css += size
+
+    print(f"Initial JS  (gz): {total_js:>8} / {INITIAL_JS_BUDGET} budget")
+    print(f"Initial CSS (gz): {total_css:>8} / {INITIAL_CSS_BUDGET} budget")
+    print(
+        f"Largest chunk (gz): {largest_chunk[0]:>6} / {LARGEST_CHUNK_BUDGET} budget"
+        f"  ({largest_chunk[1]})"
+    )
+
+    failures = []
+    if total_js > INITIAL_JS_BUDGET:
+        failures.append(
+            f"initial JS payload {total_js} gz exceeds budget {INITIAL_JS_BUDGET}"
+        )
+    if total_css > INITIAL_CSS_BUDGET:
+        failures.append(
+            f"initial CSS payload {total_css} gz exceeds budget {INITIAL_CSS_BUDGET}"
+        )
+    if largest_chunk[0] > LARGEST_CHUNK_BUDGET:
+        failures.append(
+            f"largest entry chunk {largest_chunk[1]} is {largest_chunk[0]} gz, "
+            f"budget {LARGEST_CHUNK_BUDGET}"
+        )
+
+    if failures:
+        print("\nBUNDLE BUDGET EXCEEDED:")
+        for f in failures:
+            print(f"  ✗ {f}")
+        print(
+            "\nA budget breach means real weight moved into the startup-critical"
+            "\npath. Check for: a new dependency imported eagerly, a lazy route"
+            "\nchunk that became static, or a util pulled into the entry graph."
+            "\nIf the cost is intentional, raise the budget in"
+            "\nscripts/check_bundle_budget.py in the same PR and justify it."
+        )
+        return 1
+
+    print("Bundle budgets OK.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server/tests/integration/main.rs
+++ b/server/tests/integration/main.rs
@@ -25,6 +25,7 @@ mod mention_permission;
 mod messages_http;
 mod oidc;
 mod pages;
+mod performance_budgets;
 mod ratelimit;
 mod ratelimit_http;
 mod reports;

--- a/server/tests/integration/performance_budgets.rs
+++ b/server/tests/integration/performance_budgets.rs
@@ -1,0 +1,147 @@
+//! Server-side performance budgets (Phase 8, Goal 5 item 2).
+//!
+//! Release-blocking latency budgets for the hottest read paths, designed to
+//! catch order-of-magnitude regressions (N+1 queries, lost indexes, full
+//! scans) — not micro-benchmarks. Budgets are deliberately generous for
+//! noisy shared CI runners and use best-of-3 timing; typical local times
+//! are 10–50x under budget.
+//!
+//! Frontend budgets (initial bundle size as a startup proxy) live in
+//! `scripts/check_bundle_budget.py`. Budgets that still require manual or
+//! instrumented measurement (true client startup, voice join end-to-end,
+//! client memory) are listed in
+//! `docs/developer-guide/development/performance-budgets.md`.
+
+use std::time::{Duration, Instant};
+
+use axum::body::Body;
+use axum::http::{Method, StatusCode};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use super::helpers::{
+    create_channel, create_guild, create_test_user, generate_access_token, TestApp,
+};
+
+/// Seed `count` messages into a channel with one multi-row insert per 500.
+async fn seed_messages(pool: &PgPool, channel_id: Uuid, user_id: Uuid, count: usize) {
+    let mut remaining = count;
+    let mut batch_start = 0usize;
+    while remaining > 0 {
+        let batch = remaining.min(500);
+        let mut qb = sqlx::QueryBuilder::new(
+            "INSERT INTO messages (id, channel_id, user_id, content, created_at) ",
+        );
+        qb.push_values(0..batch, |mut b, i| {
+            let n = batch_start + i;
+            b.push_bind(Uuid::now_v7())
+                .push_bind(channel_id)
+                .push_bind(user_id)
+                .push_bind(format!("seeded message number {n}"))
+                .push("NOW() - make_interval(secs => ")
+                .push_bind_unseparated(((count - n) as f64) * 0.1)
+                .push_unseparated(")");
+        });
+        qb.build().execute(pool).await.expect("seed batch failed");
+        batch_start += batch;
+        remaining -= batch;
+    }
+}
+
+/// Run `req_fn` three times, returning the fastest wall-clock duration.
+/// Best-of-N filters out CI scheduler noise; a genuine regression slows
+/// every attempt.
+async fn best_of_3<F, Fut>(mut req_fn: F) -> Duration
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Duration>,
+{
+    let mut best = Duration::MAX;
+    for _ in 0..3 {
+        let d = req_fn().await;
+        if d < best {
+            best = d;
+        }
+    }
+    best
+}
+
+/// Budget: fetching a 50-message page from a 1,000-message channel must
+/// complete well under 500ms (typical: single-digit ms). Catches lost
+/// indexes and N+1 author/attachment loading.
+#[sqlx::test]
+async fn budget_message_history_page_under_500ms(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
+    let (owner, _) = create_test_user(&pool).await;
+    let guild = create_guild(&pool, owner).await;
+    let channel = create_channel(&pool, guild, "perf-history").await;
+    seed_messages(&pool, channel, owner, 1_000).await;
+    let token = generate_access_token(&app.config, owner);
+
+    let best = best_of_3(|| {
+        let app = &app;
+        let token = token.clone();
+        async move {
+            let start = Instant::now();
+            let resp = app
+                .oneshot(
+                    TestApp::request(
+                        Method::GET,
+                        &format!("/api/messages/channel/{channel}?limit=50"),
+                    )
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+                )
+                .await;
+            let elapsed = start.elapsed();
+            assert_eq!(resp.status(), StatusCode::OK);
+            elapsed
+        }
+    })
+    .await;
+
+    assert!(
+        best < Duration::from_millis(500),
+        "message history page took {best:?} (budget 500ms) — check for lost \
+         indexes or N+1 loading on the messages read path"
+    );
+}
+
+/// Budget: guild full-text search over 1,000 messages must complete well
+/// under 750ms. Catches regressions in the tsvector index usage.
+#[sqlx::test]
+async fn budget_guild_search_under_750ms(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
+    let (owner, _) = create_test_user(&pool).await;
+    let guild = create_guild(&pool, owner).await;
+    let channel = create_channel(&pool, guild, "perf-search").await;
+    seed_messages(&pool, channel, owner, 1_000).await;
+    let token = generate_access_token(&app.config, owner);
+
+    let best = best_of_3(|| {
+        let app = &app;
+        let token = token.clone();
+        async move {
+            let start = Instant::now();
+            let resp = app
+                .oneshot(
+                    TestApp::request(Method::GET, &format!("/api/guilds/{guild}/search?q=seeded"))
+                        .header("Authorization", format!("Bearer {token}"))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await;
+            let elapsed = start.elapsed();
+            assert_eq!(resp.status(), StatusCode::OK);
+            elapsed
+        }
+    })
+    .await;
+
+    assert!(
+        best < Duration::from_millis(750),
+        "guild search took {best:?} (budget 750ms) — check tsvector index \
+         usage on the search path"
+    );
+}


### PR DESCRIPTION
## Summary

Goal 5 item 2 — performance budgets become release-blocking CI gates, scoped to what's deterministically measurable headlessly today.

### Enforced now

| Budget | Threshold | Baseline | Gate |
|---|---|---|---|
| Initial JS payload (gz, index.html-referenced) | ≤ 300 KB | 237 KB | `check_bundle_budget.py` in Frontend job |
| Initial CSS payload (gz) | ≤ 25 KB | 16 KB | same |
| Largest entry chunk (gz) | ≤ 170 KB | 130 KB | same |
| Message-history page (50 of 1,000 msgs) | best-of-3 < 500 ms | ~5 ms | `performance_budgets.rs` in Rust Tests |
| Guild full-text search (1,000 msgs) | best-of-3 < 750 ms | ~10 ms | same |

Design choices: lazy chunks are excluded (they don't block startup — the bundle gate is the practical <3 s-startup proxy); server gates use best-of-3 with generous thresholds so shared-runner noise can't flake them — they catch order-of-magnitude regressions (lost index, N+1), not micro-perf. Breach messages tell the author what to look for and how to raise a budget legitimately.

### Documented as manual (for now)

True client startup, voice-join E2E, and client memory budgets need a running Tauri app / real WebRTC peers — recorded in `docs/developer-guide/development/performance-budgets.md` with migration notes for when startup instrumentation lands.

## Verification

Both server budget tests pass locally; the bundle gate passes against the current build; clippy `--tests`, nightly fmt, docs governance, and CI guardrails all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)