### PR TITLE
feat(auth): linked-identity endpoints + OIDC link flow

### DIFF
--- a/docs/developer-guide/project/goals.md
+++ b/docs/developer-guide/project/goals.md
@@ -255,9 +255,17 @@ the SaaS path is actually pursued:
        login lookup, back-fills the legacy single `users.external_id`); OIDC
        login resolves and records identities through it. Verified: code review
        found the model was one-identity-per-account by construction; no linking
-       existed. Remaining: (a) authenticated link/list/unlink endpoints +
-       link-intent OIDC flow; (b) client "Linked Accounts" settings UI. Both
-       build directly on this table.
+       existed. **Endpoints + link flow shipped 2026-06-20 (PR #601):**
+       `GET /auth/me/identities` (list), `DELETE /auth/me/identities/{id}`
+       (unlink, ownership-checked, with a last-login-method guard for
+       passwordless accounts), and `GET /auth/me/identities/authorize/{provider}`
+       (authenticated link flow — the OIDC callback branches on a `link_user_id`
+       carried in the encrypted flow state, attaching the identity instead of
+       logging in; refuses identities already bound to another account).
+       Remaining: client "Linked Accounts" settings UI (PR3). NOTE: before any
+       further multi-identity hardening, consider demoting `users.external_id`'s
+       UNIQUE constraint (commented in login.rs) — linking does not write it, so
+       it is not yet a problem.
 5. [ ] **Billing & subscriptions (Stripe)** — defer until a SaaS launch
        decision is made; do not build speculatively.
 

--- a/server/src/auth/error.rs
+++ b/server/src/auth/error.rs
@@ -101,6 +101,14 @@ pub enum AuthError {
     #[error("This authentication method is disabled")]
     AuthMethodDisabled,
 
+    /// The external identity is already linked to another account.
+    #[error("This external account is already linked to another Kaiku account")]
+    IdentityAlreadyLinked,
+
+    /// Refusing to unlink the account's only remaining login method.
+    #[error("Cannot remove your only login method; set a password or link another account first")]
+    CannotUnlinkLastIdentity,
+
     /// Internal server error.
     #[error("Internal server error")]
     Internal(String),
@@ -141,6 +149,8 @@ impl IntoResponse for AuthError {
             Self::OidcCodeExchangeFailed(_) => (StatusCode::BAD_GATEWAY, "OIDC_EXCHANGE_FAILED"),
             Self::RegistrationDisabled => (StatusCode::FORBIDDEN, "REGISTRATION_DISABLED"),
             Self::AuthMethodDisabled => (StatusCode::FORBIDDEN, "AUTH_METHOD_DISABLED"),
+            Self::IdentityAlreadyLinked => (StatusCode::CONFLICT, "IDENTITY_ALREADY_LINKED"),
+            Self::CannotUnlinkLastIdentity => (StatusCode::CONFLICT, "CANNOT_UNLINK_LAST_IDENTITY"),
             Self::Internal(_) => (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL_ERROR"),
         };
 

--- a/server/src/auth/identities.rs
+++ b/server/src/auth/identities.rs
@@ -120,31 +120,15 @@ pub async fn unlink_identity(
     auth_user: AuthUser,
     Path(identity_id): Path<Uuid>,
 ) -> AuthResult<StatusCode> {
-    // Must exist and belong to the caller. Treat "not yours" as 404 so identity
-    // IDs of other accounts can't be probed.
-    let identity = db::find_user_identity_by_id(&state.db, identity_id)
-        .await?
-        .filter(|i| i.user_id == auth_user.id)
-        .ok_or_else(|| AuthError::NotFound("Identity not found".to_string()))?;
-
-    // Refuse to remove the account's only login method: a user with no password
-    // and a single linked identity would otherwise lock themselves out.
-    let user = db::find_user_by_id(&state.db, auth_user.id)
-        .await?
-        .ok_or(AuthError::UserNotFound)?;
-    if user.password_hash.is_none() {
-        let count = db::count_user_identities(&state.db, auth_user.id).await?;
-        if count <= 1 {
-            return Err(AuthError::CannotUnlinkLastIdentity);
+    // Ownership check, last-login-method guard, and delete run atomically under
+    // a user-row lock (see unlink_identity_guarded). Ownership failure is a 404
+    // so other accounts' identity IDs can't be probed.
+    match db::unlink_identity_guarded(&state.db, auth_user.id, identity_id).await? {
+        db::UnlinkOutcome::Deleted => {
+            tracing::info!(user_id = %auth_user.id, identity_id = %identity_id, "Unlinked OIDC identity");
+            Ok(StatusCode::NO_CONTENT)
         }
+        db::UnlinkOutcome::NotFound => Err(AuthError::NotFound("Identity not found".to_string())),
+        db::UnlinkOutcome::WouldLockOut => Err(AuthError::CannotUnlinkLastIdentity),
     }
-
-    let removed = db::delete_user_identity(&state.db, auth_user.id, identity.id).await?;
-    if !removed {
-        // Raced with another unlink of the same row.
-        return Err(AuthError::NotFound("Identity not found".to_string()));
-    }
-
-    tracing::info!(user_id = %auth_user.id, identity_id = %identity.id, provider = %identity.provider_slug, "Unlinked OIDC identity");
-    Ok(StatusCode::NO_CONTENT)
 }

--- a/server/src/auth/identities.rs
+++ b/server/src/auth/identities.rs
@@ -1,0 +1,150 @@
+//! Linked-identity management handlers.
+//!
+//! Lets an authenticated user view the external (OIDC) identities linked to
+//! their account, start a flow to link an additional one, and unlink an
+//! existing one. The link flow itself reuses the OIDC machinery in
+//! [`super::login`]; the callback distinguishes a link from a login by the
+//! `link_user_id` carried in the encrypted flow state.
+
+use std::collections::HashMap;
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::Response;
+use axum::Json;
+use uuid::Uuid;
+
+use super::error::{AuthError, AuthResult};
+use super::login::start_oidc_flow;
+use super::middleware::AuthUser;
+use super::types::{IdentityInfo, IdentityListResponse, OidcAuthorizeQuery};
+use crate::api::AppState;
+use crate::db;
+
+/// List the external identities linked to the authenticated account.
+///
+/// GET /auth/me/identities
+#[utoipa::path(
+    get,
+    path = "/auth/me/identities",
+    tag = "auth",
+    responses(
+        (status = 200, description = "Linked external identities", body = IdentityListResponse),
+    ),
+    security(("bearer_auth" = [])),
+)]
+#[tracing::instrument(skip(state))]
+pub async fn list_identities(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+) -> AuthResult<Json<IdentityListResponse>> {
+    let identities = db::list_user_identities(&state.db, auth_user.id).await?;
+
+    // Resolve provider slugs to human-readable names (fall back to the slug if
+    // the provider has since been removed).
+    let provider_names: HashMap<String, String> = db::list_oidc_providers(&state.db)
+        .await?
+        .into_iter()
+        .map(|p| (p.slug, p.display_name))
+        .collect();
+
+    let infos = identities
+        .into_iter()
+        .map(|i| IdentityInfo {
+            provider_name: provider_names
+                .get(&i.provider_slug)
+                .cloned()
+                .unwrap_or_else(|| i.provider_slug.clone()),
+            id: i.id,
+            provider_slug: i.provider_slug,
+            email: i.email,
+            created_at: i.created_at,
+            last_used_at: i.last_used_at,
+        })
+        .collect();
+
+    Ok(Json(IdentityListResponse { identities: infos }))
+}
+
+/// Begin linking an additional external identity to the authenticated account.
+///
+/// GET /auth/me/identities/authorize/{provider}
+#[utoipa::path(
+    get,
+    path = "/auth/me/identities/authorize/{provider}",
+    tag = "auth",
+    params(
+        ("provider" = String, Path, description = "OIDC provider slug"),
+        ("redirect_uri" = Option<String>, Query, description = "Optional localhost redirect (Tauri)"),
+    ),
+    responses(
+        (status = 307, description = "Redirect to provider authorization URL"),
+        (status = 400, description = "OIDC not configured or auth method disabled"),
+    ),
+    security(("bearer_auth" = [])),
+)]
+#[tracing::instrument(skip(state, query), fields(provider = %provider))]
+pub async fn link_authorize(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(provider): Path<String>,
+    axum::extract::Query(query): axum::extract::Query<OidcAuthorizeQuery>,
+) -> Result<Response, AuthError> {
+    start_oidc_flow(
+        &state,
+        &provider,
+        query.redirect_uri.as_deref(),
+        Some(auth_user.id),
+    )
+    .await
+}
+
+/// Unlink an external identity from the authenticated account.
+///
+/// `DELETE /auth/me/identities/{id}`
+#[utoipa::path(
+    delete,
+    path = "/auth/me/identities/{id}",
+    tag = "auth",
+    params(("id" = Uuid, Path, description = "Identity ID to unlink")),
+    responses(
+        (status = 204, description = "Identity unlinked"),
+        (status = 404, description = "Identity not found or not owned by the caller"),
+        (status = 409, description = "Cannot remove the account's only login method"),
+    ),
+    security(("bearer_auth" = [])),
+)]
+#[tracing::instrument(skip(state))]
+pub async fn unlink_identity(
+    State(state): State<AppState>,
+    auth_user: AuthUser,
+    Path(identity_id): Path<Uuid>,
+) -> AuthResult<StatusCode> {
+    // Must exist and belong to the caller. Treat "not yours" as 404 so identity
+    // IDs of other accounts can't be probed.
+    let identity = db::find_user_identity_by_id(&state.db, identity_id)
+        .await?
+        .filter(|i| i.user_id == auth_user.id)
+        .ok_or_else(|| AuthError::NotFound("Identity not found".to_string()))?;
+
+    // Refuse to remove the account's only login method: a user with no password
+    // and a single linked identity would otherwise lock themselves out.
+    let user = db::find_user_by_id(&state.db, auth_user.id)
+        .await?
+        .ok_or(AuthError::UserNotFound)?;
+    if user.password_hash.is_none() {
+        let count = db::count_user_identities(&state.db, auth_user.id).await?;
+        if count <= 1 {
+            return Err(AuthError::CannotUnlinkLastIdentity);
+        }
+    }
+
+    let removed = db::delete_user_identity(&state.db, auth_user.id, identity.id).await?;
+    if !removed {
+        // Raced with another unlink of the same row.
+        return Err(AuthError::NotFound("Identity not found".to_string()));
+    }
+
+    tracing::info!(user_id = %auth_user.id, identity_id = %identity.id, provider = %identity.provider_slug, "Unlinked OIDC identity");
+    Ok(StatusCode::NO_CONTENT)
+}

