### PR TITLE
feat(auth): user_identities table as OIDC login lookup (linking foundation)

### DIFF
--- a/docs/developer-guide/project/goals.md
+++ b/docs/developer-guide/project/goals.md
@@ -248,9 +248,16 @@ the SaaS path is actually pursued:
        server OTel (Goal 4). *Only remaining: release source-map upload —
        needs an external Sentry account (operator infra), so out of scope
        here.* [Original "partially present" framing was stale.]
-4. [ ] **Identity trust / OAuth linking** — medium priority. (OIDC login
+4. [~] **Identity trust / OAuth linking** — medium priority. (OIDC login
        already exists; "linking" of multiple external identities to one
-       account is the new surface — verify before building.)
+       account is the new surface.) **Foundation shipped 2026-06-20 (PR #600):**
+       new `user_identities` table (authoritative `(provider_slug, subject)`
+       login lookup, back-fills the legacy single `users.external_id`); OIDC
+       login resolves and records identities through it. Verified: code review
+       found the model was one-identity-per-account by construction; no linking
+       existed. Remaining: (a) authenticated link/list/unlink endpoints +
+       link-intent OIDC flow; (b) client "Linked Accounts" settings UI. Both
+       build directly on this table.
 5. [ ] **Billing & subscriptions (Stripe)** — defer until a SaaS launch
        decision is made; do not build speculatively.
 

--- a/server/migrations/20260322000000_user_identities.sql
+++ b/server/migrations/20260322000000_user_identities.sql
@@ -1,0 +1,49 @@
+-- OAuth/OIDC identity linking: allow one Kaiku account to be reached by
+-- multiple external identities.
+--
+-- Until now a user's single external identity lived in `users.external_id`
+-- ("{provider_slug}:{subject}", UNIQUE), which structurally permits only one
+-- linked provider per account. This table makes the identity set first-class:
+-- the OIDC login lookup resolves through it, and (in a follow-up) authenticated
+-- users can attach and remove additional identities.
+--
+-- `users.external_id` is retained as the original/primary identity marker (it
+-- still satisfies the oidc_user_has_external_id CHECK and is back-filled below),
+-- but it is no longer the authoritative lookup key.
+
+CREATE TABLE user_identities (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    -- Provider slug, mirroring oidc_providers.slug. Intentionally NOT a foreign
+    -- key: legacy/env-seeded providers and provider deletion must not orphan or
+    -- cascade-delete a user's identity history.
+    provider_slug VARCHAR(64) NOT NULL,
+    -- Provider-specific subject ("sub") claim. May itself contain ':'.
+    subject VARCHAR(255) NOT NULL,
+    -- Email reported by the provider at link time (informational; nullable).
+    email VARCHAR(255),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_used_at TIMESTAMPTZ,
+
+    -- An external identity belongs to exactly one Kaiku account.
+    CONSTRAINT user_identities_provider_subject_unique UNIQUE (provider_slug, subject),
+    -- At most one identity per provider per account (no two Google logins on one account).
+    CONSTRAINT user_identities_user_provider_unique UNIQUE (user_id, provider_slug)
+);
+
+CREATE INDEX idx_user_identities_user_id ON user_identities(user_id);
+
+-- Back-fill existing single-identity OIDC users. external_id is
+-- "{slug}:{subject}"; the slug never contains ':', so the first ':' is the
+-- separator and any remaining ':' stay with the subject.
+INSERT INTO user_identities (user_id, provider_slug, subject, email, created_at)
+SELECT
+    id,
+    split_part(external_id, ':', 1),
+    substring(external_id FROM position(':' IN external_id) + 1),
+    email,
+    created_at
+FROM users
+WHERE auth_method = 'oidc'
+  AND external_id IS NOT NULL
+  AND position(':' IN external_id) > 0;

--- a/server/src/auth/login.rs
+++ b/server/src/auth/login.rs
@@ -638,6 +638,12 @@ pub async fn oidc_callback(
     // Composite external_id: "{provider_slug}:{subject}". Retained as the
     // user's primary-identity marker; the authoritative lookup is the
     // user_identities table keyed by (provider_slug, subject).
+    //
+    // NOTE for the linking follow-up: users.external_id still carries a UNIQUE
+    // constraint and only ever holds the *first* identity. Once an account can
+    // attach additional identities, that constraint must not be treated as a
+    // uniqueness guarantee for the identity set (user_identities is) — and
+    // should likely be demoted to non-unique before multi-identity writes land.
     let external_id = format!("{}:{}", flow_state.slug, user_info.subject);
 
     // User resolution: resolve the external identity to an account.
@@ -763,10 +769,31 @@ pub async fn oidc_callback(
             }
         }
 
-        new_user.ok_or_else(|| {
-            tracing::error!(external_id = %external_id, "Failed to create OIDC user after 5 collision retries");
-            AuthError::Internal("Username generation failed after retries".to_string())
-        })?
+        match new_user {
+            Some(user) => user,
+            None => {
+                // The retry loop exhausted. The dominant cause is losing a
+                // concurrent first-login race for this same identity: another
+                // request created the account (and its identity row) between our
+                // pre-loop lookup and our insert, so insert_oidc_user kept hitting
+                // the users.external_id UNIQUE constraint (reported as a generic
+                // collision). Re-resolve the identity; if it now exists, log that
+                // account in instead of failing.
+                if let Some(user_id) =
+                    find_user_id_by_identity(&state.db, &flow_state.slug, &user_info.subject)
+                        .await?
+                {
+                    find_user_by_id(&state.db, user_id).await?.ok_or_else(|| {
+                        AuthError::Internal("Identity resolved to a missing user".to_string())
+                    })?
+                } else {
+                    tracing::error!(external_id = %external_id, "Failed to create OIDC user after 5 collision retries");
+                    return Err(AuthError::Internal(
+                        "Username generation failed after retries".to_string(),
+                    ));
+                }
+            }
+        }
     };
 
     // Generate JWT token pair

