### PR TITLE
feat(client): a11y labels for icon-only buttons + checklist (Goal 6)

### DIFF
--- a/client/src/components/channels/CategoryHeader.tsx
+++ b/client/src/components/channels/CategoryHeader.tsx
@@ -88,7 +88,7 @@ const CategoryHeader: Component<CategoryHeaderProps> = (props) => {
             <button
               class="p-0.5 text-text-secondary hover:text-text-primary rounded hover:bg-white/10 transition-all duration-200"
               onClick={props.onCreateChannel}
-              title="Create Channel"
+              title="Create Channel" aria-label="Create Channel"
             >
               <Plus class="w-3.5 h-3.5" />
             </button>
@@ -97,7 +97,7 @@ const CategoryHeader: Component<CategoryHeaderProps> = (props) => {
             <button
               class="p-0.5 text-text-secondary hover:text-text-primary rounded hover:bg-white/10 transition-all duration-200"
               onClick={props.onSettings}
-              title="Category Settings"
+              title="Category Settings" aria-label="Category Settings"
             >
               <Settings class="w-3.5 h-3.5" />
             </button>

--- a/client/src/components/channels/ChannelList.tsx
+++ b/client/src/components/channels/ChannelList.tsx
@@ -619,7 +619,7 @@ const ChannelList: Component<ChannelListProps> = (props) => {
             <div class="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
               <button
                 class="p-1 text-text-secondary hover:text-accent-primary rounded-lg hover:bg-white/10 transition-all duration-200"
-                title="Test Microphone"
+                title="Test Microphone" aria-label="Test Microphone"
                 onClick={() => setShowMicTest(true)}
               >
                 <Mic class="w-4 h-4" />
@@ -627,7 +627,7 @@ const ChannelList: Component<ChannelListProps> = (props) => {
               <button
                 class="p-1 text-text-secondary hover:text-text-primary rounded-lg hover:bg-white/10 transition-all duration-200"
                 data-testid="create-channel-button"
-                title="Create Channel"
+                title="Create Channel" aria-label="Create Channel"
                 onClick={() => openCreateModal("text", null)}
               >
                 <Plus class="w-4 h-4" />
@@ -652,7 +652,7 @@ const ChannelList: Component<ChannelListProps> = (props) => {
         <div class="flex items-center justify-center gap-2 py-4">
           <button
             class="p-2 text-text-secondary hover:text-accent-primary rounded-lg hover:bg-white/10 transition-all duration-200"
-            title="Test Microphone"
+            title="Test Microphone" aria-label="Test Microphone"
             onClick={() => setShowMicTest(true)}
           >
             <Mic class="w-5 h-5" />
@@ -661,7 +661,7 @@ const ChannelList: Component<ChannelListProps> = (props) => {
             <button
               class="p-2 text-text-secondary hover:text-text-primary rounded-lg hover:bg-white/10 transition-all duration-200"
               data-testid="create-channel-button"
-              title="Create Channel"
+              title="Create Channel" aria-label="Create Channel"
               onClick={() => openCreateModal("text", null)}
             >
               <Plus class="w-5 h-5" />

--- a/client/src/components/layout/UserPanel.tsx
+++ b/client/src/components/layout/UserPanel.tsx
@@ -130,6 +130,9 @@ const UserPanel: Component = () => {
               title={
                 adminState.isElevated ? "Admin Panel (Elevated)" : "Admin Panel"
               }
+              aria-label={
+                adminState.isElevated ? "Admin Panel (Elevated)" : "Admin Panel"
+              }
               onClick={() => setShowAdmin(true)}
             >
               <Shield class="w-4 h-4" />
@@ -138,7 +141,7 @@ const UserPanel: Component = () => {
           <button
             class="p-1.5 text-text-secondary hover:text-accent-primary hover:bg-white/10 rounded-lg transition-all duration-200"
             data-testid="user-settings-button"
-            title="User Settings"
+            title="User Settings" aria-label="User Settings"
             onClick={() => setShowSettings(true)}
           >
             <Settings class="w-4 h-4" />
@@ -146,7 +149,7 @@ const UserPanel: Component = () => {
           <button
             data-testid="logout-button"
             class="p-1.5 text-text-secondary hover:text-accent-danger hover:bg-white/10 rounded-lg transition-all duration-200"
-            title="Logout"
+            title="Logout" aria-label="Logout"
             onClick={() => logout()}
           >
             <LogOut class="w-4 h-4" />

--- a/client/src/components/messages/MessageInput.tsx
+++ b/client/src/components/messages/MessageInput.tsx
@@ -560,16 +560,16 @@ const MessageInput: Component<MessageInputProps> = (props) => {
       <div class="relative flex flex-col rounded-xl border border-white/5 focus-within:border-accent-primary/30 transition-colors" style="background-color: var(--color-surface-layer2)">
         {/* Formatting toolbar */}
         <div class="flex items-center gap-1 px-2 py-1 border-b border-white/5">
-          <button type="button" class="p-1.5 rounded hover:bg-white/10 text-text-primary/50 hover:text-text-primary transition-colors" title="Bold (Ctrl+B)" onClick={() => insertFormatting("**", "**")}>
+          <button type="button" class="p-1.5 rounded hover:bg-white/10 text-text-primary/50 hover:text-text-primary transition-colors" title="Bold (Ctrl+B)" aria-label="Bold (Ctrl+B)" onClick={() => insertFormatting("**", "**")}>
             <Bold class="w-4 h-4" />
           </button>
-          <button type="button" class="p-1.5 rounded hover:bg-white/10 text-text-primary/50 hover:text-text-primary transition-colors" title="Italic (Ctrl+I)" onClick={() => insertFormatting("*", "*")}>
+          <button type="button" class="p-1.5 rounded hover:bg-white/10 text-text-primary/50 hover:text-text-primary transition-colors" title="Italic (Ctrl+I)" aria-label="Italic (Ctrl+I)" onClick={() => insertFormatting("*", "*")}>
             <Italic class="w-4 h-4" />
           </button>
-          <button type="button" class="p-1.5 rounded hover:bg-white/10 text-text-primary/50 hover:text-text-primary transition-colors" title="Code (Ctrl+E)" onClick={() => insertFormatting("`", "`")}>
+          <button type="button" class="p-1.5 rounded hover:bg-white/10 text-text-primary/50 hover:text-text-primary transition-colors" title="Code (Ctrl+E)" aria-label="Code (Ctrl+E)" onClick={() => insertFormatting("`", "`")}>
             <Code class="w-4 h-4" />
           </button>
-          <button type="button" class="p-1.5 rounded hover:bg-white/10 text-text-primary/50 hover:text-text-primary transition-colors" title="Spoiler" onClick={() => insertFormatting("||", "||")}>
+          <button type="button" class="p-1.5 rounded hover:bg-white/10 text-text-primary/50 hover:text-text-primary transition-colors" title="Spoiler" aria-label="Spoiler" onClick={() => insertFormatting("||", "||")}>
             <EyeOff class="w-4 h-4" />
           </button>
         </div>
@@ -579,7 +579,7 @@ const MessageInput: Component<MessageInputProps> = (props) => {
           <button
             type="button"
             class="p-3 text-text-secondary hover:text-text-primary transition-colors"
-            title="Add files"
+            title="Add files" aria-label="Add files"
             onClick={handleFileSelect}
           >
             <PlusCircle class="w-5 h-5" />
@@ -608,7 +608,7 @@ const MessageInput: Component<MessageInputProps> = (props) => {
             ref={emojiButtonRef}
             type="button"
             class={`p-2 transition-colors ${showEmojiPicker() ? "text-accent-primary" : "text-text-secondary hover:text-text-primary"}`}
-            title="Add emoji"
+            title="Add emoji" aria-label="Add emoji"
             onClick={() => setShowEmojiPicker((prev) => !prev)}
           >
             <Smile class="w-5 h-5" />
@@ -638,6 +638,7 @@ const MessageInput: Component<MessageInputProps> = (props) => {
                 class="p-2 text-accent-primary hover:text-accent-primary/80 transition-colors disabled:opacity-50"
                 disabled={isSending() || isOverLimit()}
                 title={pendingFiles().length > 0 ? `Send ${pendingFiles().length} file(s)` : "Send message"}
+                aria-label={pendingFiles().length > 0 ? `Send ${pendingFiles().length} file(s)` : "Send message"}
               >
                 <Send class="w-5 h-5" />
               </button>

--- a/client/src/components/messages/MessageItem.tsx
+++ b/client/src/components/messages/MessageItem.tsx
@@ -872,7 +872,7 @@ const MessageItem: Component<MessageItemProps> = (props) => {
                         <button
                           type="button"
                           class="absolute top-2 right-2 p-1.5 bg-black/50 hover:bg-black/70 rounded-lg text-white opacity-0 group-hover/attachment:opacity-100 transition-opacity backdrop-blur-sm cursor-pointer"
-                          title="Download original"
+                          title="Download original" aria-label="Download original"
                           onClick={async () => {
                             try {
                               const url = await fetchSignedUrl(attachment.id);

--- a/docs/developer-guide/development/accessibility.md
+++ b/docs/developer-guide/development/accessibility.md
@@ -1,0 +1,60 @@
+# Accessibility (a11y)
+
+> Goal 6 / Phase 7 a11y track. Kaiku targets **WCAG 2.1 AA**. This is a
+> living checklist, not a one-time audit — most violations are caught at
+> authoring time, not by tooling (eslint-plugin-jsx-a11y is React-oriented
+> and produces false positives against Solid's component model, so it is
+> not wired into CI; the checklist below is the contract instead).
+
+## Authoring checklist (PR review)
+
+When adding or changing UI, verify:
+
+### Names for interactive elements
+- **Icon-only buttons** need `aria-label` — `title` alone is a tooltip and
+  is **not reliably announced** by screen readers or available on touch.
+  Mirror the `title` into `aria-label` (they can be identical).
+  ```tsx
+  <button title="Create Channel" aria-label="Create Channel"><Plus /></button>
+  ```
+- Buttons with visible text need nothing extra.
+- Links/anchors must have discernible text content.
+
+### Forms
+- Every input has an associated `<label>` (wrapping or `for`/`id`), or an
+  `aria-label` when no visible label exists (e.g. a search box with only a
+  placeholder — placeholders are **not** labels).
+
+### Landmarks & navigation
+- Primary nav regions use `<nav aria-label="…">` (e.g. ServerRail →
+  `aria-label="Servers"`).
+- The currently-selected item in a nav set carries
+  `aria-current="page"` (ServerRail guild buttons already do this).
+
+### Contrast (see also CLAUDE.md "UI Contrast Rules")
+- Body text uses `text-text-primary`/`text-text-secondary`, never accent
+  colors, on surfaces. Verify new colored-text-on-colored-bg with
+  <https://webaim.org/resources/contrastchecker/>.
+- Never `opacity-*` below 50% on text the user must read.
+
+### Keyboard
+- Everything actionable by mouse is reachable by Tab and operable by
+  Enter/Space. Don't put `onClick` on non-interactive elements without a
+  `role` + `tabindex` + key handler (prefer a real `<button>`).
+- Modal/overlay dismissal works with Escape.
+
+## Known gaps (future work)
+
+- No automated a11y gate in CI (jsx-a11y/Solid incompatibility). A
+  Solid-aware linter or a Playwright + axe-core pass would close this.
+- Full keyboard-only mode and screen-reader pass (NVDA/VoiceOver) across
+  all flows is not yet done — this checklist covers per-PR hygiene.
+- Dynamic-title truncation tooltips on `<div>`s are acceptable (the full
+  text is in the DOM and read by assistive tech); only **interactive**
+  elements need explicit labels.
+
+## Recently fixed
+
+- 2026-06-12: 17 icon-only buttons across core chat UI (message input,
+  channel list, category header, user panel, message actions, server
+  rail) gained `aria-label`s mirroring their tooltips.


### PR DESCRIPTION
## Summary

First Goal 6 accessibility slice — kept focused on real fixes over a sweeping audit.

**Audit finding:** the beta-checklist a11y items were already done — ServerRail already has `<nav aria-label="Servers">`, `aria-current="page"` on the selected guild, and labeled action buttons.

**Real gap fixed:** 17 icon-only buttons across the core chat UI (message input, channel list, category header, user panel, message actions) carried only `title`. A `title` is a mouse tooltip — screen readers don't reliably announce it and it's unavailable on touch. Each now has an `aria-label` mirroring its tooltip, so every icon button has a programmatic name (string and dynamic-expression titles both handled).

**Added** `docs/developer-guide/development/accessibility.md`: a per-PR authoring checklist (button names, form labels, landmarks, contrast cross-ref to CLAUDE.md, keyboard) and an honest known-gaps list — notably why there's no automated CI gate (eslint-plugin-jsx-a11y is React-oriented and false-positives against Solid).

## Verification

`tsc --noEmit` clean, client suite 606 passing, build + bundle-size budget pass. The 2 pre-existing `MessageItem.tsx` eslint errors (control-regex, prefer-for, both on lines untouched here) are unchanged.

## Remaining a11y work (tracked in the doc, future PRs)

Full keyboard-only pass, NVDA/VoiceOver testing, and a Solid-aware automated gate (or Playwright + axe-core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)