### PR TITLE
feat(auth): link-a-new-identity UI (desktop + browser)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release note structure source: `docs/project/RELEASE_NOTES_TEMPLATE.md`
 
 ### Added
-- Account settings now show your **linked accounts** — the external sign-in providers (e.g. Google, GitHub) connected to your profile — with the ability to unlink one. Removing the only login method of a password-less account is blocked so you can't lock yourself out.
+- Account settings now manage your **linked accounts** — the external sign-in providers (e.g. Google, GitHub) connected to your profile. You can link an additional provider so you can sign in with any of them, and unlink ones you no longer use. Removing the only login method of a password-less account is blocked so you can't lock yourself out.
 - Android: react to messages — long-pressing a message and choosing "React" now opens an emoji picker (16 common reactions) that adds your reaction, instead of doing nothing
 - Android: direct messages are now accessible — a new envelope button on the home screen opens a conversation list (avatar, name, last-message preview, unread badge); tapping a conversation opens it like any channel
 - Android: message attachments now display — images render as inline thumbnails, other files as a chip with name and size (previously attachments were invisible)

--- a/client/src-tauri/src/commands/auth.rs
+++ b/client/src-tauri/src/commands/auth.rs
@@ -712,6 +712,158 @@ pub async fn oidc_authorize(
     })
 }
 
