### PR TITLE
feat(infra): upgrade preflight script + playbook (Phase 8, Goal 5 item 3)

### DIFF
--- a/docs/ops/upgrade-playbook.md
+++ b/docs/ops/upgrade-playbook.md
@@ -1,0 +1,98 @@
+# Upgrade Playbook
+
+> Phase 8 "self-hosted upgrade safety" (Goal 5 item 3). How to upgrade a
+> Kaiku deployment safely, and how to get back when an upgrade goes wrong.
+> Companion script: `infra/scripts/upgrade-preflight.sh`.
+> Backup/restore details: `docs/ops/backup-restore-runbook.md`.
+
+## Compatibility matrix (beta)
+
+During the 0.1.x beta, server and clients ship in **lockstep** — the
+WebSocket protocol and REST surface are not yet versioned, so always
+upgrade server and clients from the same release tag.
+
+| Server | Desktop client | Android | Status |
+|---|---|---|---|
+| 0.1.x (tag N) | 0.1.x (tag N) | 0.1.x | ✅ the only supported combination |
+| tag N | tag N−1 | — | ⚠️ usually works for text chat; voice/WS event changes may break — not tested, don't rely on it |
+
+This table must gain real rows when the protocol gets versioned
+(prerequisite for non-lockstep upgrades and the desktop auto-updater
+serving older servers).
+
+## Safe upgrade windows
+
+- Prefer low-activity hours (check Grafana for the daily usage trough;
+  for the beta server that is typically **03:00–07:00 UTC**, after the
+  03:00 backup cron has produced a fresh dump).
+- Never upgrade with active voice calls if avoidable: container restart
+  drops all calls (clients auto-rejoin, but it's user-visible).
+- Never upgrade with a failed or stale backup — the preflight enforces it.
+
+## Upgrade procedure
+
+All commands run on the VPS unless noted. Deploys are operator-run, never
+automated.
+
+```bash
+# 0. Preflight — fix every ✗ before continuing
+/opt/kaiku/infra/scripts/upgrade-preflight.sh
+# Note the printed "Current server image" digest — that is your rollback pin.
+
+# 1. Fresh backup if the latest is more than a few hours old
+/opt/kaiku/infra/scripts/backup.sh
+
+# 2. Update the checkout (compose files, migrations, client source)
+cd /opt/kaiku && git pull
+
+# 3. Deploy (from the workstation, or run the equivalent on the VPS)
+./infra/scripts/deploy.sh              # server + client
+#   --server-only / --client-only as needed
+
+# 4. Verify
+curl -sf http://localhost:8080/health
+docker logs canis-server --since 5m | grep -iE 'error|migrat' | head
+# In the app: log in, open a channel, send a message, join voice briefly.
+```
+
+Migrations apply automatically on server start. Watch the logs in step 4 —
+a migration failure leaves the server crash-looping and is your signal to
+roll back.
+
+## Rollback
+
+**Decide fast.** Two situations:
+
+### A. New version misbehaves, no new migrations ran
+
+Pin the previous image (digest printed by the preflight) and restart:
+
+```bash
+cd /opt/kaiku/infra/compose
+# Edit docker-compose.yml: replace the server image line with the digest, e.g.
+#   image: ghcr.io/detair/kaiku/server@sha256:<previous-digest>
+docker compose --profile monitoring up -d server
+curl -sf http://localhost:8080/health
+```
+
+Revert the compose edit after the next successful upgrade.
+
+### B. New migrations ran (schema changed)
+
+There are **no down-migrations** in this project (zero `.down.sql` files —
+verified 2026-06-12). An applied migration cannot be reverted in place;
+rolling back the binary alone may crash against the newer schema.
+
+1. Pin the previous image as in (A) — if the old server starts and works
+   against the new schema (additive migration), you're done.
+2. If it does not: restore the database from the pre-upgrade backup using
+   the **Restore: PostgreSQL** procedure in
+   `docs/ops/backup-restore-runbook.md`, then start the pinned image.
+   Messages sent between backup and rollback are lost — this is why the
+   preflight refuses to run without a fresh backup.
+
+## After any rollback
+
+- Note what broke in the release's GitHub issue/PR before memories fade.
+- Keep the failed image digest for debugging; don't retry the upgrade
+  until the cause is understood.

--- a/infra/scripts/upgrade-preflight.sh
+++ b/infra/scripts/upgrade-preflight.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Pre-upgrade safety checks for Kaiku. Run ON THE VPS before any deploy.
+#
+# Usage (on the VPS):
+#   /opt/kaiku/infra/scripts/upgrade-preflight.sh
+#
+# Exits non-zero if any check fails — do not deploy until all pass.
+# Companion playbook: docs/ops/upgrade-playbook.md
+#
+# Environment variables (defaults shown):
+#   COMPOSE_DIR=/opt/kaiku/infra/compose
+#   BACKUP_DIR=/var/lib/kaiku/backups
+#   MIGRATIONS_DIR=/opt/kaiku/server/migrations
+#   POSTGRES_CONTAINER=canis-postgres
+#   MIN_FREE_DISK_PCT=20
+#   MAX_BACKUP_AGE_HOURS=26
+
+set -uo pipefail
+
+COMPOSE_DIR="${COMPOSE_DIR:-/opt/kaiku/infra/compose}"
+BACKUP_DIR="${BACKUP_DIR:-/var/lib/kaiku/backups}"
+MIGRATIONS_DIR="${MIGRATIONS_DIR:-/opt/kaiku/server/migrations}"
+PG="${POSTGRES_CONTAINER:-canis-postgres}"
+MIN_FREE_DISK_PCT="${MIN_FREE_DISK_PCT:-20}"
+MAX_BACKUP_AGE_HOURS="${MAX_BACKUP_AGE_HOURS:-26}"
+
+FAILURES=0
+
+pass() { echo "  ✓ $1"; }
+fail() {
+    echo "  ✗ $1" >&2
+    FAILURES=$((FAILURES + 1))
+}
+
+echo "=== Kaiku upgrade preflight ($(date)) ==="
+
+# --- 1. Core services healthy ------------------------------------------------
+echo "[1/6] Service health"
+for c in canis-server "$PG" canis-valkey canis-caddy; do
+    state=$(docker inspect --format '{{.State.Status}}{{if .State.Health}}/{{.State.Health.Status}}{{end}}' "$c" 2>/dev/null || echo "missing")
+    case "$state" in
+        running | running/healthy) pass "$c: $state" ;;
+        *) fail "$c: $state" ;;
+    esac
+done
+
+# --- 2. Server HTTP health ----------------------------------------------------
+echo "[2/6] Server /health endpoint"
+if curl -sf --max-time 5 http://localhost:8080/health > /dev/null; then
+    pass "server responds healthy"
+else
+    fail "server /health did not respond OK"
+fi
+
+# --- 3. Disk space -------------------------------------------------------------
+echo "[3/6] Disk space (need >${MIN_FREE_DISK_PCT}% free)"
+used_pct=$(df --output=pcent / | tail -1 | tr -dc '0-9')
+free_pct=$((100 - used_pct))
+if [ "$free_pct" -gt "$MIN_FREE_DISK_PCT" ]; then
+    pass "${free_pct}% free on /"
+else
+    fail "only ${free_pct}% free on / — image pull + old image may not fit"
+fi
+
+# --- 4. Backup recency ----------------------------------------------------------
+echo "[4/6] Backup recency (<${MAX_BACKUP_AGE_HOURS}h, integrity-checked)"
+latest_backup=$(find "$BACKUP_DIR" -name 'kaiku-2*.sql.gz' -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-)
+if [ -z "$latest_backup" ]; then
+    fail "no postgres backup found in $BACKUP_DIR — run infra/scripts/backup.sh first"
+else
+    age_hours=$(( ($(date +%s) - $(stat -c %Y "$latest_backup")) / 3600 ))
+    if [ "$age_hours" -lt "$MAX_BACKUP_AGE_HOURS" ] && gzip -t "$latest_backup" 2>/dev/null; then
+        pass "latest backup ${age_hours}h old, gzip intact ($(basename "$latest_backup"))"
+    else
+        fail "latest backup is ${age_hours}h old or corrupt — take a fresh one before upgrading"
+    fi
+fi
+
+# --- 5. Pending migrations (informational gate) --------------------------------
+echo "[5/6] Migration delta (repo vs database)"
+repo_migrations=$(find "$MIGRATIONS_DIR" -name '*.sql' 2>/dev/null | wc -l)
+db_migrations=$(docker exec "$PG" psql -U voicechat -d voicechat -tAc \
+    "SELECT count(*) FROM _sqlx_migrations" 2>/dev/null || echo "?")
+if [ "$db_migrations" = "?" ]; then
+    fail "could not read _sqlx_migrations from the database"
+elif [ "$repo_migrations" -lt "$db_migrations" ]; then
+    fail "repo has FEWER migrations ($repo_migrations) than the DB ($db_migrations) — checkout is older than the running data; git pull first"
+else
+    pending=$((repo_migrations - db_migrations))
+    pass "$pending pending migration(s) will apply on server start ($db_migrations applied, $repo_migrations in repo)"
+    if [ "$pending" -gt 0 ]; then
+        echo "    NOTE: there are NO down-migrations — rollback after a migration"
+        echo "    means restoring the database from backup (see the playbook)."
+    fi
+fi
+
+# --- 6. Compose config + rollback reference -------------------------------------
+echo "[6/6] Compose config & current image (record for rollback)"
+if (cd "$COMPOSE_DIR" && docker compose config -q 2>/dev/null); then
+    pass "docker compose config parses"
+else
+    fail "docker compose config is invalid — fix before deploying"
+fi
+current_image=$(docker inspect --format '{{index .RepoDigests 0}}' canis-server 2>/dev/null || echo "unknown")
+echo "    Current server image (pin this for rollback): $current_image"
+
+echo
+if [ "$FAILURES" -gt 0 ]; then
+    echo "PREFLIGHT FAILED: $FAILURES check(s) — do not deploy."
+    exit 1
+fi
+echo "Preflight OK — safe to deploy."


### PR DESCRIPTION
## Summary

Goal 5 item 3 — **self-hosted upgrade safety**. One operator script + one playbook:

### `infra/scripts/upgrade-preflight.sh` (run on the VPS, blocks bad deploys)
1. Core containers running/healthy + server `/health`
2. >20% free disk (image pull headroom)
3. Latest backup **<26h old and gzip-intact** — refuses to deploy unprotected
4. Migration delta (repo files vs `_sqlx_migrations` rows) — catches deploying an older checkout against newer data, and warns that pending migrations have no reverse path
5. Compose config validity + prints the current image **digest as the rollback pin**

### `docs/ops/upgrade-playbook.md`
- Beta compatibility matrix: server + clients are **lockstep** until the protocol is versioned (honest single supported row)
- Safe upgrade windows (post-backup-cron trough, no active voice)
- Step-by-step upgrade w/ verification, and a two-path rollback: image-pin for binary problems; **restore-from-backup when migrations ran** — verified the project has zero `.down.sql` files, so the playbook says so instead of pretending migrations revert

`bash -n` + docs governance pass. Pure ops content — no application code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)