### PR TITLE
feat(api): admin diagnostics endpoint + ops runbook index (Goal 5 item 4)

### DIFF
--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -1,0 +1,33 @@
+# Kaiku Operations Runbooks
+
+> Index for operators of self-hosted Kaiku instances. Every entry assumes
+> the docker-compose deployment from `infra/compose/`.
+
+## Runbooks
+
+| Situation | Runbook |
+|---|---|
+| Taking / restoring backups, quarterly restore drill | [backup-restore-runbook.md](backup-restore-runbook.md) |
+| Upgrading to a new release, rolling back a bad one | [upgrade-playbook.md](upgrade-playbook.md) |
+| Reading metrics/traces/logs, alert meanings | [observability-runbook.md](observability-runbook.md) |
+| Observability data contract (what the server emits) | [observability-contract.md](observability-contract.md) |
+
+## Quick triage
+
+1. **One-call health snapshot** (system admin token required):
+   `GET /api/admin/diagnostics` — store connectivity, DB pool pressure,
+   disk usage, active voice/WS counts, error count (last 5 min).
+2. **Liveness**: `GET /health` (no auth) — `ok` / `degraded` with per-store
+   booleans.
+3. **Metrics view**: admin dashboard → Observability, or Grafana
+   (`--profile monitoring`).
+4. **Before any deploy**: `infra/scripts/upgrade-preflight.sh` on the host.
+
+## Scripts (run on the host)
+
+| Script | Purpose |
+|---|---|
+| `infra/scripts/backup.sh` | Daily postgres + RustFS backup (cron) |
+| `infra/scripts/upgrade-preflight.sh` | Pre-deploy safety gate |
+| `infra/scripts/deploy.sh` | Operator-run deploy (never automated) |
+| `infra/scripts/setup-beta.sh` | Initial host provisioning |

