### PR TITLE
fix(auth): demote users.external_id UNIQUE constraint (TD-31)

### DIFF
--- a/docs/developer-guide/project/goals.md
+++ b/docs/developer-guide/project/goals.md
@@ -269,9 +269,9 @@ the SaaS path is actually pursued:
        (the link-authorize endpoint gained a `?response=json` mode so an
        authenticated XHR can fetch the provider URL, since a popup can't send the
        Bearer header). A full code review of the feature produced 9 follow-up
-       issues (#604–#612), all fixed. NOTE: before any change that writes
-       `users.external_id` on link, demote its UNIQUE constraint (tech-debt
-       TD-31) — linking does not write it today, so it is not yet a problem.
+       issues (#604–#612), all fixed. The legacy `users.external_id` UNIQUE
+       constraint has since been demoted (tech-debt TD-31, resolved
+       2026-07-04), so a future change may safely write it on link.
 5. [ ] **Billing & subscriptions (Stripe)** — defer until a SaaS launch
        decision is made; do not build speculatively.
 

--- a/docs/developer-guide/project/tech-debt.md
+++ b/docs/developer-guide/project/tech-debt.md
@@ -174,18 +174,19 @@ Three `#[ignore]` tests waiting on:
 
 ## Priority: Low
 
-### TD-31: Demote `users.external_id` UNIQUE constraint
+### TD-31: Demote `users.external_id` UNIQUE constraint ✅ RESOLVED
 
-**File:** `server/migrations/20260322000000_user_identities.sql`, `server/src/auth/login.rs`
+**File:** `server/migrations/20260704000000_demote_external_id_unique.sql`, `server/src/auth/login.rs`
 
-Since the OAuth identity-linking work (PRs #600/#601/#603), `user_identities`
-`(provider_slug, subject)` is the authoritative identity-set uniqueness
-guarantee. `users.external_id` is retained only as the primary-identity marker
-and to satisfy the `oidc_user_has_external_id` CHECK, but it still carries a
-UNIQUE constraint. Linking does not currently write `external_id`, so this is
-inert today — but a future change that does (e.g. promoting a linked identity to
-primary) could have a second-identity link blocked by the legacy constraint.
-Demote `users.external_id` to non-unique (new migration) before any such change.
+**Resolved 2026-07-04** — migration drops `users_external_id_key`; the
+authoritative identity-set uniqueness guarantee is
+`user_identities(provider_slug, subject)` (lookups stay indexed via the
+non-unique `idx_users_external_id`). The OIDC registration retry loop, which
+relied on the external_id UNIQUE violation to detect a lost concurrent
+first-login race, now detects it via the `insert_user_identity` unique
+violation instead (same transaction, same graceful re-resolve). A future
+change may now safely write `external_id` on link (e.g. promoting a linked
+identity to primary).
 
 ---
 

--- a/server/migrations/20260704000000_demote_external_id_unique.sql
+++ b/server/migrations/20260704000000_demote_external_id_unique.sql
@@ -1,0 +1,12 @@
+-- TD-31: demote users.external_id to non-unique.
+--
+-- Since the OAuth identity-linking work (user_identities table), the
+-- authoritative identity-set uniqueness guarantee is
+-- user_identities(provider_slug, subject). users.external_id is retained only
+-- as the primary-identity marker (and to satisfy the oidc_user_has_external_id
+-- CHECK); its legacy UNIQUE constraint could block a future change that writes
+-- external_id on link (e.g. promoting a linked identity to primary).
+--
+-- Lookups stay indexed via the existing non-unique idx_users_external_id.
+
+ALTER TABLE users DROP CONSTRAINT users_external_id_key;

--- a/server/src/auth/login.rs
+++ b/server/src/auth/login.rs
@@ -676,10 +676,8 @@ pub async fn oidc_callback(
     //
     // Accounts can now attach additional identities (see handle_identity_link),
     // so users.external_id only ever holds the *first* identity — it is no
-    // longer the identity-set uniqueness guarantee (user_identities is). Its
-    // retained UNIQUE constraint is a latent footgun: a future change that
-    // writes external_id on link could be blocked by it. Demotion to non-unique
-    // is tracked in tech-debt (TD-31).
+    // longer the identity-set uniqueness guarantee (user_identities is), and
+    // it carries no UNIQUE constraint (demoted in TD-31).
     let external_id = format!("{}:{}", flow_state.slug, user_info.subject);
 
     // Link flow: attach this identity to the already-authenticated user instead
@@ -769,7 +767,7 @@ pub async fn oidc_callback(
                 Some(user) => {
                     // Record the external identity (authoritative login key) in
                     // the same transaction as the user row.
-                    db::insert_user_identity(
+                    match db::insert_user_identity(
                         &mut *tx,
                         user.id,
                         &flow_state.slug,
@@ -777,10 +775,21 @@ pub async fn oidc_callback(
                         user_info.email.as_deref(),
                     )
                     .await
-                    .map_err(|e| {
-                        tracing::error!(error = %e, user_id = %user.id, provider = %flow_state.slug, "Failed to record OIDC identity");
-                        AuthError::Database(e)
-                    })?;
+                    {
+                        Ok(_) => {}
+                        // Lost a concurrent first-login race: another request
+                        // registered this identity between our pre-loop lookup
+                        // and here. Roll back and fall through to the post-loop
+                        // re-resolve, which logs that account in.
+                        Err(sqlx::Error::Database(ref db_err)) if db_err.is_unique_violation() => {
+                            drop(tx);
+                            break;
+                        }
+                        Err(e) => {
+                            tracing::error!(error = %e, user_id = %user.id, provider = %flow_state.slug, "Failed to record OIDC identity");
+                            return Err(AuthError::Database(e));
+                        }
+                    }
 
                     // Grant admin to first user
                     if is_first_user {
@@ -814,12 +823,10 @@ pub async fn oidc_callback(
         match new_user {
             Some(user) => user,
             None => {
-                // The retry loop exhausted. The dominant cause is losing a
-                // concurrent first-login race for this same identity: another
-                // request created the account (and its identity row) between our
-                // pre-loop lookup and our insert, so insert_oidc_user kept hitting
-                // the users.external_id UNIQUE constraint (reported as a generic
-                // collision). Re-resolve the identity; if it now exists, log that
+                // Either the username-retry loop exhausted, or we lost a
+                // concurrent first-login race for this same identity (the
+                // insert_user_identity unique violation broke out of the loop
+                // above). Re-resolve the identity; if it now exists, log that
                 // account in instead of failing.
                 if let Some(user_id) =
                     find_user_id_by_identity(&state.db, &flow_state.slug, &user_info.subject)


### PR DESCRIPTION
## Summary
- New migration `20260704000000_demote_external_id_unique.sql` drops `users_external_id_key`. Since the OAuth identity-linking work, `user_identities(provider_slug, subject)` is the authoritative identity-set uniqueness guarantee; `users.external_id` is only the primary-identity marker, and its legacy UNIQUE constraint could block a future change that writes `external_id` on link (e.g. promoting a linked identity to primary). Lookups stay indexed via the existing non-unique `idx_users_external_id`.
- The OIDC registration retry loop in `server/src/auth/login.rs` relied on the external_id UNIQUE violation to detect a lost concurrent first-login race. It now detects the race via the `insert_user_identity` unique violation (same transaction): roll back and fall through to the existing post-loop re-resolve, which logs the winning account in — preserving the previous graceful behavior.
- Docs: TD-31 marked resolved in `tech-debt.md`; stale note removed from `goals.md`.

## Test plan
- [x] Migration applied on dev DB; verified `users_external_id_key` gone, `idx_users_external_id` retained
- [x] `cargo test -p vc-server` — 538 passed
- [x] `cargo fmt --check` and `SQLX_OFFLINE=true cargo clippy -p vc-server -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdxjK7ngJvdtdREoJJrr3H