### PR TITLE
feat(client): linked-accounts settings UI (view + unlink)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release note structure source: `docs/project/RELEASE_NOTES_TEMPLATE.md`
 
 ### Added
+- Account settings now show your **linked accounts** — the external sign-in providers (e.g. Google, GitHub) connected to your profile — with the ability to unlink one. Removing the only login method of a password-less account is blocked so you can't lock yourself out.
 - Android: react to messages — long-pressing a message and choosing "React" now opens an emoji picker (16 common reactions) that adds your reaction, instead of doing nothing
 - Android: direct messages are now accessible — a new envelope button on the home screen opens a conversation list (avatar, name, last-message preview, unread badge); tapping a conversation opens it like any channel
 - Android: message attachments now display — images render as inline thumbnails, other files as a chip with name and size (previously attachments were invisible)

--- a/client/src/components/settings/AccountSettings.tsx
+++ b/client/src/components/settings/AccountSettings.tsx
@@ -6,6 +6,7 @@ import * as tauri from "@/lib/tauri";
 import { validateFileSize, getUploadLimitText } from "@/lib/tauri";
 import { showToast } from "@/components/ui/Toast";
 import ChangePasswordModal from "./ChangePasswordModal";
+import LinkedAccountsSection from "./LinkedAccountsSection";
 import SessionsSection from "./SessionsSection";
 
 const AccountSettings: Component = () => {
@@ -159,6 +160,11 @@ const AccountSettings: Component = () => {
             Update your password to keep your account secure
           </div>
         </button>
+      </div>
+
+      {/* Linked accounts */}
+      <div class="pt-4 border-t border-white/5">
+        <LinkedAccountsSection />
       </div>
 
       {/* Sessions */}

--- a/client/src/components/settings/LinkedAccountsSection.tsx
+++ b/client/src/components/settings/LinkedAccountsSection.tsx
@@ -1,0 +1,130 @@
+import { Component, createSignal, onMount, For, Show } from "solid-js";
+import { KeyRound, Unlink } from "lucide-solid";
+import * as tauri from "@/lib/tauri";
+import type { IdentityInfo } from "@/lib/types";
+
+/**
+ * Lists the external (OIDC) identities linked to the account and lets the user
+ * unlink them. Adding new identities is handled separately (the link flow needs
+ * the desktop app's native callback handling).
+ */
+const LinkedAccountsSection: Component = () => {
+  const [identities, setIdentities] = createSignal<IdentityInfo[]>([]);
+  const [loading, setLoading] = createSignal(true);
+  const [error, setError] = createSignal<string | null>(null);
+
+  const loadIdentities = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const resp = await tauri.listIdentities();
+      setIdentities(resp.identities);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  onMount(loadIdentities);
+
+  const handleUnlink = async (identity: IdentityInfo) => {
+    const label = identity.provider_name || identity.provider_slug;
+    if (
+      !window.confirm(
+        `Unlink ${label}? You will no longer be able to sign in with it.`,
+      )
+    ) {
+      return;
+    }
+    try {
+      setError(null);
+      await tauri.unlinkIdentity(identity.id);
+      setIdentities((prev) => prev.filter((i) => i.id !== identity.id));
+    } catch (err) {
+      // Surfaces the server's message, e.g. the last-login-method guard (409).
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const formatRelativeTime = (dateStr: string): string => {
+    const date = new Date(dateStr);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+    if (diffMins < 1) return "just now";
+    if (diffMins < 60) return `${diffMins}m ago`;
+    const diffHours = Math.floor(diffMins / 60);
+    if (diffHours < 24) return `${diffHours}h ago`;
+    const diffDays = Math.floor(diffHours / 24);
+    return `${diffDays}d ago`;
+  };
+
+  return (
+    <div class="space-y-3">
+      <h4 class="text-sm font-semibold text-text-secondary uppercase tracking-wide">
+        Linked Accounts
+      </h4>
+
+      <Show when={error()}>
+        <div class="text-sm text-status-danger p-3 rounded-xl bg-status-danger/10 border border-status-danger/20">
+          {error()}
+        </div>
+      </Show>
+
+      <Show when={loading()}>
+        <div class="text-sm text-text-secondary py-4 text-center">
+          Loading linked accounts...
+        </div>
+      </Show>
+
+      <Show when={!loading()}>
+        <Show
+          when={identities().length > 0}
+          fallback={
+            <div class="text-sm text-text-secondary py-4 text-center">
+              No external accounts are linked to your profile.
+            </div>
+          }
+        >
+          <div class="space-y-2">
+            <For each={identities()}>
+              {(identity) => (
+                <div class="flex items-center gap-3 p-3 rounded-xl bg-surface-layer2 border border-white/5">
+                  <div class="shrink-0 text-text-secondary">
+                    <KeyRound size={20} />
+                  </div>
+                  <div class="flex-1 min-w-0">
+                    <span class="text-sm font-medium text-text-primary truncate block">
+                      {identity.provider_name || identity.provider_slug}
+                    </span>
+                    <div class="flex items-center gap-2 text-xs text-text-secondary mt-0.5">
+                      <Show when={identity.email}>
+                        <span class="truncate">{identity.email}</span>
+                        <span class="opacity-40">&middot;</span>
+                      </Show>
+                      <span>
+                        {identity.last_used_at
+                          ? `last used ${formatRelativeTime(identity.last_used_at)}`
+                          : `linked ${formatRelativeTime(identity.created_at)}`}
+                      </span>
+                    </div>
+                  </div>
+                  <button
+                    onClick={() => handleUnlink(identity)}
+                    class="shrink-0 p-1.5 rounded-lg text-text-secondary hover:text-status-danger hover:bg-status-danger/10 transition-colors"
+                    title={`Unlink ${identity.provider_name || identity.provider_slug}`}
+                  >
+                    <Unlink size={16} />
+                  </button>
+                </div>
+              )}
+            </For>
+          </div>
+        </Show>
+      </Show>
+    </div>
+  );
+};
+
+export default LinkedAccountsSection;

--- a/client/src/lib/tauri/auth.ts
+++ b/client/src/lib/tauri/auth.ts
@@ -4,6 +4,7 @@
  */
 
 import type {
+  IdentityListResponse,
   OidcLoginResult,
   RevokeAllResponse,
   ServerSettings,
@@ -313,6 +314,29 @@ export async function revokeSession(sessionId: string): Promise<void> {
  */
 export async function revokeAllOtherSessions(): Promise<RevokeAllResponse> {
   return fetchApi<RevokeAllResponse>("/auth/sessions", { method: "DELETE" });
+}
+
+// ============================================================================
+// Linked external (OIDC) identities
+// ============================================================================
+
+/**
+ * List the external identities linked to the current account.
+ */
+export async function listIdentities(): Promise<IdentityListResponse> {
+  return fetchApi<IdentityListResponse>("/auth/me/identities");
+}
+
+/**
+ * Unlink an external identity by ID.
+ *
+ * The server returns 409 when this would remove the only login method of a
+ * passwordless account; the caller surfaces that message to the user.
+ */
+export async function unlinkIdentity(identityId: string): Promise<void> {
+  await fetchApi<void>(`/auth/me/identities/${identityId}`, {
+    method: "DELETE",
+  });
 }
 
 // ============================================================================

--- a/client/src/lib/types/user.ts
+++ b/client/src/lib/types/user.ts
@@ -78,6 +78,21 @@ export interface SessionListResponse {
   sessions: SessionInfo[];
 }
 
+// Linked external (OIDC) identities
+
+export interface IdentityInfo {
+  id: string;
+  provider_slug: string;
+  provider_name: string;
+  email: string | null;
+  created_at: string;
+  last_used_at: string | null;
+}
+
+export interface IdentityListResponse {
+  identities: IdentityInfo[];
+}
+
 export interface RevokeAllResponse {
   revoked_count: number;
 }

--- a/docs/developer-guide/project/goals.md
+++ b/docs/developer-guide/project/goals.md
@@ -262,7 +262,13 @@ the SaaS path is actually pursued:
        (authenticated link flow — the OIDC callback branches on a `link_user_id`
        carried in the encrypted flow state, attaching the identity instead of
        logging in; refuses identities already bound to another account).
-       Remaining: client "Linked Accounts" settings UI (PR3). NOTE: before any
+       **Client UI — view + unlink shipped 2026-06-20 (PR #603):** a "Linked
+       Accounts" section in account settings lists connected providers and
+       unlinks them (surfaces the last-login-method guard). Remaining: the
+       *link-a-new-identity* UI — deferred because it needs a native Tauri
+       command (the link-authorize endpoint requires a Bearer header a browser
+       popup can't send) plus a server tweak to redirect link *errors* to the
+       desktop localhost callback (success already does). NOTE: before any
        further multi-identity hardening, consider demoting `users.external_id`'s
        UNIQUE constraint (commented in login.rs) — linking does not write it, so
        it is not yet a problem.


### PR DESCRIPTION
## What & why

**Part 3 of OAuth identity linking** (Goal 6 item 4), consuming the endpoints from #601. Adds a **"Linked Accounts"** section to account settings so users can see the external sign-in providers connected to their profile and unlink them. Mirrors the existing `SessionsSection` pattern.

## Changes
- `IdentityInfo` / `IdentityListResponse` wire types (snake_case, matching the server)
- `listIdentities()` + `unlinkIdentity()` API wrappers (`fetchApi`, work in both browser and Tauri)
- `LinkedAccountsSection.tsx` — loads on mount; per identity shows provider name, email, and last-used/linked time; confirm-then-unlink; surfaces the server's **last-login-method guard (409)** inline so a passwordless user can't lock themselves out
- Embedded in `AccountSettings` just above Sessions

## Scope note — view + unlink only
Linking a *new* identity is intentionally deferred to its own PR. The link-authorize endpoint requires a `Bearer` header that a browser popup (`window.open`) can't send (unlike the public login-authorize), so it needs a **native Tauri command** (desktop) plus a small **server tweak to redirect link *errors*** to the localhost callback (success already redirects). Those warrant a focused, CI-compiled PR rather than a tail-end addition here. Existing users still have their backfilled identity listed, so view + unlink is immediately useful.

## Verification
- ✅ `bun run test:run`: **606 tests pass** (no regressions)
- ✅ `bun run build` (tsc typecheck + vite): clean — confirms the new types/component/API are type-correct
- ✅ new files lint-clean (the one eslint error in `auth.ts` is pre-existing `uploadAvatar` code; CI's Frontend job runs tests + bundle budget, not eslint)
- No component render test: the project tests stores/logic, not presentational components (`SessionsSection`, the template, has none)

Completes the user-facing slice of **Goal 6 item 4**; this PR carries its CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017m2TjrBiDvBjGipb5E9BFb