--- a/server/src/auth/login.rs
+++ b/server/src/auth/login.rs
@@ -30,8 +30,8 @@ use super::{cookies, geoip, hash_token};
 use crate::api::AppState;
 use crate::db::{
     self, create_password_reset_token, create_session, delete_session_by_token_hash,
-    find_session_by_token_hash, find_user_by_email, find_user_by_external_id, find_user_by_id,
-    find_user_by_username, find_valid_reset_token, get_auth_methods_allowed,
+    find_session_by_token_hash, find_user_by_email, find_user_by_id, find_user_by_username,
+    find_user_id_by_identity, find_valid_reset_token, get_auth_methods_allowed,
     get_unused_mfa_backup_codes, invalidate_user_reset_tokens, is_setup_complete,
     mark_mfa_backup_code_used,
 };
@@ -635,11 +635,19 @@ pub async fn oidc_callback(
             AuthError::OidcCodeExchangeFailed(format!("Failed to extract user info: {e}"))
         })?;
 
-    // Composite external_id: "{provider_slug}:{subject}"
+    // Composite external_id: "{provider_slug}:{subject}". Retained as the
+    // user's primary-identity marker; the authoritative lookup is the
+    // user_identities table keyed by (provider_slug, subject).
     let external_id = format!("{}:{}", flow_state.slug, user_info.subject);
 