--- a/server/src/admin/mod.rs
+++ b/server/src/admin/mod.rs
@@ -94,6 +94,7 @@ pub fn router(state: AppState) -> Router<AppState> {
     let admin_routes = Router::new()
         .route("/health", get(|| async { "admin ok" }))
         .route("/stats", get(system::get_admin_stats))
+        .route("/diagnostics", get(system::get_diagnostics))
         .route("/users", get(users::list_users))
         .route("/users/export", get(users::export_users_csv))
         .route("/users/{id}/details", get(users::get_user_details))

--- a/server/src/admin/observability.rs
+++ b/server/src/admin/observability.rs
@@ -29,7 +29,7 @@ pub fn init_start_time() {
     START_TIME.get_or_init(Instant::now);
 }
 
-fn server_uptime_seconds() -> u64 {
+pub(super) fn server_uptime_seconds() -> u64 {
     START_TIME.get_or_init(Instant::now).elapsed().as_secs()
 }
 

--- a/server/src/admin/system.rs
+++ b/server/src/admin/system.rs
@@ -8,6 +8,7 @@ use std::net::SocketAddr;
 use axum::extract::{ConnectInfo, Path, State};
 use axum::{Extension, Json};
 use chrono::{DateTime, Utc};
+use fred::interfaces::ClientLike;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 use uuid::Uuid;
@@ -633,4 +634,125 @@ pub async fn delete_oidc_provider(
     }
 
     Ok(Json(serde_json::json!({ "success": true })))
+}
+
+// ============================================================================
+// Diagnostics (operator supportability pack — Phase 8)
+// ============================================================================
+
+/// Filesystem usage for the server's root mount, if measurable.
+#[derive(Debug, Serialize)]
+pub struct DiskDiagnostics {
+    pub total_bytes: u64,
+    pub available_bytes: u64,
+    pub used_percent: f64,
+}
+
+/// Database connectivity and pool pressure.
+#[derive(Debug, Serialize)]
+pub struct DatabaseDiagnostics {
+    pub ok: bool,
+    pub pool_size: u32,
+    pub pool_idle: usize,
+}
+
+/// One-call infrastructure snapshot for operator triage.
+#[derive(Debug, Serialize)]
+pub struct DiagnosticsResponse {
+    /// "ok" when both stores respond, "degraded" otherwise.
+    pub status: &'static str,
+    pub version: &'static str,
+    pub uptime_seconds: u64,
+    pub database: DatabaseDiagnostics,
+    pub valkey_ok: bool,
+    /// `None` when the host has no usable `df` (e.g. minimal containers).
+    pub disk: Option<DiskDiagnostics>,
+    /// Active voice sessions in the last 5 minutes (telemetry-derived).
+    pub voice_active_sessions: Option<i64>,
+    /// Active WebSocket connections in the last 5 minutes (telemetry-derived).
+    pub ws_active_connections: Option<i64>,
+    /// Server error events in the last 5 minutes (telemetry-derived).
+    pub errors_last_5m: Option<i64>,
+}
+
+/// Best-effort disk usage via `df` (no unsafe statvfs — the workspace
+/// forbids unsafe code). Returns `None` if `df` is unavailable or output
+/// is unparseable; diagnostics must degrade, not fail.
+async fn disk_usage() -> Option<DiskDiagnostics> {
+    let output = tokio::process::Command::new("df")
+        .args(["-B1", "--output=size,avail", "/"])
+        .output()
+        .await
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8(output.stdout).ok()?;
+    let line = text.lines().nth(1)?;
+    let mut parts = line.split_whitespace();
+    let total_bytes: u64 = parts.next()?.parse().ok()?;
+    let available_bytes: u64 = parts.next()?.parse().ok()?;
+    if total_bytes == 0 {
+        return None;
+    }
+    #[allow(clippy::cast_precision_loss)]
+    let used_percent =
+        ((total_bytes - available_bytes) as f64 / total_bytes as f64 * 1000.0).round() / 10.0;
+    Some(DiskDiagnostics {
+        total_bytes,
+        available_bytes,
+        used_percent,
+    })
+}
+
+/// `GET /api/admin/diagnostics`
+///
+/// Operator triage snapshot: store connectivity, DB pool pressure, disk,
+/// and recent activity/error counts in a single call. Complements
+/// `/api/admin/observability/summary` (metrics-flavored) with the
+/// infrastructure-flavored view the ops runbooks reference.
+///
+/// Telemetry-derived fields are `null` when observability is disabled —
+/// connectivity checks always run.
+#[tracing::instrument(skip(state, _admin))]
+pub async fn get_diagnostics(
+    Extension(_admin): Extension<SystemAdminUser>,
+    State(state): State<AppState>,
+) -> Json<DiagnosticsResponse> {
+    let now = Utc::now();
+    let five_min_ago = now - chrono::Duration::minutes(5);
+
+    let db_ok = sqlx::query("SELECT 1").fetch_one(&state.db).await.is_ok();
+    let valkey_ok = state.redis.ping::<String>(None).await.is_ok();
+    let disk = disk_usage().await;
+
+    // Telemetry-derived counts are best-effort: a failure (e.g. telemetry
+    // tables absent) must not break the triage endpoint.
+    let voice_active_sessions = queries::summary_active_voice_sessions(&state.db, five_min_ago)
+        .await
+        .ok()
+        .flatten();
+    let ws_active_connections = queries::summary_active_ws_connections(&state.db, five_min_ago)
+        .await
+        .ok()
+        .flatten();
+    let errors_last_5m = queries::summary_recent_error_count(&state.db, five_min_ago)
+        .await
+        .ok();
+
+    Json(DiagnosticsResponse {
+        status: if db_ok && valkey_ok { "ok" } else { "degraded" },
+        version: env!("CARGO_PKG_VERSION"),
+        uptime_seconds: super::observability::server_uptime_seconds(),
+        database: DatabaseDiagnostics {
+            ok: db_ok,
+            pool_size: state.db.size(),
+            pool_idle: state.db.num_idle(),
+        },
+        valkey_ok,
+        disk,
+        voice_active_sessions,
+        ws_active_connections,
+        errors_last_5m,
+    })
 }

--- a/server/tests/integration/admin_diagnostics.rs
+++ b/server/tests/integration/admin_diagnostics.rs
@@ -1,0 +1,54 @@
+//! Integration tests for `GET /api/admin/diagnostics` (operator
+//! supportability pack, Phase 8 Goal 5).
+
+use axum::body::Body;
+use axum::http::{Method, StatusCode};
+use sqlx::PgPool;
+
+use super::helpers::{body_to_json, create_test_user, generate_access_token, make_admin, TestApp};
+
+#[sqlx::test]
+async fn admin_gets_diagnostics_snapshot(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
+    let (admin_id, _) = create_test_user(&pool).await;
+    make_admin(&pool, admin_id).await;
+    let token = generate_access_token(&app.config, admin_id);
+
+    let resp = app
+        .oneshot(
+            TestApp::request(Method::GET, "/api/admin/diagnostics")
+                .header("Authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = body_to_json(resp).await;
+    assert_eq!(body["status"], "ok", "test stores are up: {body}");
+    assert_eq!(body["database"]["ok"], true);
+    assert_eq!(body["valkey_ok"], true);
+    assert!(body["database"]["pool_size"].as_u64().unwrap() >= 1);
+    assert!(body["version"].is_string());
+    assert!(body["uptime_seconds"].is_number());
+    // Telemetry-derived fields exist (may be null without observability)
+    assert!(body.get("voice_active_sessions").is_some());
+    assert!(body.get("errors_last_5m").is_some());
+}
+
+#[sqlx::test]
+async fn non_admin_cannot_access_diagnostics(pool: PgPool) {
+    let app = TestApp::with_pool(pool.clone()).await;
+    let (user_id, _) = create_test_user(&pool).await;
+    let token = generate_access_token(&app.config, user_id);
+
+    let resp = app
+        .oneshot(
+            TestApp::request(Method::GET, "/api/admin/diagnostics")
+                .header("Authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}

--- a/server/tests/integration/main.rs
+++ b/server/tests/integration/main.rs
@@ -1,5 +1,6 @@
 mod helpers;
 
+mod admin_diagnostics;
 mod admin_elevation;
 mod admin_reports;
 mod auth;


### PR DESCRIPTION
## Summary

The **operator supportability pack** — last of Goal 5's four priority reliability items.

### `GET /api/admin/diagnostics` (system-admin gated)

One call for triage: `status` (ok/degraded), version + uptime, DB connectivity **with pool size/idle pressure**, Valkey connectivity, disk usage (best-effort `df` — the workspace forbids unsafe, so no statvfs), and telemetry-derived activity (active voice/WS, errors last 5 min; `null` when observability is disabled — connectivity checks always run, and telemetry failures degrade to null instead of breaking the endpoint you need most during incidents).

Complements `/api/admin/observability/summary` (metrics-flavored) with the infrastructure-flavored view.

### `docs/ops/README.md`

Runbook index tying together backup-restore, upgrade playbook, and observability runbooks, with a quick-triage order (diagnostics → /health → Grafana → preflight) and the host-script table.

## Verification

- Integration tests: elevated admin → 200 with all expected fields asserted; plain user → 403
- clippy `--tests`, nightly fmt, docs governance clean; 2/2 new tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)