### PR TITLE
feat(voice): default STUN to self-hosted coturn, not Google (Goal 5)

### DIFF
--- a/docs/admin-guide/self-hosting.md
+++ b/docs/admin-guide/self-hosting.md
@@ -41,5 +41,31 @@ The fastest way to get a node online. We will provide a pre-configured `docker-c
 ### 2. The "Esports Org" (Kubernetes)
 For massive communities. Detailed Helm charts and documentation for deploying scalable replicas of the Signaling server behind a load balancer, with dedicated external TURN clusters.
 
+## <span style="color: #88C0D0;">Voice NAT Traversal & Sovereignty (STUN/TURN)</span>
+
+WebRTC needs a **STUN** server (to discover each client's public address) and,
+for clients behind strict NATs/firewalls, a **TURN** relay. The bundled
+`docker-compose.yml` runs a `coturn` instance that serves **both** on port
+`3478`.
+
+**Point STUN at your own coturn, not Google.** The server's default
+`STUN_SERVER` is Google's public server (`stun:stun.l.google.com:19302`) so
+voice works out of the box — but on a self-hosted node that still leaks every
+client's IP-discovery request to a third party, defeating the point of
+self-hosting. Set:
+
+```env
+STUN_SERVER=stun:<your-domain>:3478
+TURN_SERVER=turn:<your-domain>:3478
+TURN_SHARED_SECRET=<random 32+ byte hex>   # coturn use-auth-secret mode
+```
+
+`infra/scripts/setup-beta.sh` does this automatically (rewrites `STUN_SERVER`
+to your domain and generates the shared secret). If you configure TURN but
+leave STUN on Google, the server logs a startup **warning** flagging the leak.
+
+TURN credentials are issued per-request as HMAC-SHA1 time-limited tokens
+(RFC 5766), so no static password is stored client-side.
+
 ---
 *Documentation to be expanded as the implementation stabilizes.*

--- a/infra/compose/.env.beta
+++ b/infra/compose/.env.beta
@@ -43,6 +43,10 @@ ALLOW_EMPTY_PASSWORD=no
 # =============================================================================
 # WebRTC Voice
 # =============================================================================
+# STUN: point at the self-hosted coturn (it serves STUN on the same 3478 port)
+# so client IP discovery stays on your infrastructure instead of leaking to
+# Google. setup-beta.sh rewrites this to stun:${DOMAIN}:3478 automatically.
+# Only fall back to stun:stun.l.google.com:19302 if you run no coturn.
 STUN_SERVER=stun:stun.l.google.com:19302
 RTP_PORT_MIN=10000
 RTP_PORT_MAX=10100

--- a/infra/scripts/setup-beta.sh
+++ b/infra/scripts/setup-beta.sh
@@ -146,11 +146,15 @@ if [[ "${SKIP_ENV:-0}" != "1" ]]; then
     sed -i "s|GRAFANA_ADMIN_PASSWORD=CHANGEME|GRAFANA_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}|" "$ENV_FILE"
     sed -i "s|TURN_SHARED_SECRET=CHANGEME_TURN_SECRET|TURN_SHARED_SECRET=${TURN_SHARED_SECRET}|" "$ENV_FILE"
 
+    # Point STUN at the self-hosted coturn (serves STUN on the same 3478
+    # port) so client IP discovery does not leak to Google's public server.
+    sed -i "s|STUN_SERVER=stun:stun.l.google.com:19302|STUN_SERVER=stun:${DOMAIN}:3478|" "$ENV_FILE"
+
     # Detect public IP for WebRTC and TURN
     if [[ -n "$SERVER_IP" && "$SERVER_IP" != "unknown" ]]; then
         sed -i "s|PUBLIC_IP=CHANGEME|PUBLIC_IP=${SERVER_IP}|" "$ENV_FILE"
         sed -i "s|TURN_SERVER=CHANGEME_TURN|TURN_SERVER=turn:${DOMAIN}:3478|" "$ENV_FILE"
-        log "Set PUBLIC_IP=${SERVER_IP}, TURN_SERVER=turn:${DOMAIN}:3478"
+        log "Set PUBLIC_IP=${SERVER_IP}, STUN/TURN to self-hosted coturn (${DOMAIN}:3478)"
     else
         sed -i "s|TURN_SERVER=CHANGEME_TURN|TURN_SERVER=turn:${DOMAIN}:3478|" "$ENV_FILE"
         warn "PUBLIC_IP could not be detected. Set it manually in ${ENV_FILE} for TURN to work."

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -451,6 +451,21 @@ impl Config {
              browsers will reject the refresh cookie without the Secure flag"
         );
 
+        // Sovereignty check: a self-hosted deployment that runs its own TURN
+        // (coturn) but still points STUN at Google leaks every client's IP
+        // discovery to a third party — defeating the point of self-hosting.
+        // coturn serves STUN on the same host/port as TURN, so the operator
+        // can almost always point STUN at it. Warn loudly rather than fail,
+        // since some operators deliberately use a public STUN.
+        if stun_leaks_with_self_hosted_turn(&config.stun_server, config.turn_server.as_deref()) {
+            tracing::warn!(
+                stun_server = %config.stun_server,
+                "TURN is self-hosted but STUN still points at Google's public \
+                 server — client IP discovery is leaking to a third party. Set \
+                 STUN_SERVER to your coturn endpoint (e.g. stun:<your-domain>:3478)."
+            );
+        }
+
         Ok(config)
     }
 
@@ -576,3 +591,42 @@ const TEST_JWT_PUBLIC_KEY: &str = "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUNvd0JRW
 /// Generated with: openssl rand -hex 32
 const TEST_MFA_ENCRYPTION_KEY: &str =
     "a4f8e2d1b7c9036f5e8d4a2b1c7f9e3d6a8b5c2d4e7f1a3b9c6d8e2f5a7b4c";
+
+/// Returns true when a self-hosted TURN server is configured but STUN still
+/// points at Google's public server — a sovereignty leak (client IP
+/// discovery goes to a third party). Pure helper so the condition is unit
+/// tested without a tracing subscriber.
+fn stun_leaks_with_self_hosted_turn(stun_server: &str, turn_server: Option<&str>) -> bool {
+    turn_server.is_some() && stun_server.contains("stun.l.google.com")
+}
+
+#[cfg(test)]
+mod stun_sovereignty_tests {
+    use super::stun_leaks_with_self_hosted_turn;
+
+    #[test]
+    fn google_stun_with_self_hosted_turn_leaks() {
+        assert!(stun_leaks_with_self_hosted_turn(
+            "stun:stun.l.google.com:19302",
+            Some("turn:chat.example.com:3478"),
+        ));
+    }
+
+    #[test]
+    fn self_hosted_stun_does_not_leak() {
+        assert!(!stun_leaks_with_self_hosted_turn(
+            "stun:chat.example.com:3478",
+            Some("turn:chat.example.com:3478"),
+        ));
+    }
+
+    #[test]
+    fn google_stun_without_turn_is_not_flagged() {
+        // No self-hosted TURN configured — using public STUN is a deliberate
+        // choice, not a leak to warn about.
+        assert!(!stun_leaks_with_self_hosted_turn(
+            "stun:stun.l.google.com:19302",
+            None,
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

Remaining Goal 5 / Phase 8 item — **self-hosted STUN/TURN sovereignty**. The roadmap flagged it: the server defaulted STUN to Google's public server (`stun.l.google.com`) **even on deployments running their own coturn** (which already serves STUN on the same 3478 port as TURN). Every client's IP-discovery request was leaking to a third party — defeating the point of self-hosting. The beta's own `.env.beta` had this leak.

## Changes

- **`config.rs`**: startup **warning** when TURN is self-hosted but STUN still points at Google, with the fix in the message. The condition is a pure `stun_leaks_with_self_hosted_turn()` helper with 3 unit tests (leak / self-hosted-no-leak / no-TURN-so-not-flagged — using public STUN without your own TURN is a deliberate choice, not a leak).
- **`setup-beta.sh`**: rewrites `STUN_SERVER` → `stun:${DOMAIN}:3478` alongside the TURN setup, so provisioned nodes keep STUN on their own coturn.
- **`.env.beta`**: documents the choice; the Google default stays for coturn-less nodes but the setup script overrides it.
- **`self-hosting.md`**: new STUN/TURN sovereignty section.

Warn-don't-fail: some operators deliberately use public STUN; the default still works out of the box.

## Verification

clippy `--tests`, nightly fmt, `bash -n`, docs governance clean; 3 new config tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)