### PR TITLE
fix(infra): allow empty checksums for pkgconfiglite on Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,7 +393,9 @@ jobs:
         if: matrix.platform == 'windows-latest'
         run: |
           vcpkg install libvpx:x64-windows-static-md
-          choco install -y pkgconfiglite
+          # pkgconfiglite ships from SourceForge with no checksum; Chocolatey
+          # now blocks empty checksums on non-secure sources by default.
+          choco install -y pkgconfiglite --allow-empty-checksums
 
       - name: Configure pkg-config (Windows)
         if: matrix.platform == 'windows-latest'

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -83,7 +83,9 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           vcpkg install libvpx:x64-windows-static-md
-          choco install -y pkgconfiglite
+          # pkgconfiglite ships from SourceForge with no checksum; Chocolatey
+          # now blocks empty checksums on non-secure sources by default.
+          choco install -y pkgconfiglite --allow-empty-checksums
 
       - name: Set VPX environment for Windows
         if: runner.os == 'Windows'


### PR DESCRIPTION
## Problem

Chocolatey changed its default policy to **block empty checksums for non-secure (HTTP/SourceForge) sources**. `pkgconfiglite` is fetched from SourceForge with no checksum, so `choco install -y pkgconfiglite` now fails:

```
ERROR: Empty checksums are no longer allowed by default for non-secure sources...
The install of pkgconfiglite was NOT successful.
```

This breaks the **"Install dependencies (Windows)"** step — before any compilation — in the Windows jobs of both workflows, failing every PR's Windows build:
- `ci.yml` → **Build (windows-latest)**
- `tauri-build.yml` → **Tauri windows-latest**

It started between ~01:22 and ~02:03 UTC on 2026-06-20 (the last green Windows Tauri build on `main` was #600's at 01:22; the next PR build failed). It is unrelated to any product code.

## Fix

Add `--allow-empty-checksums` (the flag named in Chocolatey's own error message) to the `pkgconfiglite` install in both workflows. The Windows build in this PR's own CI validates the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017m2TjrBiDvBjGipb5E9BFb