+/// Link an additional external (OIDC) identity to the signed-in account (desktop).
+///
+/// Mirrors `oidc_authorize`, but: (1) it sends the user's Bearer token to the
+/// authenticated link-authorize endpoint, and (2) the localhost callback carries
+/// `linked` / `link_error` instead of tokens. Returns `Ok(())` on success; an
+/// `Err(message)` (e.g. already-linked) is surfaced to the user.
+#[command]
+pub async fn oidc_link_identity(
+    state: State<'_, AppState>,
+    app_handle: tauri::AppHandle,
+    server_url: String,
+    provider_slug: String,
+) -> Result<(), String> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use url::Url;
+
+    info!(
+        "Starting OIDC identity link for provider: {}",
+        provider_slug
+    );
+
+    let server_url = server_url.trim_end_matches('/');
+
+    // The link-authorize endpoint requires authentication.
+    let access_token = {
+        let auth = state.auth.read().await;
+        auth.access_token.clone()
+    }
+    .ok_or("Not signed in")?;
+
+    // 1. Bind a temporary TCP listener on localhost for the callback
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .map_err(|e| format!("Failed to bind localhost listener: {e}"))?;
+    let local_addr = listener
+        .local_addr()
+        .map_err(|e| format!("Failed to get local address: {e}"))?;
+    let redirect_uri = format!("http://127.0.0.1:{}/callback", local_addr.port());
+
+    // 2. Ask the server (authenticated) for the provider authorization URL. The server replies with
+    //    a 302 to the provider; capture the Location.
+    let mut authorize_parsed =
+        Url::parse(server_url).map_err(|e| format!("Invalid server URL: {e}"))?;
+    authorize_parsed
+        .path_segments_mut()
+        .map_err(|()| "Invalid server URL: cannot be a base")?
+        .extend(&["auth", "me", "identities", "authorize", &provider_slug]);
+    authorize_parsed
+        .query_pairs_mut()
+        .append_pair("redirect_uri", &redirect_uri);
+    let authorize_url = authorize_parsed.to_string();
+
+    let no_redirect_client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|e| format!("Failed to create HTTP client: {e}"))?;
+
+    let redirect_response = no_redirect_client
+        .get(&authorize_url)
+        .header("Authorization", format!("Bearer {access_token}"))
+        .send()
+        .await
+        .map_err(|e| format!("Failed to get authorize URL: {e}"))?;
+
+    let auth_url = if redirect_response.status().is_redirection() {
+        redirect_response
+            .headers()
+            .get("location")
+            .and_then(|v| v.to_str().ok())
+            .ok_or("Server did not return a redirect URL")?
+            .to_string()
+    } else {
+        let status = redirect_response.status();
+        let body = redirect_response.text().await.unwrap_or_default();
+        return Err(format!("Link authorize failed ({status}): {body}"));
+    };
+
+    // 3. Open the authorize URL in the default browser
+    #[allow(deprecated)] // tauri-plugin-shell::open is deprecated in favor of tauri-plugin-opener
+    {
+        use tauri_plugin_shell::ShellExt;
+        app_handle
+            .shell()
+            .open(&auth_url, None)
+            .map_err(|e| format!("Failed to open browser: {e}"))?;
+    }
+
+    info!("Opened browser for OIDC link, waiting for callback...");
+
+    // 4. Wait for the callback (with timeout), ignoring favicon/other requests
+    let accept_future = async {
+        loop {
+            let (mut stream, _addr) = listener.accept().await?;
+            let mut buf = vec![0u8; 8192];
+            let n = stream.read(&mut buf).await?;
+            let request = String::from_utf8_lossy(&buf[..n]);
+            let first_line = request.lines().next().unwrap_or("");
+            let path = first_line.split_whitespace().nth(1).unwrap_or("/");
+            if !path.starts_with("/callback") {
+                let response = "HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n";
+                let _ = stream.write_all(response.as_bytes()).await;
+                let _ = stream.flush().await;
+                continue;
+            }
+            let full_url = format!("http://localhost{path}");
+            let parsed = Url::parse(&full_url)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+            let params: HashMap<String, String> = parsed
+                .query_pairs()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect();
+            let html = if params.contains_key("linked") {
+                "<html><body><h2>Account linked!</h2><p>You can close this window and return to the app.</p><script>window.close()</script></body></html>"
+            } else {
+                "<html><body><h2>Linking failed</h2><p>You can close this window and return to the app.</p></body></html>"
+            };
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                html.len(),
+                html
+            );
+            stream.write_all(response.as_bytes()).await?;
+            stream.flush().await?;
+            return Ok::<HashMap<String, String>, std::io::Error>(params);
+        }
+    };
+
+    let params = tokio::time::timeout(std::time::Duration::from_secs(60), accept_future)
+        .await
+        .map_err(|_| "Linking timed out (60s). Please try again.".to_string())?
+        .map_err(|e| format!("Failed to receive link callback: {e}"))?;
+
+    // 5. Interpret the callback result
+    if params.contains_key("linked") {
+        info!("OIDC identity linked: {}", provider_slug);
+        Ok(())
+    } else if let Some(code) = params.get("link_error") {
+        match code.as_str() {
+            "IDENTITY_ALREADY_LINKED" => {
+                Err("This account is already linked to another Kaiku account.".to_string())
+            }
+            other => Err(format!("Linking failed: {other}")),
+        }
+    } else if let Some(error) = params.get("error") {
+        Err(format!("Linking failed: {error}"))
+    } else {
+        Err("Linking failed: no result in callback".to_string())
+    }
+}
+
 // Keyring helpers
 
 const KEYRING_SERVICE: &str = "voicechat";

