### PR TITLE
fix(voice): close connectivity monitor gaps (resolves TD-27)

### DIFF
--- a/client/src/components/settings/SessionList.tsx
+++ b/client/src/components/settings/SessionList.tsx
@@ -5,7 +5,14 @@
  * Shows channel name, guild, time info, and basic metrics for each session.
  */
 
-import { Component, createResource, createSignal, Show, For } from "solid-js";
+import {
+  Component,
+  createResource,
+  createSignal,
+  createEffect,
+  Show,
+  For,
+} from "solid-js";
 import { fetchApi } from "../../lib/tauri";
 
 interface SessionSummary {
@@ -44,7 +51,20 @@ async function fetchSessions(offset: number): Promise<SessionSummary[]> {
 
 export const SessionList: Component = () => {
   const [offset, setOffset] = createSignal(0);
-  const [sessions] = createResource(offset, fetchSessions);
+  // Accumulate pages instead of replacing: each fetched page is appended so
+  // "Load more" grows the list rather than swapping to just the newest page.
+  const [allSessions, setAllSessions] = createSignal<SessionSummary[]>([]);
+  const [pageSize, setPageSize] = createSignal(0);
+  const [page] = createResource(offset, fetchSessions);
+
+  createEffect(() => {
+    const fetched = page();
+    if (!fetched) return;
+    setPageSize(fetched.length);
+    setAllSessions((prev) =>
+      offset() === 0 ? fetched : [...prev, ...fetched],
+    );
+  });
 
   const formatTime = (iso: string) => {
     const d = new Date(iso);
@@ -73,10 +93,10 @@ export const SessionList: Component = () => {
   return (
     <div class="space-y-2">
       <Show
-        when={!sessions.loading}
+        when={!page.loading || allSessions().length > 0}
         fallback={<div class="text-text-secondary text-sm">Loading...</div>}
       >
-        <For each={sessions()}>
+        <For each={allSessions()}>
           {(session) => (
             <div class="flex items-center gap-3 p-3 bg-surface-layer2 rounded-lg">
               <div
@@ -109,12 +129,13 @@ export const SessionList: Component = () => {
           )}
         </For>
 
-        <Show when={sessions()?.length === 10}>
+        <Show when={pageSize() === 10}>
           <button
             class="w-full py-2 text-sm text-text-secondary hover:text-text-primary"
+            disabled={page.loading}
             onClick={() => setOffset((o) => o + 10)}
           >
-            Load more...
+            {page.loading ? "Loading..." : "Load more..."}
           </button>
         </Show>
       </Show>

--- a/docs/developer-guide/project/tech-debt.md
+++ b/docs/developer-guide/project/tech-debt.md
@@ -252,14 +252,15 @@ Password reset emails are plain text. HTML alternative with `lettre::message::Mu
 
 ---
 
-### TD-27: Connectivity monitor known gaps
+### TD-27: Connectivity monitor known gaps ✅ RESOLVED
 
 **Source:** `docs/developer-guide/plans/2026-01-19-user-connectivity-monitor-PR.md:139-144`
 
-- No integration tests for REST API endpoints
-- Session ID is client-generated, not validated server-side
-- Pagination replaces list instead of appending
-- No retry for session finalization on DB failure
+**Resolved:** 2026-06-12 — all four gaps closed:
+- **REST integration tests** — `server/tests/integration/connectivity_http.rs` (10 tests: summary, sessions list, pagination, session detail, auth required, RLS cross-user isolation) was added between the audit and now.
+- **Server-side session ID validation** — `handle_voice_stats` now overwrites the client-supplied `session_id` with the server-tracked `peer.session_id`, so metrics can't be filed against a forged or foreign session (`server/src/voice/ws_handler.rs`).
+- **Pagination append** — `SessionList.tsx` accumulates pages (createEffect appends each fetched page) instead of replacing on offset change; "Load more" grows the list.
+- **Finalization retry** — `finalize_session` is called inside a 3-attempt exponential-backoff loop (100/200/400 ms) in `ws_handler.rs`; this was already present.
 
 ---
 
@@ -290,12 +291,12 @@ Threads feature is complete but there's no guild-level setting to enable/disable
 
 | Status | Count |
 |--------|-------|
-| ✅ Resolved | 20 |
-| Open | 10 |
+| ✅ Resolved | 21 |
+| Open | 9 |
 | **Total** | 30 |
 
-**Resolved items:** TD-01, TD-02, TD-03, TD-04, TD-05, TD-06, TD-08, TD-09, TD-10, TD-11, TD-12, TD-13, TD-15, TD-16, TD-17, TD-20, TD-22, TD-25, TD-26, TD-30
-**Open items:** TD-07, TD-14, TD-18, TD-19, TD-21, TD-23, TD-24, TD-27, TD-28, TD-29 (rescoped)
+**Resolved items:** TD-01, TD-02, TD-03, TD-04, TD-05, TD-06, TD-08, TD-09, TD-10, TD-11, TD-12, TD-13, TD-15, TD-16, TD-17, TD-20, TD-22, TD-25, TD-26, TD-27, TD-30
+**Open items:** TD-07, TD-14, TD-18, TD-19, TD-21, TD-23, TD-24, TD-28, TD-29 (rescoped)
 
 ## Code Quality Summary
 

--- a/server/src/voice/ws_handler.rs
+++ b/server/src/voice/ws_handler.rs
@@ -682,7 +682,7 @@ async fn handle_voice_stats(
     pool: &PgPool,
     user_id: Uuid,
     channel_id: Uuid,
-    stats: VoiceStats,
+    mut stats: VoiceStats,
 ) -> Result<(), VoiceError> {
     // Rate limit check
     if sfu.check_stats_rate_limit(user_id).await.is_err() {
@@ -696,24 +696,33 @@ async fn handle_voice_stats(
         return Ok(());
     }
 
-    // Broadcast to room participants
-    let broadcast = ServerEvent::VoiceUserStats {
-        channel_id,
-        user_id,
-        latency: stats.latency,
-        packet_loss: stats.packet_loss,
-        jitter: stats.jitter,
-        quality: stats.quality,
+    // The peer must be in the room; bail before storing anything otherwise.
+    // We also take the SERVER-tracked session id from the peer rather than
+    // trusting the client-supplied `stats.session_id` — the client value is
+    // unauthenticated and a wrong/forged id would file metrics against a
+    // session that never gets finalized (or another user's session).
+    let Some(room) = sfu.get_room(channel_id).await else {
+        return Ok(());
     };
+    let Some(peer) = room.get_peer(user_id).await else {
+        warn!(user_id = %user_id, channel_id = %channel_id, "User sent voice stats for a room they are not in");
+        return Ok(());
+    };
+    stats.session_id = peer.session_id;
 
-    if let Some(room) = sfu.get_room(channel_id).await {
-        // Verify user is actually in the room before broadcasting
-        if room.get_peer(user_id).await.is_none() {
-            warn!(user_id = %user_id, channel_id = %channel_id, "User attempted to broadcast stats to a room they are not in");
-            return Ok(());
-        }
-        room.broadcast_except(user_id, broadcast).await;
-    }
+    // Broadcast to room participants
+    room.broadcast_except(
+        user_id,
+        ServerEvent::VoiceUserStats {
+            channel_id,
+            user_id,
+            latency: stats.latency,
+            packet_loss: stats.packet_loss,
+            jitter: stats.jitter,
+            quality: stats.quality,
+        },
+    )
+    .await;
 
     // Store in database (fire-and-forget)
     let guild_id = get_guild_id(pool, channel_id).await;


### PR DESCRIPTION
## Summary

Resolves **TD-27** — the four connectivity-monitor gaps from the original PR, audited against current code:

| Gap | Status |
|---|---|
| **Server-side session ID validation** (security) | **Fixed** — `handle_voice_stats` stored the client-supplied `session_id` verbatim into `connection_metrics`. A forged or wrong id files metrics against a session that never finalizes (or another user's). Now overwritten with the server-tracked `peer.session_id` (peer room membership was already verified before storing) |
| **Pagination replaces instead of appends** | **Fixed** — `SessionList.tsx` used `createResource(offset, …)` which swaps to the newest page; "Load more" lost prior pages. Now accumulates via a `createEffect` that appends each fetched page and resets on offset 0 |
| **No REST integration tests** | **Already present** — `connectivity_http.rs` has 10 tests (summary, sessions, pagination, detail, auth, cross-user RLS isolation), added between the audit and now |
| **No finalization retry** | **Already present** — `finalize_session` runs inside a 3-attempt exponential-backoff loop (100/200/400 ms) in `ws_handler.rs` |

The two already-present items are documented as resolved in tech-debt.md rather than duplicated.

## Verification

clippy , nightly fmt, , client suite (606 passing), connectivity REST tests (10 passing), docs governance — all clean. tech-debt.md resolution summary now **21 resolved / 9 open**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)