### PR TITLE
docs(auth): reflect identity-linking model in reference docs (#607, #608, #609)

### DIFF
--- a/docs/developer-guide/architecture/overview.md
+++ b/docs/developer-guide/architecture/overview.md
@@ -248,8 +248,18 @@ flowchart TD
     end
     OIDC --> SSOProviders["Authentik, Keycloak, Azure AD, Okta, Google..."]
     Local --> UserStore
-    SSOProviders --> UserStore["Unified User Store"]
+    SSOProviders --> Identities["user_identities<br/>(provider_slug, subject) → account"]
+    Identities --> UserStore["Unified User Store"]
 ```
+
+An OIDC login resolves through the **`user_identities`** table, which maps each
+external identity `(provider_slug, subject)` to one Kaiku account — so a single
+account can have several linked external identities. (`users.external_id`
+remains the original/primary-identity marker but is no longer the authoritative
+lookup key.) Authenticated users manage linked identities via
+`GET /auth/me/identities`, `DELETE /auth/me/identities/{id}` (unlink, with a
+last-login-method guard), and `GET /auth/me/identities/authorize/{provider}`
+(link an additional identity).
 
 ---
 

--- a/docs/developer-guide/project/roadmap.md
+++ b/docs/developer-guide/project/roadmap.md
@@ -314,7 +314,12 @@ This section is the canonical high-level roadmap view. Detailed implementation c
 - [x] **[Auth] SSO / OIDC Integration** ✅ (PR #135)
   - Admin-configurable OIDC providers (Google, Microsoft, etc.) via `openidconnect`.
   - Dynamic provider discovery and registration through admin dashboard.
-  - Seamless login flow with automatic account linking.
+  - Seamless login flow with automatic provisioning of a local profile on first SSO login.
+- [x] **[Auth] Multi-identity linking** ✅ (PRs #600/#601/#603, 2026-06)
+  - `user_identities` table makes external identities first-class; OIDC login
+    resolves through `(provider_slug, subject)`, so one account can have several.
+  - Authenticated view + unlink of linked accounts in settings (last-login-method
+    guard). Link-add UI deferred (tech-debt TD-32).
 - [x] **[Voice] Screen Sharing** ✅
   - SFU handles multiple video tracks per room with per-channel limits.
   - Spotlight/PiP/Theater viewer modes with keyboard shortcuts (Escape/V/M/F).

--- a/docs/developer-guide/project/tech-debt.md
+++ b/docs/developer-guide/project/tech-debt.md
@@ -174,6 +174,36 @@ Three `#[ignore]` tests waiting on:
 
 ## Priority: Low
 
+### TD-31: Demote `users.external_id` UNIQUE constraint
+
+**File:** `server/migrations/20260322000000_user_identities.sql`, `server/src/auth/login.rs`
+
+Since the OAuth identity-linking work (PRs #600/#601/#603), `user_identities`
+`(provider_slug, subject)` is the authoritative identity-set uniqueness
+guarantee. `users.external_id` is retained only as the primary-identity marker
+and to satisfy the `oidc_user_has_external_id` CHECK, but it still carries a
+UNIQUE constraint. Linking does not currently write `external_id`, so this is
+inert today — but a future change that does (e.g. promoting a linked identity to
+primary) could have a second-identity link blocked by the legacy constraint.
+Demote `users.external_id` to non-unique (new migration) before any such change.
+
+---
+
+### TD-32: Identity link-add UI deferred (desktop native command + server error-redirect)
+
+**Files:** `client/src-tauri/src/commands/auth.rs`, `server/src/auth/login.rs`, `client/src/components/settings/LinkedAccountsSection.tsx`
+
+View + unlink of linked identities shipped (#603). *Adding* a new identity is
+deferred: the `link_authorize` endpoint requires a `Bearer` header a browser
+popup can't send, so desktop linking needs a native Tauri command (mirroring
+`oidc_authorize`, sending the user's token and handling the `?linked=` callback),
+and the client needs an `oidc-link-callback` postMessage receiver + "Link
+account" buttons. The server side already reports link errors via the callback
+channel (`?link_error=` / postMessage) as of the #605 fix. Tracked as GitHub
+issue #605.
+
+---
+
 ### TD-18: Swagger UI not wired up
 
 **File:** `server/src/api/mod.rs:334`

--- a/server/migrations/AGENTS.md
+++ b/server/migrations/AGENTS.md
@@ -7,14 +7,19 @@ SQLx database migrations for the Kaiku server. Defines the PostgreSQL schema evo
 
 ## Key Files
 
-| File | Purpose |
-|------|---------|
-| `20240101000000_initial_schema.sql` | Core tables: users, channels, messages, sessions |
-| `20240102000000_security_improvements.sql` | Security enhancements: indices, constraints, audit columns |
-| `20240201000000_guilds.sql` | Guild (server) system: guilds, memberships, roles |
-| `20260113000000_add_dm_read_state.sql` | Direct message read state tracking |
-| `20260113000001_permission_system.sql` | Fine-grained permission system |
-| `20260114000000_guild_invites.sql` | Guild invitation system |
+Migrations are timestamp-prefixed (`YYYYMMDDHHmmss_description.sql`) and
+self-documenting via their header comments. They are forward-only (no
+down-migrations). Rather than maintain a hand-curated list here (which drifts),
+discover them directly:
+
+```bash
+ls server/migrations/*.sql                  # all migrations, in apply order
+sqlx migrate info --source server/migrations # applied vs pending
+```
+
+Foundational ones to know: `20240101000000_initial_schema.sql` (core tables:
+users, channels, messages, sessions) and `20240201000000_guilds.sql` (guilds,
+memberships, roles).
 
 ## For AI Agents
 

--- a/server/src/auth/AGENTS.md
+++ b/server/src/auth/AGENTS.md
@@ -20,6 +20,7 @@
 - `login.rs` — Login, logout, refresh, password reset, OIDC handlers
 - `mfa.rs` — MFA setup/verify/disable, backup codes, QR login handlers
 - `sessions.rs` — Session listing and revocation handlers
+- `identities.rs` — Linked external (OIDC) identity view/link/unlink handlers
 - `profile.rs` — Profile read/update, avatar upload, password change handlers
 - `helpers.rs` — Shared helpers (token extraction, user-agent parsing)
 - `jwt.rs` — JWT token creation, validation, and claims parsing
@@ -85,7 +86,7 @@ Config::default()  // Uses OWASP-recommended defaults
 3. Client sends second request with `totp_code` in login body
 4. `mfa_crypto::verify_totp()` checks code (30s window, ±1 step tolerance)
 
-**Backup Codes**: Not yet implemented. TODO: Generate 10 single-use backup codes on MFA setup.
+**Backup Codes**: Implemented (`backup_codes.rs`, `mfa::mfa_generate_backup_codes`) — single-use hashed codes accepted by the login MFA path.
 
 ### OIDC Integration
 
@@ -99,7 +100,7 @@ Config::default()  // Uses OWASP-recommended defaults
 
 **State Parameter**: Prevents CSRF. Generated as random UUID, stored in Redis with 10min TTL (`oidc:state:{uuid}` key).
 
-**User Linking**: If email matches existing user, link OIDC identity. Otherwise create new user with `oidc:{provider}:{sub}` as username.
+**Identity Resolution & Linking**: An OIDC login resolves the account via the `user_identities` table keyed by `(provider_slug, subject)` (the authoritative lookup; `users.external_id` is retained as the primary-identity marker only). A first-time login provisions a new account + identity row; a known identity logs in. Authenticated users can attach additional identities (`/auth/me/identities/authorize/{provider}` stamps `link_user_id` into the encrypted flow state; the callback's `handle_identity_link` binds the identity instead of logging in) and unlink them (`DELETE /auth/me/identities/{id}`, refused if it's the only login method of a passwordless account → `CANNOT_UNLINK_LAST_IDENTITY`). A conflict (identity already bound elsewhere) is reported as a generic `IDENTITY_ALREADY_LINKED` code.
 
 ### Rate Limiting Strategy
 

--- a/server/src/auth/login.rs
+++ b/server/src/auth/login.rs
@@ -657,11 +657,12 @@ pub async fn oidc_callback(
     // user's primary-identity marker; the authoritative lookup is the
     // user_identities table keyed by (provider_slug, subject).
     //
-    // NOTE for the linking follow-up: users.external_id still carries a UNIQUE
-    // constraint and only ever holds the *first* identity. Once an account can
-    // attach additional identities, that constraint must not be treated as a
-    // uniqueness guarantee for the identity set (user_identities is) — and
-    // should likely be demoted to non-unique before multi-identity writes land.
+    // Accounts can now attach additional identities (see handle_identity_link),
+    // so users.external_id only ever holds the *first* identity — it is no
+    // longer the identity-set uniqueness guarantee (user_identities is). Its
+    // retained UNIQUE constraint is a latent footgun: a future change that
+    // writes external_id on link could be blocked by it. Demotion to non-unique
+    // is tracked in tech-debt (TD-31).
     let external_id = format!("{}:{}", flow_state.slug, user_info.subject);
 
     // Link flow: attach this identity to the already-authenticated user instead

--- a/server/src/db/AGENTS.md
+++ b/server/src/db/AGENTS.md
@@ -36,6 +36,7 @@ PostgreSQL connection pooling and Redis client setup. Data models and query func
 
 **Tables** (see `migrations/*.sql` for full DDL):
 - `users` — User accounts (id, username, email, password_hash, mfa_secret, status)
+- `user_identities` — Linked external OIDC identities (id, user_id, provider_slug, subject, email, last_used_at); authoritative `(provider_slug, subject)` login lookup
 - `sessions` — Refresh tokens (id, user_id, token_hash, expires_at)
 - `guilds` — Servers/workspaces (id, name, owner_id)
 - `guild_members` — Guild membership (guild_id, user_id, joined_at)


### PR DESCRIPTION
Documentation findings from the identity-linking review.

- **#607** — `architecture/overview.md` §5 now shows OIDC resolving through `user_identities` (+ the three `/auth/me/identities*` endpoints); `auth/AGENTS.md` "User Linking" note rewritten for the `user_identities` lookup + link/unlink flow + error codes, `identities.rs` added to Key Files (and the stale "backup codes not implemented" line corrected); `db/AGENTS.md` lists `user_identities`; `migrations/AGENTS.md` key-files table de-hardcoded (it had drifted ~18 months — now points at `ls` / `sqlx migrate info`).
- **#608** — tech-debt **TD-31** (demote `users.external_id` UNIQUE) + **TD-32** (deferred link-add UI); the future-tense `users.external_id` NOTE in `login.rs` reworded to present tense, pointing at TD-31.
- **#609** — roadmap SSO bullet softened ("automatic account linking" → first-login provisioning) + a "Multi-identity linking" entry added.

Docs/comment only — no behavior change.

Closes #607, closes #608, closes #609.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017m2TjrBiDvBjGipb5E9BFb