### PR TITLE
fix(auth): harden identity-linking endpoints (#604, #605, #606)

### DIFF
--- a/server/src/auth/error.rs
+++ b/server/src/auth/error.rs
@@ -101,10 +101,6 @@ pub enum AuthError {
     #[error("This authentication method is disabled")]
     AuthMethodDisabled,
 
-    /// The external identity is already linked to another account.
-    #[error("This external account is already linked to another Kaiku account")]
-    IdentityAlreadyLinked,
-
     /// Refusing to unlink the account's only remaining login method.
     #[error("Cannot remove your only login method; set a password or link another account first")]
     CannotUnlinkLastIdentity,
@@ -149,7 +145,6 @@ impl IntoResponse for AuthError {
             Self::OidcCodeExchangeFailed(_) => (StatusCode::BAD_GATEWAY, "OIDC_EXCHANGE_FAILED"),
             Self::RegistrationDisabled => (StatusCode::FORBIDDEN, "REGISTRATION_DISABLED"),
             Self::AuthMethodDisabled => (StatusCode::FORBIDDEN, "AUTH_METHOD_DISABLED"),
-            Self::IdentityAlreadyLinked => (StatusCode::CONFLICT, "IDENTITY_ALREADY_LINKED"),
             Self::CannotUnlinkLastIdentity => (StatusCode::CONFLICT, "CANNOT_UNLINK_LAST_IDENTITY"),
             Self::Internal(_) => (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL_ERROR"),
         };

--- a/server/src/auth/login.rs
+++ b/server/src/auth/login.rs
@@ -905,47 +905,64 @@ if (window.opener) {{
 /// Attach a freshly-authenticated external identity to an existing account
 /// (the OIDC *link* flow). Unlike login, this issues no tokens.
 ///
-/// Refuses to steal an identity already bound to a different account. Linking
-/// the same identity again, or a second identity for a provider already linked
-/// to this account, are both surfaced as `IdentityAlreadyLinked`.
+/// Refuses to steal an identity already bound to a different account. A conflict
+/// (already bound elsewhere, or the provider already linked to this account) is
+/// reported back to the opener as a generic `IDENTITY_ALREADY_LINKED` code via
+/// the same redirect/postMessage channel — not as an HTTP error.
 async fn handle_identity_link(
     state: &AppState,
     flow_state: &OidcFlowState,
     user_info: &OidcUserInfo,
     link_user_id: Uuid,
 ) -> Result<Response, AuthError> {
-    match find_user_id_by_identity(&state.db, &flow_state.slug, &user_info.subject).await? {
+    // Determine the link outcome. Genuine server faults (DB errors) propagate as
+    // AuthError; a *conflict* instead becomes a generic error code carried back to
+    // the opener via the same redirect/postMessage channel, so the popup always
+    // closes rather than hanging on an HTTP error page. The code is intentionally
+    // ownerless — it never reveals which account holds the identity.
+    let error_code: Option<&'static str> = match find_user_id_by_identity(
+        &state.db,
+        &flow_state.slug,
+        &user_info.subject,
+    )
+    .await?
+    {
         // Already linked to this account — idempotent success.
         Some(existing) if existing == link_user_id => {
             tracing::info!(user_id = %link_user_id, provider = %flow_state.slug, "OIDC identity already linked to this account");
+            None
         }
         // Bound to someone else — refuse.
-        Some(_) => return Err(AuthError::IdentityAlreadyLinked),
-        None => {
-            match db::insert_user_identity(
-                &state.db,
-                link_user_id,
-                &flow_state.slug,
-                &user_info.subject,
-                user_info.email.as_deref(),
-            )
-            .await
-            {
-                Ok(_) => {
-                    tracing::info!(user_id = %link_user_id, provider = %flow_state.slug, "Linked OIDC identity to account");
-                }
-                // Lost a race, or the account already has an identity for this
-                // provider (the (user_id, provider_slug) UNIQUE constraint).
-                Err(sqlx::Error::Database(db_err)) if db_err.is_unique_violation() => {
-                    return Err(AuthError::IdentityAlreadyLinked);
-                }
-                Err(e) => return Err(AuthError::Database(e)),
+        Some(_) => Some("IDENTITY_ALREADY_LINKED"),
+        None => match db::insert_user_identity(
+            &state.db,
+            link_user_id,
+            &flow_state.slug,
+            &user_info.subject,
+            user_info.email.as_deref(),
+        )
+        .await
+        {
+            Ok(_) => {
+                tracing::info!(user_id = %link_user_id, provider = %flow_state.slug, "Linked OIDC identity to account");
+                None
             }
-        }
+            // Lost a race, or the account already has an identity for this
+            // provider (the (user_id, provider_slug) UNIQUE constraint).
+            Err(sqlx::Error::Database(db_err)) if db_err.is_unique_violation() => {
+                Some("IDENTITY_ALREADY_LINKED")
+            }
+            Err(e) => return Err(AuthError::Database(e)),
+        },
+    };
+
+    if let Some(code) = error_code {
+        tracing::info!(user_id = %link_user_id, provider = %flow_state.slug, error_code = code, "OIDC identity link rejected");
     }
 
-    // Token-less success response (mirrors the login callback's Tauri-vs-browser
+    // Token-less result response (mirrors the login callback's Tauri-vs-browser
     // split, minus the session/cookie since the caller is already authenticated).
+    // Always completes the handshake — success or a generic error code.
     let parsed_redirect = openidconnect::url::Url::parse(&flow_state.redirect_uri)
         .map_err(|e| AuthError::Internal(format!("Invalid redirect URI: {e}")))?;
     let is_localhost = matches!(
@@ -955,15 +972,21 @@ async fn handle_identity_link(
 
     if is_localhost {
         let mut redirect_url = parsed_redirect;
-        redirect_url
-            .query_pairs_mut()
-            .append_pair("linked", &flow_state.slug);
+        match error_code {
+            Some(code) => redirect_url
+                .query_pairs_mut()
+                .append_pair("link_error", code),
+            None => redirect_url
+                .query_pairs_mut()
+                .append_pair("linked", &flow_state.slug),
+        };
         Ok(Redirect::temporary(redirect_url.as_str()).into_response())
     } else {
         let payload = serde_json::json!({
             "type": "oidc-link-callback",
-            "success": true,
+            "success": error_code.is_none(),
             "provider_slug": flow_state.slug,
+            "error_code": error_code,
         });
         let html = format!(
             r#"<!DOCTYPE html>
@@ -972,7 +995,7 @@ if (window.opener) {{
     window.opener.postMessage({payload}, window.location.origin);
     window.close();
 }} else {{
-    document.body.innerText = "Account linked. You can close this window.";
+    document.body.innerText = "You can close this window.";
 }}
 </script></body></html>"#,
         );

--- a/server/src/auth/mod.rs
+++ b/server/src/auth/mod.rs
@@ -187,17 +187,36 @@ pub fn router(state: AppState) -> Router<AppState> {
         )
         .route("/me/identities", get(identities::list_identities))
         .route("/me/identities/{id}", delete(identities::unlink_identity))
-        .route(
-            "/me/identities/authorize/{provider}",
-            get(identities::link_authorize),
-        )
         .route("/mfa/setup", post(mfa::mfa_setup))
         .route("/mfa/verify", post(mfa::mfa_verify))
         .route("/mfa/disable", post(mfa::mfa_disable))
         .route("/mfa/backup-codes", post(mfa::mfa_generate_backup_codes))
         .route("/mfa/backup-codes/count", get(mfa::mfa_backup_code_count))
         .route("/qr/create", post(mfa::qr_create))
-        .layer(axum_middleware::from_fn_with_state(state, require_auth));
+        .layer(axum_middleware::from_fn_with_state(
+            state.clone(),
+            require_auth,
+        ));
 
-    public_routes.merge(protected_routes)
+    // Identity link-authorize: like the public OIDC authorize, each call triggers
+    // an outbound request to the provider + a Redis state write, so it needs the
+    // same per-IP throttle on top of auth (the rest of the protected block is
+    // cheap DB work and stays unthrottled to avoid breaking the settings UI).
+    let link_authorize_route = Router::new()
+        .route(
+            "/me/identities/authorize/{provider}",
+            get(identities::link_authorize),
+        )
+        .layer(axum_middleware::from_fn_with_state(
+            state.clone(),
+            require_auth,
+        ))
+        .layer(axum_middleware::from_fn_with_state(state, rate_limit_by_ip))
+        .layer(axum_middleware::from_fn(with_category(
+            RateLimitCategory::AuthOther,
+        )));
+
+    public_routes
+        .merge(protected_routes)
+        .merge(link_authorize_route)
 }

--- a/server/src/db/queries.rs
+++ b/server/src/db/queries.rs
@@ -190,6 +190,22 @@ pub async fn unlink_identity_guarded(
     Ok(UnlinkOutcome::Deleted)
 }
 
+/// Count legacy OIDC users whose `external_id` has no `:` separator.
+///
+/// Such rows got no `user_identities` back-fill (the slug/subject split needs a
+/// colon), so the `(provider_slug, subject)` login lookup can't resolve them.
+/// Expected to be zero — the login flow always writes `{slug}:{subject}`. A
+/// positive count means an operator must reconcile those accounts.
+pub async fn count_unsplittable_oidc_external_ids(pool: &PgPool) -> sqlx::Result<i64> {
+    sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM users
+         WHERE auth_method = 'oidc' AND external_id IS NOT NULL
+           AND position(':' IN external_id) = 0",
+    )
+    .fetch_one(pool)
+    .await
+}
+
 /// Mark an identity as just used for login. Best-effort; matches by
 /// `(provider_slug, subject)`. No-op if the row does not exist.
 pub async fn touch_user_identity_last_used(

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -311,6 +311,22 @@ async fn main() -> Result<()> {
                     tracing::info!(error = %e, "OIDC providers not loaded (optional)");
                 }
 
+                // Defensive: legacy OIDC users whose external_id lacks a ':'
+                // have no user_identities back-fill row and cannot be resolved
+                // by the (provider_slug, subject) login lookup. Should be zero.
+                match vc_server::db::count_unsplittable_oidc_external_ids(&db_pool).await {
+                    Ok(0) => {}
+                    Ok(n) => tracing::warn!(
+                        count = n,
+                        "Found OIDC users with a malformed external_id (no ':' separator) and no \
+                         user_identities row — these accounts cannot log in via OIDC until an \
+                         operator reconciles them"
+                    ),
+                    Err(e) => {
+                        tracing::warn!(error = %e, "Could not check for malformed OIDC external_ids");
+                    }
+                }
+
                 info!("OIDC provider manager initialized");
                 Some(manager)
             }

--- a/server/tests/integration/ratelimit_http.rs
+++ b/server/tests/integration/ratelimit_http.rs
@@ -179,3 +179,44 @@ async fn test_request_ids_are_unique(pool: PgPool) {
         }
     }
 }
+
+/// The authenticated identity link-authorize endpoint must be throttled the same
+/// way the public OIDC authorize route is — each call triggers an outbound
+/// provider request, so an authenticated user could otherwise loop it.
+///
+/// The rate-limit layer runs before `require_auth`, so unauthenticated probes
+/// (401) still count toward the per-IP `AuthOther` budget; the over-limit request
+/// returns 429 before reaching auth.
+#[sqlx::test]
+async fn test_link_authorize_is_rate_limited(pool: PgPool) {
+    let limits = RateLimits {
+        auth_other: LimitConfig {
+            requests: 3,
+            window_secs: 60,
+        },
+        ..RateLimits::default()
+    };
+
+    let (server, _config) = create_rate_limited_app(pool, limits).await;
+    let client = reqwest::Client::new();
+    let url = format!("{}/auth/me/identities/authorize/google", server.url);
+
+    // First 3 are under the limit — they pass rate-limiting and hit require_auth (401).
+    for i in 0..3 {
+        let resp = client.get(&url).send().await.expect("Request failed");
+        assert_eq!(
+            resp.status(),
+            401,
+            "link-authorize request {} should pass the limiter and reach auth (401)",
+            i + 1
+        );
+    }
+
+    // 4th trips the per-IP AuthOther limit before auth runs.
+    let resp = client.get(&url).send().await.expect("Request failed");
+    assert_eq!(
+        resp.status(),
+        429,
+        "4th link-authorize request should be rate limited (429)"
+    );
+}


### PR DESCRIPTION
Addresses the three security findings from the OAuth identity-linking code review.

## #604 (Medium) — rate-limit `link_authorize`
`GET /auth/me/identities/authorize/{provider}` runs the same `start_oidc_flow` as the public `oidc_authorize` (outbound provider request + Redis state write) but lived in the unthrottled `protected_routes` block. An authenticated user could loop it to flood the OIDC provider from the server's IP. Pulled into a sub-router with `require_auth` + `rate_limit_by_ip` + `AuthOther` category, mirroring `oidc_authorize_route`. `list`/`unlink` stay unthrottled (cheap DB ops; throttling them would break the settings UI). **New integration test** asserts 429 over-limit.

## #605 (Low) — link callback always completes the handshake
On a conflict, `handle_identity_link` returned an HTTP 409 page that never reached the popup opener (would hang). It now reports a generic `IDENTITY_ALREADY_LINKED` code through the same channel as success — `?link_error=<code>` (Tauri redirect) / `postMessage {success:false, error_code}` (browser). Message stays ownerless (no leak). The now-unused `AuthError::IdentityAlreadyLinked` variant is removed.

## #606 (Low) — startup warning for unsplittable external_ids
Logs a warning at boot if any legacy `auth_method='oidc'` user has a colon-less `external_id` (no `user_identities` backfill row → unresolvable by the new login lookup). Expected zero; surfaces any rows needing operator reconciliation. (The production verification query remains an operator action, noted in #606.)

## Verification
- ✅ `clippy --all-targets -D warnings` clean (incl. nursery), nightly `fmt` clean
- ✅ 83 identities/oidc/ratelimit/auth integration tests pass, including the new `test_link_authorize_is_rate_limited`

Closes #604, closes #605, closes #606.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017m2TjrBiDvBjGipb5E9BFb