--- a/client/src-tauri/src/lib.rs
+++ b/client/src-tauri/src/lib.rs
@@ -119,6 +119,7 @@ pub fn run() {
             commands::auth::get_auth_info,
             commands::auth::register,
             commands::auth::oidc_authorize,
+            commands::auth::oidc_link_identity,
             commands::auth::mfa_setup,
             commands::auth::mfa_verify,
             commands::auth::mfa_disable,

--- a/client/src/components/settings/LinkedAccountsSection.tsx
+++ b/client/src/components/settings/LinkedAccountsSection.tsx
@@ -1,25 +1,37 @@
 import { Component, createSignal, onMount, For, Show } from "solid-js";
-import { KeyRound, Unlink } from "lucide-solid";
+import { KeyRound, Unlink, Plus } from "lucide-solid";
 import * as tauri from "@/lib/tauri";
 import { formatRelativeTimeShort } from "@/lib/utils";
-import type { IdentityInfo } from "@/lib/types";
+import type { IdentityInfo, OidcProvider } from "@/lib/types";
 
 /**
- * Lists the external (OIDC) identities linked to the account and lets the user
- * unlink them. Adding new identities is handled separately (the link flow needs
- * the desktop app's native callback handling).
+ * Lists the external (OIDC) identities linked to the account, and lets the user
+ * link an additional provider or unlink an existing one.
+ *
+ * Linking uses the native command on desktop (Tauri) and a popup + postMessage
+ * handshake in the browser — see `tauri.linkIdentity`.
  */
 const LinkedAccountsSection: Component = () => {
   const [identities, setIdentities] = createSignal<IdentityInfo[]>([]);
+  const [providers, setProviders] = createSignal<OidcProvider[]>([]);
   const [loading, setLoading] = createSignal(true);
   const [error, setError] = createSignal<string | null>(null);
+  // Slug currently being linked (disables its button / shows progress).
+  const [linking, setLinking] = createSignal<string | null>(null);
 
-  const loadIdentities = async () => {
+  const loadData = async () => {
     try {
-      setLoading(true);
       setError(null);
       const resp = await tauri.listIdentities();
       setIdentities(resp.identities);
+      // Available providers come from the public server settings; ignore
+      // failures here (linking just won't be offered).
+      try {
+        const settings = await tauri.fetchServerSettings(tauri.getServerUrl());
+        setProviders(settings.oidc_enabled ? settings.oidc_providers : []);
+      } catch {
+        setProviders([]);
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -27,7 +39,13 @@ const LinkedAccountsSection: Component = () => {
     }
   };
 
-  onMount(loadIdentities);
+  onMount(loadData);
+
+  // Providers not already linked to this account.
+  const availableProviders = (): OidcProvider[] => {
+    const linkedSlugs = new Set(identities().map((i) => i.provider_slug));
+    return providers().filter((p) => !linkedSlugs.has(p.slug));
+  };
 
   const handleUnlink = async (identity: IdentityInfo) => {
     const label = identity.provider_name || identity.provider_slug;
@@ -45,6 +63,53 @@ const LinkedAccountsSection: Component = () => {
     } catch (err) {
       // Surfaces the server's message, e.g. the last-login-method guard (409).
       setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const handleLink = async (provider: OidcProvider) => {
+    setError(null);
+    setLinking(provider.slug);
+    try {
+      const result = await tauri.linkIdentity(provider.slug);
+
+      if (result.mode === "tauri") {
+        // Native command resolved on success; refresh the list.
+        await loadData();
+        setLinking(null);
+        return;
+      }
+
+      // Browser: open a popup and wait for the callback's postMessage.
+      const expectedOrigin = new URL(tauri.getServerUrl()).origin;
+      const messageHandler = (event: MessageEvent) => {
+        if (event.origin !== expectedOrigin) return;
+        if (event.data?.type !== "oidc-link-callback") return;
+        window.removeEventListener("message", messageHandler);
+        if (event.data.success) {
+          loadData().catch(() => {});
+        } else {
+          setError(
+            event.data.error_code === "IDENTITY_ALREADY_LINKED"
+              ? "That account is already linked to another Kaiku account."
+              : "Linking failed. Please try again.",
+          );
+        }
+        setLinking(null);
+      };
+      window.addEventListener("message", messageHandler);
+
+      const popup = window.open(result.authUrl, "oidc-link", "width=600,height=700");
+      // Stop waiting if the popup is closed without completing.
+      const checkClosed = setInterval(() => {
+        if (popup?.closed) {
+          clearInterval(checkClosed);
+          window.removeEventListener("message", messageHandler);
+          setLinking(null);
+        }
+      }, 500);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setLinking(null);
     }
   };
 
@@ -70,7 +135,7 @@ const LinkedAccountsSection: Component = () => {
         <Show
           when={identities().length > 0}
           fallback={
-            <div class="text-sm text-text-secondary py-4 text-center">
+            <div class="text-sm text-text-secondary py-2">
               No external accounts are linked to your profile.
             </div>
           }
@@ -106,6 +171,25 @@ const LinkedAccountsSection: Component = () => {
                     <Unlink size={16} />
                   </button>
                 </div>
+              )}
+            </For>
+          </div>
+        </Show>
+
+        <Show when={availableProviders().length > 0}>
+          <div class="flex flex-wrap gap-2 pt-1">
+            <For each={availableProviders()}>
+              {(provider) => (
+                <button
+                  onClick={() => handleLink(provider)}
+                  disabled={linking() !== null}
+                  class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm bg-surface-layer2 hover:bg-surface-highlight border border-white/5 text-text-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <Plus size={14} />
+                  {linking() === provider.slug
+                    ? "Linking..."
+                    : `Link ${provider.display_name}`}
+                </button>
               )}
             </For>
           </div>

--- a/client/src/lib/tauri/auth.ts
+++ b/client/src/lib/tauri/auth.ts
@@ -15,6 +15,7 @@ import {
   browserState,
   clearBrowserTokens,
   fetchApi,
+  getServerUrl,
   getUploadAuth,
   HttpError,
   httpRequest,
@@ -337,6 +338,32 @@ export async function unlinkIdentity(identityId: string): Promise<void> {
   await fetchApi<void>(`/auth/me/identities/${identityId}`, {
     method: "DELETE",
   });
+}
+
+/**
+ * Start linking an additional external identity to the current account.
+ *
+ * Tauri: the native command runs the full flow (opens the system browser, waits
+ * on a localhost callback) and resolves once the identity is linked.
+ *
+ * Browser: a top-level popup can't send the Bearer header the link-authorize
+ * endpoint requires, so we fetch the provider URL as an authenticated XHR and
+ * return it for the caller to open in a popup; the result then arrives via an
+ * `oidc-link-callback` postMessage from the server callback page.
+ */
+export async function linkIdentity(
+  providerSlug: string,
+): Promise<{ mode: "tauri" } | { mode: "browser"; authUrl: string }> {
+  const baseUrl = getServerUrl().replace(/\/+$/, "");
+  if (isTauri) {
+    const { invoke } = await import("@tauri-apps/api/core");
+    await invoke("oidc_link_identity", { serverUrl: baseUrl, providerSlug });
+    return { mode: "tauri" };
+  }
+  const resp = await fetchApi<{ url: string }>(
+    `/auth/me/identities/authorize/${encodeURIComponent(providerSlug)}?response=json`,
+  );
+  return { mode: "browser", authUrl: resp.url };
 }
 
 // ============================================================================

--- a/docs/developer-guide/project/goals.md
+++ b/docs/developer-guide/project/goals.md
@@ -248,9 +248,9 @@ the SaaS path is actually pursued:
        server OTel (Goal 4). *Only remaining: release source-map upload —
        needs an external Sentry account (operator infra), so out of scope
        here.* [Original "partially present" framing was stale.]
-4. [~] **Identity trust / OAuth linking** — medium priority. (OIDC login
-       already exists; "linking" of multiple external identities to one
-       account is the new surface.) **Foundation shipped 2026-06-20 (PR #600):**
+4. [x] **Identity trust / OAuth linking** — COMPLETE 2026-06-21. (OIDC login
+       already existed; "linking" of multiple external identities to one
+       account was the new surface.) **Foundation shipped 2026-06-20 (PR #600):**
        new `user_identities` table (authoritative `(provider_slug, subject)`
        login lookup, back-fills the legacy single `users.external_id`); OIDC
        login resolves and records identities through it. Verified: code review
@@ -262,16 +262,16 @@ the SaaS path is actually pursued:
        (authenticated link flow — the OIDC callback branches on a `link_user_id`
        carried in the encrypted flow state, attaching the identity instead of
        logging in; refuses identities already bound to another account).
-       **Client UI — view + unlink shipped 2026-06-20 (PR #603):** a "Linked
-       Accounts" section in account settings lists connected providers and
-       unlinks them (surfaces the last-login-method guard). Remaining: the
-       *link-a-new-identity* UI — deferred because it needs a native Tauri
-       command (the link-authorize endpoint requires a Bearer header a browser
-       popup can't send) plus a server tweak to redirect link *errors* to the
-       desktop localhost callback (success already does). NOTE: before any
-       further multi-identity hardening, consider demoting `users.external_id`'s
-       UNIQUE constraint (commented in login.rs) — linking does not write it, so
-       it is not yet a problem.
+       **Client UI shipped 2026-06-20/21:** a "Linked Accounts" section in
+       account settings (PR #603 view + unlink; the link-a-new-identity UI then
+       completed it). Linking uses the native Tauri command `oidc_link_identity`
+       on desktop and a popup + `oidc-link-callback` postMessage in the browser
+       (the link-authorize endpoint gained a `?response=json` mode so an
+       authenticated XHR can fetch the provider URL, since a popup can't send the
+       Bearer header). A full code review of the feature produced 9 follow-up
+       issues (#604–#612), all fixed. NOTE: before any change that writes
+       `users.external_id` on link, demote its UNIQUE constraint (tech-debt
+       TD-31) — linking does not write it today, so it is not yet a problem.
 5. [ ] **Billing & subscriptions (Stripe)** — defer until a SaaS launch
        decision is made; do not build speculatively.
 

--- a/docs/developer-guide/project/tech-debt.md
+++ b/docs/developer-guide/project/tech-debt.md
@@ -189,18 +189,18 @@ Demote `users.external_id` to non-unique (new migration) before any such change.
 
 ---
 
-### TD-32: Identity link-add UI deferred (desktop native command + server error-redirect)
+### TD-32: Identity link-add UI ✅ RESOLVED
 
 **Files:** `client/src-tauri/src/commands/auth.rs`, `server/src/auth/login.rs`, `client/src/components/settings/LinkedAccountsSection.tsx`
 
-View + unlink of linked identities shipped (#603). *Adding* a new identity is
-deferred: the `link_authorize` endpoint requires a `Bearer` header a browser
-popup can't send, so desktop linking needs a native Tauri command (mirroring
-`oidc_authorize`, sending the user's token and handling the `?linked=` callback),
-and the client needs an `oidc-link-callback` postMessage receiver + "Link
-account" buttons. The server side already reports link errors via the callback
-channel (`?link_error=` / postMessage) as of the #605 fix. Tracked as GitHub
-issue #605.
+**Resolved 2026-06-21** — the link-a-new-identity UI shipped. Desktop uses the
+native `oidc_link_identity` Tauri command (mirrors `oidc_authorize`, sends the
+user's Bearer token, handles the `?linked=`/`?link_error=` localhost callback).
+Browser uses a popup + `oidc-link-callback` postMessage; the `link_authorize`
+endpoint gained a `?response=json` mode so an authenticated XHR can fetch the
+provider URL (a top-level popup can't send the Bearer header). The
+`LinkedAccountsSection` lists available providers (minus already-linked) with
+"Link" buttons. Goal 6 item 4 is complete.
 
 ---
 

--- a/server/src/auth/identities.rs
+++ b/server/src/auth/identities.rs
@@ -90,11 +90,13 @@ pub async fn link_authorize(
     Path(provider): Path<String>,
     axum::extract::Query(query): axum::extract::Query<OidcAuthorizeQuery>,
 ) -> Result<Response, AuthError> {
+    let want_json = query.response.as_deref() == Some("json");
     start_oidc_flow(
         &state,
         &provider,
         query.redirect_uri.as_deref(),
         Some(auth_user.id),
+        want_json,
     )
     .await
 }

--- a/server/src/auth/login.rs
+++ b/server/src/auth/login.rs
@@ -463,7 +463,15 @@ pub async fn oidc_authorize(
     Path(provider): Path<String>,
     axum::extract::Query(query): axum::extract::Query<OidcAuthorizeQuery>,
 ) -> Result<Response, AuthError> {
-    start_oidc_flow(&state, &provider, query.redirect_uri.as_deref(), None).await
+    let want_json = query.response.as_deref() == Some("json");
+    start_oidc_flow(
+        &state,
+        &provider,
+        query.redirect_uri.as_deref(),
+        None,
+        want_json,
+    )
+    .await
 }
 
 /// Begin an OIDC authorization flow and redirect to the provider.
@@ -472,11 +480,16 @@ pub async fn oidc_authorize(
 /// authenticated identity-link flow (`link_user_id = Some(current user)`); the
 /// only difference is what gets persisted in the encrypted Redis flow state, so
 /// the callback can tell a login apart from a link.
+///
+/// When `want_json` is set, the provider authorization URL is returned as a JSON
+/// body (`{"url": ...}`) instead of a 307 redirect — for the browser link flow,
+/// which fetches this as an authenticated XHR and opens the URL itself.
 pub async fn start_oidc_flow(
     state: &AppState,
     provider: &str,
     redirect_uri: Option<&str>,
     link_user_id: Option<Uuid>,
+    want_json: bool,
 ) -> Result<Response, AuthError> {
     let auth_methods = get_auth_methods_allowed(&state.db).await?;
     if !auth_methods.oidc {
@@ -567,8 +580,12 @@ pub async fn start_oidc_flow(
             AuthError::Internal("Failed to store OIDC state".to_string())
         })?;
 
-    tracing::info!(provider = %provider, link = link_user_id.is_some(), "Redirecting to OIDC provider");
-    Ok(Redirect::temporary(&auth_url).into_response())
+    tracing::info!(provider = %provider, link = link_user_id.is_some(), json = want_json, "Starting OIDC provider flow");
+    if want_json {
+        Ok(Json(serde_json::json!({ "url": auth_url })).into_response())
+    } else {
+        Ok(Redirect::temporary(&auth_url).into_response())
+    }
 }
 
 /// Handle OIDC callback.

--- a/server/src/auth/types.rs
+++ b/server/src/auth/types.rs
@@ -286,6 +286,11 @@ pub struct OidcCallbackQuery {
 pub struct OidcAuthorizeQuery {
     /// Optional redirect URI override (for Tauri localhost callback).
     pub redirect_uri: Option<String>,
+    /// When `"json"`, return the provider authorization URL as a JSON body
+    /// (`{"url": ...}`) instead of a 307 redirect. Used by the browser link
+    /// flow, which calls this endpoint as an authenticated XHR (a top-level
+    /// popup can't send the Bearer header) and then opens the URL itself.
+    pub response: Option<String>,
 }
 
 /// Forgot password request.


### PR DESCRIPTION
Completes **OAuth identity linking** (Goal 6 item 4 / tech-debt **TD-32**). The "Linked Accounts" settings section can now *add* a provider, not just view/unlink.

## How it works

**Desktop (Tauri):** new native command `oidc_link_identity` — mirrors `oidc_authorize`, but sends the user's `Bearer` token to the authenticated link-authorize endpoint and resolves on the `?linked=`/`?link_error=` localhost callback.

**Browser:** a top-level popup can't send the `Bearer` header the link-authorize endpoint requires, so `start_oidc_flow` gains a **`?response=json` mode** that returns the provider URL to an authenticated XHR. The client fetches it, opens it in a popup, and gets the result via the `oidc-link-callback` `postMessage` (the callback already emits this as of #613).

**Client:** `tauri.linkIdentity(slug)` abstracts the two transports; `LinkedAccountsSection` now lists available providers (server settings minus already-linked) with "Link" buttons, refreshes on success, and surfaces already-linked / guard errors.

## Verification
- ✅ server `clippy --all-targets -D warnings` + nightly `fmt` clean; 56 identity/oidc/ratelimit tests pass
- ✅ client `bun run build` (tsc + vite) + 606 tests pass; new files lint-clean
- ⏳ the native `oidc_link_identity` Tauri command compiles only in CI (vc-client can't build locally) — the Tauri Build job validates it

Closes TD-32. With this, **Goal 6 item 4 is fully complete**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017m2TjrBiDvBjGipb5E9BFb