--- a/server/src/auth/login.rs
+++ b/server/src/auth/login.rs
@@ -19,7 +19,9 @@ use super::helpers::{extract_refresh_token, extract_user_agent, should_return_re
 use super::jwt::{generate_token_pair, validate_refresh_token};
 use super::mfa_crypto::{decrypt_mfa_secret, encrypt_mfa_secret};
 use super::middleware::AuthUser;
-use super::oidc::{append_collision_suffix, generate_username_from_claims, OidcFlowState};
+use super::oidc::{
+    append_collision_suffix, generate_username_from_claims, OidcFlowState, OidcUserInfo,
+};
 use super::password::{hash_password, verify_password};
 use super::queries::{self, InsertSessionParams};
 use super::types::{
@@ -461,6 +463,21 @@ pub async fn oidc_authorize(
     Path(provider): Path<String>,
     axum::extract::Query(query): axum::extract::Query<OidcAuthorizeQuery>,
 ) -> Result<Response, AuthError> {
+    start_oidc_flow(&state, &provider, query.redirect_uri.as_deref(), None).await
+}
+
+/// Begin an OIDC authorization flow and redirect to the provider.
+///
+/// Shared by the public login flow (`link_user_id = None`) and the
+/// authenticated identity-link flow (`link_user_id = Some(current user)`); the
+/// only difference is what gets persisted in the encrypted Redis flow state, so
+/// the callback can tell a login apart from a link.
+pub async fn start_oidc_flow(
+    state: &AppState,
+    provider: &str,
+    redirect_uri: Option<&str>,
+    link_user_id: Option<Uuid>,
+) -> Result<Response, AuthError> {
     let auth_methods = get_auth_methods_allowed(&state.db).await?;
     if !auth_methods.oidc {
         return Err(AuthError::AuthMethodDisabled);
@@ -472,12 +489,12 @@ pub async fn oidc_authorize(
         .ok_or(AuthError::OidcNotConfigured)?;
 
     // Verify provider exists
-    if oidc_manager.get_provider_row(&provider).await.is_none() {
+    if oidc_manager.get_provider_row(provider).await.is_none() {
         return Err(AuthError::OidcProviderNotFound);
     }
 
     // Determine callback URL
-    let callback_base = if let Some(ref redirect_uri) = query.redirect_uri {
+    let callback_base = if let Some(redirect_uri) = redirect_uri {
         // Tauri flow: validate the redirect URI is a localhost callback
         let parsed = openidconnect::url::Url::parse(redirect_uri)
             .map_err(|_| AuthError::Validation("Invalid redirect_uri".to_string()))?;
@@ -485,7 +502,7 @@ pub async fn oidc_authorize(
             (parsed.scheme(), parsed.host_str()),
             ("http", Some("localhost" | "127.0.0.1"))
         ) {
-            redirect_uri.clone()
+            redirect_uri.to_string()
         } else {
             tracing::warn!(redirect_uri = %redirect_uri, "Rejected non-localhost redirect_uri");
             return Err(AuthError::Validation(
@@ -502,7 +519,7 @@ pub async fn oidc_authorize(
     };
 
     let (auth_url, csrf_state, nonce, pkce_verifier) = oidc_manager
-        .generate_auth_url(&provider, &callback_base)
+        .generate_auth_url(provider, &callback_base)
         .await
         .map_err(|e| {
             tracing::error!(error = %e, provider = %provider, "Failed to generate OIDC auth URL");
@@ -513,11 +530,12 @@ pub async fn oidc_authorize(
     let state_hash = hex::encode(Sha256::digest(csrf_state.as_bytes()));
     let redis_key = format!("oidc:state:{state_hash}");
     let flow_state = OidcFlowState {
-        slug: provider.clone(),
+        slug: provider.to_string(),
         pkce_verifier,
         nonce,
         redirect_uri: callback_base,
         created_at: Utc::now().timestamp(),
+        link_user_id,
     };
 
     let flow_json =
@@ -549,7 +567,7 @@ pub async fn oidc_authorize(
             AuthError::Internal("Failed to store OIDC state".to_string())
         })?;
 
-    tracing::info!(provider = %provider, "Redirecting to OIDC provider");
+    tracing::info!(provider = %provider, link = link_user_id.is_some(), "Redirecting to OIDC provider");
     Ok(Redirect::temporary(&auth_url).into_response())
 }
 
@@ -645,6 +663,12 @@ pub async fn oidc_callback(
     // uniqueness guarantee for the identity set (user_identities is) — and
     // should likely be demoted to non-unique before multi-identity writes land.
     let external_id = format!("{}:{}", flow_state.slug, user_info.subject);
+
+    // Link flow: attach this identity to the already-authenticated user instead
+    // of logging in or creating an account.
+    if let Some(link_user_id) = flow_state.link_user_id {
+        return handle_identity_link(&state, &flow_state, &user_info, link_user_id).await;
+    }
 
     // User resolution: resolve the external identity to an account.
     let existing_user =
@@ -796,6 +820,13 @@ pub async fn oidc_callback(
         }
     };
 
+    // Best-effort: record that this identity was just used to log in.
+    if let Err(e) =
+        db::touch_user_identity_last_used(&state.db, &flow_state.slug, &user_info.subject).await
+    {
+        tracing::warn!(error = %e, provider = %flow_state.slug, "Failed to update identity last_used_at");
+    }
+
     // Generate JWT token pair
     let tokens = generate_token_pair(
         user.id,
@@ -868,6 +899,84 @@ if (window.opener) {{
 </script></body></html>"#,
         );
         Ok((jar, axum::response::Html(html)).into_response())
+    }
+}
+
+/// Attach a freshly-authenticated external identity to an existing account
+/// (the OIDC *link* flow). Unlike login, this issues no tokens.
+///
+/// Refuses to steal an identity already bound to a different account. Linking
+/// the same identity again, or a second identity for a provider already linked
+/// to this account, are both surfaced as `IdentityAlreadyLinked`.
+async fn handle_identity_link(
+    state: &AppState,
+    flow_state: &OidcFlowState,
+    user_info: &OidcUserInfo,
+    link_user_id: Uuid,
+) -> Result<Response, AuthError> {
+    match find_user_id_by_identity(&state.db, &flow_state.slug, &user_info.subject).await? {
+        // Already linked to this account — idempotent success.
+        Some(existing) if existing == link_user_id => {
+            tracing::info!(user_id = %link_user_id, provider = %flow_state.slug, "OIDC identity already linked to this account");
+        }
+        // Bound to someone else — refuse.
+        Some(_) => return Err(AuthError::IdentityAlreadyLinked),
+        None => {
+            match db::insert_user_identity(
+                &state.db,
+                link_user_id,
+                &flow_state.slug,
+                &user_info.subject,
+                user_info.email.as_deref(),
+            )
+            .await
+            {
+                Ok(_) => {
+                    tracing::info!(user_id = %link_user_id, provider = %flow_state.slug, "Linked OIDC identity to account");
+                }
+                // Lost a race, or the account already has an identity for this
+                // provider (the (user_id, provider_slug) UNIQUE constraint).
+                Err(sqlx::Error::Database(db_err)) if db_err.is_unique_violation() => {
+                    return Err(AuthError::IdentityAlreadyLinked);
+                }
+                Err(e) => return Err(AuthError::Database(e)),
+            }
+        }
+    }
+
+    // Token-less success response (mirrors the login callback's Tauri-vs-browser
+    // split, minus the session/cookie since the caller is already authenticated).
+    let parsed_redirect = openidconnect::url::Url::parse(&flow_state.redirect_uri)
+        .map_err(|e| AuthError::Internal(format!("Invalid redirect URI: {e}")))?;
+    let is_localhost = matches!(
+        (parsed_redirect.scheme(), parsed_redirect.host_str()),
+        ("http", Some("localhost" | "127.0.0.1"))
+    );
+
+    if is_localhost {
+        let mut redirect_url = parsed_redirect;
+        redirect_url
+            .query_pairs_mut()
+            .append_pair("linked", &flow_state.slug);
+        Ok(Redirect::temporary(redirect_url.as_str()).into_response())
+    } else {
+        let payload = serde_json::json!({
+            "type": "oidc-link-callback",
+            "success": true,
+            "provider_slug": flow_state.slug,
+        });
+        let html = format!(
+            r#"<!DOCTYPE html>
+<html><body><script>
+if (window.opener) {{
+    window.opener.postMessage({payload}, window.location.origin);
+    window.close();
+}} else {{
+    document.body.innerText = "Account linked. You can close this window.";
+}}
+</script></body></html>"#,
+        );
+        Ok(axum::response::Html(html).into_response())
     }
 }
 

--- a/server/src/auth/mod.rs
+++ b/server/src/auth/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod cookies;
 pub(crate) mod error;
 pub mod geoip;
 mod helpers;
+pub(crate) mod identities;
 pub mod jwt;
 pub(crate) mod login;
 pub(crate) mod mfa;
@@ -183,6 +184,12 @@ pub fn router(state: AppState) -> Router<AppState> {
         .route(
             "/me/avatar",
             post(profile::upload_avatar).layer(DefaultBodyLimit::max(state.config.max_avatar_size)),
+        )
+        .route("/me/identities", get(identities::list_identities))
+        .route("/me/identities/{id}", delete(identities::unlink_identity))
+        .route(
+            "/me/identities/authorize/{provider}",
+            get(identities::link_authorize),
         )
         .route("/mfa/setup", post(mfa::mfa_setup))
         .route("/mfa/verify", post(mfa::mfa_verify))

--- a/server/src/auth/oidc.rs
+++ b/server/src/auth/oidc.rs
@@ -63,6 +63,11 @@ pub struct OidcFlowState {
     pub redirect_uri: String,
     /// When the state was created (for debugging).
     pub created_at: i64,
+    /// When set, this is a *link* flow: the resulting identity is attached to
+    /// this already-authenticated user instead of logging in / creating an
+    /// account. `None` (the default) is an ordinary login flow.
+    #[serde(default)]
+    pub link_user_id: Option<Uuid>,
 }
 
 /// Cached provider configuration with pre-built client.

--- a/server/src/auth/types.rs
+++ b/server/src/auth/types.rs
@@ -226,6 +226,31 @@ pub struct SessionListResponse {
     pub sessions: Vec<SessionInfo>,
 }
 
+/// A single external (OIDC/OAuth) identity linked to the account.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct IdentityInfo {
+    /// Identity row ID (used to unlink).
+    pub id: Uuid,
+    /// Provider slug (e.g. "google").
+    pub provider_slug: String,
+    /// Human-readable provider name, resolved from the provider config.
+    /// Falls back to the slug if the provider has since been removed.
+    pub provider_name: String,
+    /// Email reported by the provider at link time, if any.
+    pub email: Option<String>,
+    /// When the identity was linked.
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    /// When the identity was last used to log in, if ever.
+    pub last_used_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Response containing the account's linked external identities.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct IdentityListResponse {
+    /// External identities linked to the authenticated account.
+    pub identities: Vec<IdentityInfo>,
+}
+
 /// Response for revoking all other sessions.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct RevokeAllResponse {

--- a/server/src/db/queries.rs
+++ b/server/src/db/queries.rs
@@ -114,18 +114,6 @@ pub async fn list_user_identities(pool: &PgPool, user_id: Uuid) -> sqlx::Result<
     .map_err(db_error!("list_user_identities", user_id = %user_id))
 }
 
-/// Look up a single external identity by its row ID (does not enforce ownership).
-pub async fn find_user_identity_by_id(
-    pool: &PgPool,
-    id: Uuid,
-) -> sqlx::Result<Option<UserIdentity>> {
-    sqlx::query_as::<_, UserIdentity>("SELECT * FROM user_identities WHERE id = $1")
-        .bind(id)
-        .fetch_optional(pool)
-        .await
-        .map_err(db_error!("find_user_identity_by_id", identity_id = %id))
-}
-
 /// Count the external identities linked to a user.
 pub async fn count_user_identities(pool: &PgPool, user_id: Uuid) -> sqlx::Result<i64> {
     sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM user_identities WHERE user_id = $1")
@@ -135,19 +123,71 @@ pub async fn count_user_identities(pool: &PgPool, user_id: Uuid) -> sqlx::Result
         .map_err(db_error!("count_user_identities", user_id = %user_id))
 }
 
-/// Delete an identity, enforcing ownership. Returns `true` if a row was removed.
-pub async fn delete_user_identity(
+/// Result of [`unlink_identity_guarded`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum UnlinkOutcome {
+    /// The identity was removed.
+    Deleted,
+    /// No such identity, or it belongs to another user.
+    NotFound,
+    /// Removing it would leave a passwordless account with no way to log in.
+    WouldLockOut,
+}
+
+/// Unlink an identity atomically.
+///
+/// Runs the ownership check, the last-login-method guard, and the delete in a
+/// single transaction that locks the owning user row, so concurrent unlinks for
+/// the same account cannot race past the guard and strand a passwordless user
+/// with zero login methods.
+pub async fn unlink_identity_guarded(
     pool: &PgPool,
     user_id: Uuid,
     identity_id: Uuid,
-) -> sqlx::Result<bool> {
-    let result = sqlx::query("DELETE FROM user_identities WHERE id = $1 AND user_id = $2")
+) -> sqlx::Result<UnlinkOutcome> {
+    let mut tx = pool.begin().await?;
+
+    // Lock the user row to serialize concurrent unlinks for this account.
+    let password_hash: Option<Option<String>> =
+        sqlx::query_scalar("SELECT password_hash FROM users WHERE id = $1 FOR UPDATE")
+            .bind(user_id)
+            .fetch_optional(&mut *tx)
+            .await?;
+    let Some(password_hash) = password_hash else {
+        return Ok(UnlinkOutcome::NotFound);
+    };
+
+    // Ownership / existence: treat "not yours" as not-found (no probing).
+    let owned: bool = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM user_identities WHERE id = $1 AND user_id = $2)",
+    )
+    .bind(identity_id)
+    .bind(user_id)
+    .fetch_one(&mut *tx)
+    .await?;
+    if !owned {
+        return Ok(UnlinkOutcome::NotFound);
+    }
+
+    // A passwordless account must keep at least one identity.
+    if password_hash.is_none() {
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM user_identities WHERE user_id = $1")
+                .bind(user_id)
+                .fetch_one(&mut *tx)
+                .await?;
+        if count <= 1 {
+            return Ok(UnlinkOutcome::WouldLockOut);
+        }
+    }
+
+    sqlx::query("DELETE FROM user_identities WHERE id = $1 AND user_id = $2")
         .bind(identity_id)
         .bind(user_id)
-        .execute(pool)
-        .await
-        .map_err(db_error!("delete_user_identity", identity_id = %identity_id))?;
-    Ok(result.rows_affected() > 0)
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
+    Ok(UnlinkOutcome::Deleted)
 }
 
 /// Mark an identity as just used for login. Best-effort; matches by

--- a/server/src/db/queries.rs
+++ b/server/src/db/queries.rs
@@ -114,6 +114,61 @@ pub async fn list_user_identities(pool: &PgPool, user_id: Uuid) -> sqlx::Result<
     .map_err(db_error!("list_user_identities", user_id = %user_id))
 }
 
+/// Look up a single external identity by its row ID (does not enforce ownership).
+pub async fn find_user_identity_by_id(
+    pool: &PgPool,
+    id: Uuid,
+) -> sqlx::Result<Option<UserIdentity>> {
+    sqlx::query_as::<_, UserIdentity>("SELECT * FROM user_identities WHERE id = $1")
+        .bind(id)
+        .fetch_optional(pool)
+        .await
+        .map_err(db_error!("find_user_identity_by_id", identity_id = %id))
+}
+
+/// Count the external identities linked to a user.
+pub async fn count_user_identities(pool: &PgPool, user_id: Uuid) -> sqlx::Result<i64> {
+    sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM user_identities WHERE user_id = $1")
+        .bind(user_id)
+        .fetch_one(pool)
+        .await
+        .map_err(db_error!("count_user_identities", user_id = %user_id))
+}
+
+/// Delete an identity, enforcing ownership. Returns `true` if a row was removed.
+pub async fn delete_user_identity(
+    pool: &PgPool,
+    user_id: Uuid,
+    identity_id: Uuid,
+) -> sqlx::Result<bool> {
+    let result = sqlx::query("DELETE FROM user_identities WHERE id = $1 AND user_id = $2")
+        .bind(identity_id)
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .map_err(db_error!("delete_user_identity", identity_id = %identity_id))?;
+    Ok(result.rows_affected() > 0)
+}
+
+/// Mark an identity as just used for login. Best-effort; matches by
+/// `(provider_slug, subject)`. No-op if the row does not exist.
+pub async fn touch_user_identity_last_used(
+    pool: &PgPool,
+    provider_slug: &str,
+    subject: &str,
+) -> sqlx::Result<()> {
+    sqlx::query(
+        "UPDATE user_identities SET last_used_at = NOW()
+         WHERE provider_slug = $1 AND subject = $2",
+    )
+    .bind(provider_slug)
+    .bind(subject)
+    .execute(pool)
+    .await
+    .map_err(db_error!("touch_user_identity_last_used", provider_slug = %provider_slug))?;
+    Ok(())
+}
+
 /// Find user by email.
 pub async fn find_user_by_email(pool: &PgPool, email: &str) -> sqlx::Result<Option<User>> {
     sqlx::query_as::<_, User>("SELECT * FROM users WHERE email = $1")

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -81,6 +81,9 @@ use utoipa::{Modify, OpenApi};
         crate::auth::sessions::list_sessions,
         crate::auth::sessions::revoke_session,
         crate::auth::sessions::revoke_all_other_sessions,
+        crate::auth::identities::list_identities,
+        crate::auth::identities::link_authorize,
+        crate::auth::identities::unlink_identity,
         // Channels
         crate::chat::channels::create,
         crate::chat::channels::get,
@@ -349,6 +352,8 @@ use utoipa::{Modify, OpenApi};
         crate::auth::types::ResetPasswordRequest,
         crate::auth::types::SessionInfo,
         crate::auth::types::SessionListResponse,
+        crate::auth::types::IdentityInfo,
+        crate::auth::types::IdentityListResponse,
         crate::auth::types::RevokeAllResponse,
         crate::auth::error::ErrorResponse,
         // DB Models

--- a/server/tests/integration/identities_http.rs
+++ b/server/tests/integration/identities_http.rs
@@ -1,0 +1,208 @@
+//! HTTP integration tests for linked-identity management.
+//!
+//! Covers GET /auth/me/identities (list), DELETE /auth/me/identities/{id}
+//! (unlink, ownership, and last-login-method guard), and auth requirements.
+//! The link *authorize*/callback flow needs a live OIDC provider exchange and
+//! is exercised at the unit/DB level in `oidc.rs`.
+//!
+//! Run with: `cargo test --test integration identities_http`
+
+use axum::body::Body;
+use axum::http::Method;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use super::helpers::{body_to_json, create_test_user, generate_access_token, TestApp};
+
+/// Insert a passwordless OIDC-only user (NULL `password_hash`) and return its ID.
+async fn create_passwordless_user(pool: &PgPool, external_id: &str) -> Uuid {
+    let suffix = &Uuid::new_v4().to_string()[..8];
+    let username = format!("oidconly_{suffix}");
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO users (username, display_name, auth_method, external_id)
+         VALUES ($1, 'OIDC Only', 'oidc', $2) RETURNING id",
+    )
+    .bind(&username)
+    .bind(external_id)
+    .fetch_one(pool)
+    .await
+    .expect("passwordless user insert should succeed")
+}
+
+async fn get_identities(app: &TestApp, token: &str) -> (u16, serde_json::Value) {
+    let req = TestApp::request(Method::GET, "/auth/me/identities")
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await;
+    let status = resp.status().as_u16();
+    (status, body_to_json(resp).await)
+}
+
+async fn unlink(app: &TestApp, token: &str, id: Uuid) -> u16 {
+    let req = TestApp::request(Method::DELETE, &format!("/auth/me/identities/{id}"))
+        .header("Authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap();
+    app.oneshot(req).await.status().as_u16()
+}
+
+#[sqlx::test]
+async fn test_list_identities_empty(pool: PgPool) {
+    let app = TestApp::with_pool(pool).await;
+    let (user_id, _) = create_test_user(&app.pool).await;
+    let token = generate_access_token(&app.config, user_id);
+
+    let (status, json) = get_identities(&app, &token).await;
+    assert_eq!(status, 200);
+    assert_eq!(json["identities"].as_array().unwrap().len(), 0);
+}
+
+#[sqlx::test]
+async fn test_list_identities_returns_linked(pool: PgPool) {
+    let app = TestApp::with_pool(pool).await;
+    let (user_id, _) = create_test_user(&app.pool).await;
+    let token = generate_access_token(&app.config, user_id);
+
+    vc_server::db::insert_user_identity(&app.pool, user_id, "google", "g-sub", Some("a@x.io"))
+        .await
+        .unwrap();
+    vc_server::db::insert_user_identity(&app.pool, user_id, "github", "gh-sub", None)
+        .await
+        .unwrap();
+
+    let (status, json) = get_identities(&app, &token).await;
+    assert_eq!(status, 200);
+    let items = json["identities"].as_array().unwrap();
+    assert_eq!(items.len(), 2);
+    // No provider rows configured → provider_name falls back to the slug.
+    let slugs: Vec<&str> = items
+        .iter()
+        .map(|i| i["provider_slug"].as_str().unwrap())
+        .collect();
+    assert!(slugs.contains(&"google") && slugs.contains(&"github"));
+    let google = items
+        .iter()
+        .find(|i| i["provider_slug"] == "google")
+        .unwrap();
+    assert_eq!(google["provider_name"], "google");
+    assert_eq!(google["email"], "a@x.io");
+}
+
+#[sqlx::test]
+async fn test_unlink_identity_success(pool: PgPool) {
+    let app = TestApp::with_pool(pool).await;
+    // create_test_user makes a password-backed user, so the guard never trips.
+    let (user_id, _) = create_test_user(&app.pool).await;
+    let token = generate_access_token(&app.config, user_id);
+
+    let id1 = vc_server::db::insert_user_identity(&app.pool, user_id, "google", "s1", None)
+        .await
+        .unwrap()
+        .id;
+    vc_server::db::insert_user_identity(&app.pool, user_id, "github", "s2", None)
+        .await
+        .unwrap();
+
+    assert_eq!(unlink(&app, &token, id1).await, 204);
+
+    let (_, json) = get_identities(&app, &token).await;
+    let items = json["identities"].as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["provider_slug"], "github");
+}
+
+#[sqlx::test]
+async fn test_unlink_identity_not_found(pool: PgPool) {
+    let app = TestApp::with_pool(pool).await;
+    let (user_id, _) = create_test_user(&app.pool).await;
+    let token = generate_access_token(&app.config, user_id);
+
+    assert_eq!(unlink(&app, &token, Uuid::new_v4()).await, 404);
+}
+
+#[sqlx::test]
+async fn test_unlink_other_users_identity_is_404(pool: PgPool) {
+    let app = TestApp::with_pool(pool).await;
+    let (owner, _) = create_test_user(&app.pool).await;
+    let (attacker, _) = create_test_user(&app.pool).await;
+    let attacker_token = generate_access_token(&app.config, attacker);
+
+    let victim_identity =
+        vc_server::db::insert_user_identity(&app.pool, owner, "google", "s", None)
+            .await
+            .unwrap()
+            .id;
+
+    // Ownership failure is reported as 404 (no probing other accounts' IDs).
+    assert_eq!(unlink(&app, &attacker_token, victim_identity).await, 404);
+    // And the identity is untouched.
+    assert_eq!(
+        vc_server::db::count_user_identities(&app.pool, owner)
+            .await
+            .unwrap(),
+        1
+    );
+}
+
+#[sqlx::test]
+async fn test_unlink_last_identity_blocked_for_passwordless_user(pool: PgPool) {
+    let app = TestApp::with_pool(pool).await;
+    let user_id = create_passwordless_user(&app.pool, "google:only").await;
+    let token = generate_access_token(&app.config, user_id);
+
+    let id = vc_server::db::insert_user_identity(&app.pool, user_id, "google", "only", None)
+        .await
+        .unwrap()
+        .id;
+
+    // Removing the sole login method of a passwordless account is refused (409).
+    assert_eq!(unlink(&app, &token, id).await, 409);
+    assert_eq!(
+        vc_server::db::count_user_identities(&app.pool, user_id)
+            .await
+            .unwrap(),
+        1
+    );
+}
+
+#[sqlx::test]
+async fn test_unlink_one_of_two_allowed_for_passwordless_user(pool: PgPool) {
+    let app = TestApp::with_pool(pool).await;
+    let user_id = create_passwordless_user(&app.pool, "google:first").await;
+    let token = generate_access_token(&app.config, user_id);
+
+    let id1 = vc_server::db::insert_user_identity(&app.pool, user_id, "google", "first", None)
+        .await
+        .unwrap()
+        .id;
+    vc_server::db::insert_user_identity(&app.pool, user_id, "github", "second", None)
+        .await
+        .unwrap();
+
+    // With two identities, a passwordless user may still drop one.
+    assert_eq!(unlink(&app, &token, id1).await, 204);
+}
+
+#[sqlx::test]
+async fn test_identity_endpoints_require_auth(pool: PgPool) {
+    let app = TestApp::with_pool(pool).await;
+
+    let list = TestApp::request(Method::GET, "/auth/me/identities")
+        .body(Body::empty())
+        .unwrap();
+    assert_eq!(app.oneshot(list).await.status().as_u16(), 401);
+
+    let del = TestApp::request(
+        Method::DELETE,
+        &format!("/auth/me/identities/{}", Uuid::new_v4()),
+    )
+    .body(Body::empty())
+    .unwrap();
+    assert_eq!(app.oneshot(del).await.status().as_u16(), 401);
+
+    let link = TestApp::request(Method::GET, "/auth/me/identities/authorize/google")
+        .body(Body::empty())
+        .unwrap();
+    assert_eq!(app.oneshot(link).await.status().as_u16(), 401);
+}

--- a/server/tests/integration/main.rs
+++ b/server/tests/integration/main.rs
@@ -21,6 +21,7 @@ mod global_search_http;
 mod governance;
 mod guild_invite;
 mod guild_limits;
+mod identities_http;
 mod media_processing;
 mod mention_permission;
 mod messages_http;

--- a/server/tests/integration/oidc.rs
+++ b/server/tests/integration/oidc.rs
@@ -313,12 +313,14 @@ fn test_collision_suffix_respects_max_length() {
 
 #[test]
 fn test_flow_state_serialization_roundtrip() {
+    let link_user = uuid::Uuid::new_v4();
     let state = OidcFlowState {
         slug: "github".to_string(),
         pkce_verifier: "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk".to_string(),
         nonce: "abc123nonce".to_string(),
         redirect_uri: "http://127.0.0.1:12345/callback".to_string(),
         created_at: 1706745600,
+        link_user_id: Some(link_user),
     };
 
     let json = serde_json::to_string(&state).expect("Serialization should succeed");
@@ -330,6 +332,16 @@ fn test_flow_state_serialization_roundtrip() {
     assert_eq!(deserialized.nonce, "abc123nonce");
     assert_eq!(deserialized.redirect_uri, "http://127.0.0.1:12345/callback");
     assert_eq!(deserialized.created_at, 1706745600);
+    assert_eq!(deserialized.link_user_id, Some(link_user));
+}
+
+#[test]
+fn test_flow_state_link_user_id_defaults_to_none() {
+    // Old flow-state blobs (pre-linking) have no link_user_id field; #[serde(default)]
+    // must deserialize them as an ordinary login flow.
+    let legacy = r#"{"slug":"google","pkce_verifier":"v","nonce":"n","redirect_uri":"https://x/cb","created_at":0}"#;
+    let state: OidcFlowState = serde_json::from_str(legacy).expect("legacy state should parse");
+    assert_eq!(state.link_user_id, None);
 }
 
 #[test]
@@ -340,6 +352,7 @@ fn test_flow_state_json_format() {
         nonce: "nonce".to_string(),
         redirect_uri: "https://example.com/callback".to_string(),
         created_at: 0,
+        link_user_id: None,
     };
 
     let json: serde_json::Value = serde_json::to_value(&state).unwrap();


### PR DESCRIPTION
## What & why

**Part 2 of OAuth identity linking** (Goal 6 item 4), building on the `user_identities` table from #600. This adds the authenticated API for managing linked identities and the flow to link a new one. (Part 3 = the client "Linked Accounts" UI.)

## New endpoints (all auth-required, under `/auth/me/identities`)
- **`GET /auth/me/identities`** — list linked identities; provider display name resolved from the provider config, falling back to the slug if the provider was removed.
- **`DELETE /auth/me/identities/{id}`** — unlink. Ownership failures return **404** (so identity IDs of other accounts can't be probed). Refuses to remove the **only login method of a passwordless account** → `409 CANNOT_UNLINK_LAST_IDENTITY`.
- **`GET /auth/me/identities/authorize/{provider}`** — begin a link flow.

## Link flow
`OidcFlowState` gains an optional `link_user_id` (`#[serde(default)]`, so any in-flight pre-upgrade flow states still parse as ordinary logins). The shared authorize logic is extracted into `login::start_oidc_flow`; the link variant stamps the current user into the **encrypted Redis flow state**. The OIDC callback branches on it:
- present → attach the identity to that user (idempotent if already linked to them; `409 IDENTITY_ALREADY_LINKED` if bound to another account or the provider is already linked), returning a **token-less** success (no new session — the caller is already authenticated)
- absent → unchanged login/registration path

Login now also stamps `last_used_at` on the identity (resolves the write-never column noted in #600's review).

## Tests
- 8 new HTTP integration tests (`identities_http.rs`): list empty/populated, unlink success, 404 (missing + other-user ownership), passwordless last-identity guard (blocked + allowed-with-two), and auth-required on all three routes
- Flow-state serde round-trip incl. `link_user_id`, plus a legacy-blob default test
- **84 auth/oidc/sessions tests pass**; `clippy --all-targets -D warnings` clean (incl. workspace `nursery`); nightly `fmt --check` clean
- Queries are runtime-form → no `.sqlx` changes; OpenAPI paths + schemas registered

## Notes
- No CHANGELOG entry yet: the endpoints aren't user-consumable until the PR3 UI lands; the user-facing entry will accompany that. (Consistent with #600.)
- The callback's link branch needs a live OIDC exchange, so it's covered by reasoning + the DB-level conflict tests from #600 rather than an HTTP test.

Advances **Goal 6 item 4** (updated in `goals.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017m2TjrBiDvBjGipb5E9BFb