### PR TITLE
feat(android): display message attachments (beta blocker 2/5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release note structure source: `docs/project/RELEASE_NOTES_TEMPLATE.md`
 
 ### Added
+- Android: message attachments now display — images render as inline thumbnails, other files as a chip with name and size (previously attachments were invisible)
 - Android: messages now render inline markdown (bold, italic, strikethrough, inline code, and click-to-reveal spoilers) instead of plain text
 - Desktop auto-update: the app checks GitHub Releases for new signed builds shortly after startup, downloads updates in the background, and offers a one-click restart to apply — release artifacts are now cryptographically signed and ship with an updater manifest
 - Desktop system tray: Kaiku now lives in the tray with a Show/Quit menu, closing the window hides it to the tray instead of quitting (use the tray's "Quit Kaiku" to exit), and the tray shows your total unread count (tooltip everywhere, number badge on macOS and most Linux trays)

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/channel/MessageAttachments.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/channel/MessageAttachments.kt
@@ -1,0 +1,98 @@
+package io.wolftown.kaiku.ui.channel
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import io.wolftown.kaiku.domain.model.Attachment
+import kotlin.math.ln
+import kotlin.math.pow
+
+/**
+ * Renders a message's attachments: images as inline thumbnails (tappable
+ * via the surrounding message), everything else as a compact file chip
+ * with name and human-readable size.
+ */
+@Composable
+fun MessageAttachments(
+    attachments: List<Attachment>,
+    modifier: Modifier = Modifier,
+) {
+    if (attachments.isEmpty()) return
+    Column(modifier = modifier.padding(top = 4.dp)) {
+        for (att in attachments) {
+            if (att.isImage()) {
+                AsyncImage(
+                    model = att.mediumUrl ?: att.url,
+                    contentDescription = att.filename,
+                    contentScale = ContentScale.Fit,
+                    modifier = Modifier
+                        .padding(vertical = 2.dp)
+                        .widthIn(max = 240.dp)
+                        .heightIn(max = 240.dp)
+                        .clip(RoundedCornerShape(8.dp)),
+                )
+            } else {
+                FileChip(att)
+            }
+        }
+    }
+}
+
+@Composable
+private fun FileChip(att: Attachment) {
+    Row(
+        modifier = Modifier
+            .padding(vertical = 2.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+            .padding(horizontal = 12.dp, vertical = 8.dp)
+            .widthIn(max = 280.dp),
+    ) {
+        Column {
+            Text(
+                text = att.filename,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = humanReadableSize(att.size),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+/** True when the attachment is an image we can render inline. */
+fun Attachment.isImage(): Boolean = mimeType.startsWith("image/", ignoreCase = true)
+
+/**
+ * Format a byte count as a short human-readable string (e.g. "1.5 MB").
+ * Pure helper, unit-tested. Uses binary units (1024) like most file UIs.
+ */
+fun humanReadableSize(bytes: Long): String {
+    if (bytes < 0) return "0 B"
+    if (bytes < 1024) return "$bytes B"
+    val units = arrayOf("KB", "MB", "GB", "TB", "PB")
+    val exp = (ln(bytes.toDouble()) / ln(1024.0)).toInt().coerceIn(1, units.size)
+    val value = bytes / 1024.0.pow(exp.toDouble())
+    // One decimal, trimming a trailing .0
+    val rounded = (value * 10).toLong() / 10.0
+    val text = if (rounded % 1.0 == 0.0) rounded.toLong().toString() else rounded.toString()
+    return "$text ${units[exp - 1]}"
+}

--- a/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/channel/MessageItem.kt
+++ b/mobile/android/app/src/main/java/io/wolftown/kaiku/ui/channel/MessageItem.kt
@@ -107,6 +107,9 @@ fun MessageItem(
                     MessageContent(content = message.content)
                 }
 
+                // Attachments (image thumbnails + file chips)
+                MessageAttachments(attachments = message.attachments)
+
                 // Edited indicator
                 if (message.editedAt != null) {
                     Text(

--- a/mobile/android/app/src/test/java/io/wolftown/kaiku/domain/AttachmentDisplayTest.kt
+++ b/mobile/android/app/src/test/java/io/wolftown/kaiku/domain/AttachmentDisplayTest.kt
@@ -1,0 +1,60 @@
+package io.wolftown.kaiku.domain
+
+import io.wolftown.kaiku.domain.model.Attachment
+import io.wolftown.kaiku.ui.channel.humanReadableSize
+import io.wolftown.kaiku.ui.channel.isImage
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AttachmentDisplayTest {
+
+    private fun attachment(mime: String) = Attachment(
+        id = "a",
+        filename = "f",
+        mimeType = mime,
+        size = 1,
+        url = "http://x/f",
+    )
+
+    @Test
+    fun isImage_recognizesImageMimeTypes() {
+        assertTrue(attachment("image/png").isImage())
+        assertTrue(attachment("image/jpeg").isImage())
+        assertTrue(attachment("IMAGE/WEBP").isImage()) // case-insensitive
+    }
+
+    @Test
+    fun isImage_rejectsNonImages() {
+        assertFalse(attachment("application/pdf").isImage())
+        assertFalse(attachment("video/mp4").isImage())
+        assertFalse(attachment("text/plain").isImage())
+    }
+
+    @Test
+    fun humanReadableSize_bytes() {
+        assertEquals("0 B", humanReadableSize(0))
+        assertEquals("512 B", humanReadableSize(512))
+        assertEquals("1023 B", humanReadableSize(1023))
+    }
+
+    @Test
+    fun humanReadableSize_kilobytes() {
+        assertEquals("1 KB", humanReadableSize(1024))
+        assertEquals("1.5 KB", humanReadableSize(1536))
+    }
+
+    @Test
+    fun humanReadableSize_megabytes() {
+        assertEquals("1 MB", humanReadableSize(1024L * 1024))
+        assertEquals("5 MB", humanReadableSize(5L * 1024 * 1024))
+        assertEquals("1.5 MB", humanReadableSize(1024L * 1024 * 3 / 2))
+    }
+
+    @Test
+    fun humanReadableSize_gigabytes_and_negative() {
+        assertEquals("2 GB", humanReadableSize(2L * 1024 * 1024 * 1024))
+        assertEquals("0 B", humanReadableSize(-5))
+    }
+}


### PR DESCRIPTION
## Summary

Second of the five Android-beta blockers. The `Attachment` model was fully defined (filename, mimeType, size, url, thumbnail/medium URLs, dimensions) but **never rendered** — attachments were invisible in the Android message list.

- **`MessageAttachments.kt`**: images (`mimeType` `image/*`) render as inline Coil thumbnails (`mediumUrl ?: url`, capped at 240dp, rounded corners); non-images render as a compact file chip with filename + human-readable size.
- **`humanReadableSize()`** and **`Attachment.isImage()`** are pure top-level helpers (binary units, case-insensitive mime check), with 6 JUnit tests covering byte/KB/MB/GB boundaries, the 1.5× fractional case, negative-size guard, and image-mime case-insensitivity.
- `MessageItem` renders `MessageAttachments` below the message content.

## Tests

6 JUnit tests for the pure helpers; CI's **Android Build** + **testDebugUnitTest** validate compilation (Android can't be built on the dev machine).

Android Beta milestone — 3 blockers remain: unread indicators, DM UI, reaction picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)