-    // User resolution
-    let user = if let Some(existing) = find_user_by_external_id(&state.db, &external_id).await? {
+    // User resolution: resolve the external identity to an account.
+    let existing_user =
+        match find_user_id_by_identity(&state.db, &flow_state.slug, &user_info.subject).await? {
+            Some(user_id) => find_user_by_id(&state.db, user_id).await?,
+            None => None,
+        };
+
+    let user = if let Some(existing) = existing_user {
         // Existing user — login
         existing
     } else {
@@ -711,6 +719,21 @@ pub async fn oidc_callback(
             .await?
             {
                 Some(user) => {
+                    // Record the external identity (authoritative login key) in
+                    // the same transaction as the user row.
+                    db::insert_user_identity(
+                        &mut *tx,
+                        user.id,
+                        &flow_state.slug,
+                        &user_info.subject,
+                        user_info.email.as_deref(),
+                    )
+                    .await
+                    .map_err(|e| {
+                        tracing::error!(error = %e, user_id = %user.id, provider = %flow_state.slug, "Failed to record OIDC identity");
+                        AuthError::Database(e)
+                    })?;
+
                     // Grant admin to first user
                     if is_first_user {
                         queries::grant_first_user_admin(&mut tx, user.id)

--- a/server/src/db/models.rs
+++ b/server/src/db/models.rs
@@ -52,6 +52,28 @@ pub enum AuthMethod {
     Oidc,
 }
 
+/// An external (OIDC/OAuth) identity linked to a user account.
+///
+/// One account may have several of these — the authoritative lookup key for an
+/// OIDC login is `(provider_slug, subject)`.
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct UserIdentity {
+    /// Unique identity row ID.
+    pub id: Uuid,
+    /// The Kaiku account this identity belongs to.
+    pub user_id: Uuid,
+    /// Provider slug (mirrors `oidc_providers.slug`).
+    pub provider_slug: String,
+    /// Provider-specific subject (`sub`) claim.
+    pub subject: String,
+    /// Email reported by the provider at link time (informational).
+    pub email: Option<String>,
+    /// When the identity was linked.
+    pub created_at: DateTime<Utc>,
+    /// When the identity was last used to log in.
+    pub last_used_at: Option<DateTime<Utc>>,
+}
+
 /// User online status.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, sqlx::Type, utoipa::ToSchema)]
 #[sqlx(type_name = "user_status", rename_all = "lowercase")]

--- a/server/src/db/queries.rs
+++ b/server/src/db/queries.rs
@@ -52,18 +52,6 @@ pub async fn find_user_by_username(pool: &PgPool, username: &str) -> sqlx::Resul
         .map_err(db_error!("find_user_by_username", username = %username))
 }
 
-/// Find user by external ID (for OIDC).
-pub async fn find_user_by_external_id(
-    pool: &PgPool,
-    external_id: &str,
-) -> sqlx::Result<Option<User>> {
-    sqlx::query_as::<_, User>("SELECT * FROM users WHERE external_id = $1")
-        .bind(external_id)
-        .fetch_optional(pool)
-        .await
-        .map_err(db_error!("find_user_by_external_id", external_id = %external_id))
-}
-
 // ============================================================================
 // External (OIDC/OAuth) identities
 // ============================================================================

--- a/server/src/db/queries.rs
+++ b/server/src/db/queries.rs
@@ -7,14 +7,14 @@
 use std::collections::HashMap;
 
 use chrono::{DateTime, Utc};
-use sqlx::{PgPool, QueryBuilder, Row};
+use sqlx::{Executor, PgPool, Postgres, QueryBuilder, Row};
 use tracing::{debug, error};
 use uuid::Uuid;
 
 use super::models::{
     AuthMethodsConfig, Channel, ChannelMember, ChannelType, ChannelUnread, FileAttachment,
     GuildUnreadSummary, Message, MfaBackupCode, OidcProviderRow, PasswordResetToken, Session,
-    UnreadAggregate, User,
+    UnreadAggregate, User, UserIdentity,
 };
 
 /// Log and return a database error with context.
@@ -62,6 +62,68 @@ pub async fn find_user_by_external_id(
         .fetch_optional(pool)
         .await
         .map_err(db_error!("find_user_by_external_id", external_id = %external_id))
+}
+
+// ============================================================================
+// External (OIDC/OAuth) identities
+// ============================================================================
+
+/// Resolve an external identity `(provider_slug, subject)` to its Kaiku account.
+///
+/// This is the authoritative lookup for an OIDC login: it supports accounts
+/// with multiple linked identities, unlike the legacy `users.external_id` key.
+pub async fn find_user_id_by_identity(
+    pool: &PgPool,
+    provider_slug: &str,
+    subject: &str,
+) -> sqlx::Result<Option<Uuid>> {
+    sqlx::query_scalar::<_, Uuid>(
+        "SELECT user_id FROM user_identities WHERE provider_slug = $1 AND subject = $2",
+    )
+    .bind(provider_slug)
+    .bind(subject)
+    .fetch_optional(pool)
+    .await
+    .map_err(db_error!("find_user_id_by_identity", provider_slug = %provider_slug))
+}
+
+/// Insert an external identity row, returning the created record.
+///
+/// Generic over the executor so it can run on a pool or inside the OIDC
+/// registration transaction. Surfaces a unique-violation error to the caller
+/// (the `(provider_slug, subject)` and `(user_id, provider_slug)` constraints).
+pub async fn insert_user_identity<'e, E>(
+    executor: E,
+    user_id: Uuid,
+    provider_slug: &str,
+    subject: &str,
+    email: Option<&str>,
+) -> sqlx::Result<UserIdentity>
+where
+    E: Executor<'e, Database = Postgres>,
+{
+    sqlx::query_as::<_, UserIdentity>(
+        "INSERT INTO user_identities (user_id, provider_slug, subject, email)
+         VALUES ($1, $2, $3, $4)
+         RETURNING *",
+    )
+    .bind(user_id)
+    .bind(provider_slug)
+    .bind(subject)
+    .bind(email)
+    .fetch_one(executor)
+    .await
+}
+
+/// List all external identities linked to a user, oldest first.
+pub async fn list_user_identities(pool: &PgPool, user_id: Uuid) -> sqlx::Result<Vec<UserIdentity>> {
+    sqlx::query_as::<_, UserIdentity>(
+        "SELECT * FROM user_identities WHERE user_id = $1 ORDER BY created_at ASC",
+    )
+    .bind(user_id)
+    .fetch_all(pool)
+    .await
+    .map_err(db_error!("list_user_identities", user_id = %user_id))
 }
 
 /// Find user by email.

--- a/server/tests/integration/oidc.rs
+++ b/server/tests/integration/oidc.rs
@@ -814,3 +814,136 @@ async fn test_first_user_detection(pool: PgPool) {
         "setup_complete config row must exist for registration locking"
     );
 }
+
+// ============================================================================
+// External Identity Linking (user_identities table)
+// ============================================================================
+
+#[sqlx::test]
+async fn test_user_identity_insert_and_lookup(pool: PgPool) {
+    let user_id = create_test_user(&pool).await;
+
+    // No identity yet.
+    let none = vc_server::db::find_user_id_by_identity(&pool, "google", "sub-123")
+        .await
+        .expect("lookup should succeed");
+    assert_eq!(none, None);
+
+    // Insert an identity.
+    let identity = vc_server::db::insert_user_identity(
+        &pool,
+        user_id,
+        "google",
+        "sub-123",
+        Some("a@example.com"),
+    )
+    .await
+    .expect("insert should succeed");
+    assert_eq!(identity.user_id, user_id);
+    assert_eq!(identity.provider_slug, "google");
+    assert_eq!(identity.subject, "sub-123");
+    assert_eq!(identity.email.as_deref(), Some("a@example.com"));
+    assert!(identity.last_used_at.is_none());
+
+    // Now resolvable to the account.
+    let found = vc_server::db::find_user_id_by_identity(&pool, "google", "sub-123")
+        .await
+        .expect("lookup should succeed");
+    assert_eq!(found, Some(user_id));
+
+    // A different subject does not resolve.
+    let other = vc_server::db::find_user_id_by_identity(&pool, "google", "sub-999")
+        .await
+        .expect("lookup should succeed");
+    assert_eq!(other, None);
+}
+
+#[sqlx::test]
+async fn test_user_identity_list_multiple_providers(pool: PgPool) {
+    let user_id = create_test_user(&pool).await;
+
+    vc_server::db::insert_user_identity(&pool, user_id, "google", "g-1", None)
+        .await
+        .unwrap();
+    vc_server::db::insert_user_identity(&pool, user_id, "github", "gh-1", Some("u@example.com"))
+        .await
+        .unwrap();
+
+    let identities = vc_server::db::list_user_identities(&pool, user_id)
+        .await
+        .expect("list should succeed");
+    assert_eq!(identities.len(), 2);
+
+    // Both providers resolve back to the same account.
+    let g = vc_server::db::find_user_id_by_identity(&pool, "google", "g-1")
+        .await
+        .unwrap();
+    let gh = vc_server::db::find_user_id_by_identity(&pool, "github", "gh-1")
+        .await
+        .unwrap();
+    assert_eq!(g, Some(user_id));
+    assert_eq!(gh, Some(user_id));
+}
+
+#[sqlx::test]
+async fn test_user_identity_subject_unique_across_accounts(pool: PgPool) {
+    let user_a = create_test_user(&pool).await;
+    let user_b = create_test_user(&pool).await;
+
+    vc_server::db::insert_user_identity(&pool, user_a, "google", "shared-sub", None)
+        .await
+        .expect("first insert should succeed");
+
+    // The same (provider, subject) cannot be claimed by a second account.
+    let err = vc_server::db::insert_user_identity(&pool, user_b, "google", "shared-sub", None)
+        .await
+        .expect_err("duplicate (provider, subject) must be rejected");
+    match err {
+        sqlx::Error::Database(db_err) => assert!(db_err.is_unique_violation()),
+        other => panic!("expected unique violation, got {other:?}"),
+    }
+
+    // The identity still belongs to the original account.
+    let owner = vc_server::db::find_user_id_by_identity(&pool, "google", "shared-sub")
+        .await
+        .unwrap();
+    assert_eq!(owner, Some(user_a));
+}
+
+#[sqlx::test]
+async fn test_user_identity_one_per_provider_per_user(pool: PgPool) {
+    let user_id = create_test_user(&pool).await;
+
+    vc_server::db::insert_user_identity(&pool, user_id, "google", "sub-1", None)
+        .await
+        .expect("first insert should succeed");
+
+    // The same user cannot link a second identity for the same provider.
+    let err = vc_server::db::insert_user_identity(&pool, user_id, "google", "sub-2", None)
+        .await
+        .expect_err("second identity for same provider must be rejected");
+    match err {
+        sqlx::Error::Database(db_err) => assert!(db_err.is_unique_violation()),
+        other => panic!("expected unique violation, got {other:?}"),
+    }
+}
+
+#[sqlx::test]
+async fn test_user_identity_cascade_on_user_delete(pool: PgPool) {
+    let user_id = create_test_user(&pool).await;
+    vc_server::db::insert_user_identity(&pool, user_id, "google", "sub-del", None)
+        .await
+        .unwrap();
+
+    // Deleting the user cascades to its identities.
+    sqlx::query("DELETE FROM users WHERE id = $1")
+        .bind(user_id)
+        .execute(&pool)
+        .await
+        .expect("user delete should succeed");
+
+    let found = vc_server::db::find_user_id_by_identity(&pool, "google", "sub-del")
+        .await
+        .unwrap();
+    assert_eq!(found, None);
+}


### PR DESCRIPTION
## What & why

Foundation for **OAuth identity linking** (Goal 6 item 4). Verification (per the execution prompt's "verify before building") confirmed OIDC login is fully built and multi-provider, but a user's single external identity lives in `users.external_id` (`"{slug}:{subject}"`, `UNIQUE`) — structurally one provider per account, with no linking and no `user_identities` table.

This PR introduces the first-class identity table and rewires login lookup onto it, **without changing user-visible behavior** — existing OIDC logins resolve identically. It's deliberately scoped as **part 1 of 3** to keep the auth-hot-path change small and well-tested:
- **(this PR)** data model + migration + login-lookup refactor + tests
- (next) authenticated link/list/unlink endpoints + link-intent OIDC flow
- (after) client "Linked Accounts" settings UI

## Changes
- **Migration `20260322000000_user_identities.sql`**: new table with
  - `(provider_slug, subject)` UNIQUE — an external identity belongs to exactly one account
  - `(user_id, provider_slug)` UNIQUE — at most one identity per provider per account
  - `ON DELETE CASCADE` from `users`; index on `user_id`
  - back-fills existing `auth_method='oidc'` users from `external_id` (the slug never contains `:`, so the first `:` is the separator; trailing `:` stay with the subject)
- **`UserIdentity` model** (`db/models.rs`)
- **Queries** (`db/queries.rs`, runtime form → no `.sqlx` changes): `find_user_id_by_identity`, `insert_user_identity` (generic executor, works in a tx or on a pool), `list_user_identities`
- **Login callback** (`auth/login.rs`): resolves accounts via `find_user_id_by_identity` and records the identity in the **same transaction** as new-user creation. `users.external_id` is retained as the primary-identity marker (still satisfies the `oidc_user_has_external_id` CHECK).

## Verification
- ✅ Migration applies and back-fills against the dev DB
- ✅ **43 oidc** integration tests pass (5 new: insert/lookup, multi-provider list, both unique constraints, cascade delete) + **92 auth/setup** tests pass — login refactor causes no regression
- ✅ `cargo clippy -p vc-server --all-targets -D warnings` clean
- ✅ nightly `cargo fmt --check` clean
- Queries are runtime-form, so no `.sqlx` cache changes

No CHANGELOG entry: internal groundwork, no user-visible behavior change (per the repo's changelog rules).

Advances: **Goal 6 item 4** (marked in-progress in `goals.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017m2TjrBiDvBjGipb5E9BFb