### PR TITLE
docs: commit identity-linking review plan and finish-the-app prompt

### DIFF
--- a/docs/developer-guide/plans/2026-06-20-identity-linking-review-followups.md
+++ b/docs/developer-guide/plans/2026-06-20-identity-linking-review-followups.md
@@ -1,0 +1,96 @@
+# Identity-Linking Review Follow-ups — Implementation Plan
+
+> Created 2026-06-20 from a full code review (coding patterns, docs accuracy,
+> security) of the OAuth identity-linking feature: PR #600 (`user_identities`
+> table + login lookup refactor), #601 (link/list/unlink endpoints + OIDC link
+> flow), #603 (client view+unlink UI). All findings are tracked as GitHub
+> issues #604–#612. This plan groups them into ordered work phases.
+
+## Context
+
+The review found the feature **fundamentally sound** — no critical/high
+security issues, conventions broadly followed, OpenAPI/CHANGELOG/goals.md
+accurate. The follow-ups are one medium security hardening item, a backfill
+edge case to verify against production, reference-doc drift, and minor pattern
+cleanups. None block the merged work; they harden and tidy it.
+
+## Findings → issues
+
+| # | Issue | Severity | Dimension |
+|---|-------|----------|-----------|
+| F1 | [#604](https://github.com/Detair/kaiku/issues/604) Rate-limit `link_authorize` | Medium | security |
+| F2 | [#605](https://github.com/Detair/kaiku/issues/605) Link callback postMessage on error | Low | security/UX |
+| F3 | [#606](https://github.com/Detair/kaiku/issues/606) Reconcile colon-less `external_id` | Low | security/data |
+| F4 | [#607](https://github.com/Detair/kaiku/issues/607) Update reference docs / AGENTS.md | Medium | docs |
+| F5 | [#608](https://github.com/Detair/kaiku/issues/608) Tech-debt entries + stale comment | Medium | docs |
+| F6 | [#609](https://github.com/Detair/kaiku/issues/609) roadmap SSO overstatement | Low | docs |
+| F7 | [#610](https://github.com/Detair/kaiku/issues/610) `db_error!` on new queries | Low | pattern |
+| F8 | [#611](https://github.com/Detair/kaiku/issues/611) Remove unused `count_user_identities` | Low | pattern |
+| F9 | [#612](https://github.com/Detair/kaiku/issues/612) Extract shared `formatRelativeTime` | Low | pattern |
+
+## Phase 1 — Security hardening (do first)
+
+**PR A: rate-limit the protected auth routes (F1, #604).**
+- In `server/src/auth/mod.rs`, wrap `link_authorize` (and ideally the whole
+  `protected_routes` block) with `rate_limit_by_user` + `RateLimitCategory::AuthOther`,
+  mirroring the public `oidc_authorize_route` (`:103-111`). `link_authorize` is
+  the priority (external OIDC amplification); `list`/`unlink`/MFA-setup are
+  defense-in-depth.
+- Add an integration test asserting repeated `link_authorize` calls get a 429
+  after the category limit (see `ratelimit_http.rs` for the harness).
+- Verify: `cargo test`, `clippy -D warnings`, nightly fmt.
+
+**Operator action (F3, #606)** — independent, no code:
+- Run against production: `SELECT id, external_id FROM users WHERE
+  auth_method='oidc' AND external_id IS NOT NULL AND position(':' IN external_id)=0;`
+- If zero rows → close #606 (impact nil, the `{slug}:{subject}` format held).
+- If rows exist → reconcile (insert correct `user_identities` rows) before
+  relying further on the `user_identities` lookup; optionally add a startup warn.
+
+## Phase 2 — Documentation accuracy (cheap, high-signal)
+
+**PR B: reference-doc refresh (F4 #607, F5 #608, F6 #609).** A single docs PR:
+- `architecture/overview.md` §5 + endpoint list: add `user_identities` as the
+  authoritative OIDC lookup; add the three `/auth/me/identities*` endpoints.
+- `server/src/auth/AGENTS.md`: rewrite the "User Linking" note (now `user_identities`
+  + link/unlink + error codes), add `identities.rs` to Key Files.
+- `server/src/db/AGENTS.md`: add `user_identities` to the tables list.
+- `server/migrations/AGENTS.md`: add the migration row or de-hardcode the list.
+- `tech-debt.md`: add the two follow-ups (external_id UNIQUE demotion;
+  deferred link-add UI). Reword the future-tense `login.rs:660-664` comment to
+  present tense and point it at the new tech-debt item.
+- `roadmap.md:317`: soften the PR #135 "automatic account linking" claim; add a
+  2026-06 identity-linking entry.
+- Verify: docs-only, "Docs Governance" CI.
+
+## Phase 3 — Pattern cleanups (batch into one small PR)
+
+**PR C: convention tidy (F7 #610, F8 #611, F9 #612).**
+- Add `db_error!` to `insert_user_identity` (and optionally the
+  `unlink_identity_guarded` statements / `subject` field on `find_user_id_by_identity`).
+- Remove `count_user_identities`; switch the two test assertions to
+  `list_user_identities(...).len()`.
+- Extract `formatRelativeTime` to `client/src/lib/` and import in both
+  `SessionsSection` and `LinkedAccountsSection` (settle on one casing).
+- Verify: `cargo test` + `clippy` (server), `bun run test:run` + `bun run build`
+  (client).
+
+## Phase 4 — Link-add feature (the remaining product slice, larger)
+
+Not from the review — this is the deferred Goal 6 item 4 work, but F2 (#605)
+belongs here:
+- Native Tauri command `oidc_link_identity` (mirror `oidc_authorize`, but send
+  the user's `Bearer` token to `/auth/me/identities/authorize/{provider}` and
+  expect a `?linked=<slug>` callback).
+- Server: make `handle_identity_link` redirect link **errors** (not just
+  success) to the localhost/SPA callback so the popup always closes (F2, #605).
+- Client: "Link account" buttons in `LinkedAccountsSection` + an
+  `oidc-link-callback` postMessage receiver; gate browser-mode appropriately.
+- This PR carries the user-facing CHANGELOG entry for *adding* linked accounts.
+
+## Suggested sequencing
+
+1. **Phase 1 PR A** (security, #604) — highest value, small.
+2. **Operator runs the #606 query** (parallel, no code).
+3. **Phase 2 PR B** (docs) and **Phase 3 PR C** (patterns) — independent, can land in either order.
+4. **Phase 4** (link-add) — its own larger effort; closes #605 and finishes Goal 6 item 4.

--- a/docs/developer-guide/project/finish-the-app-prompt.md
+++ b/docs/developer-guide/project/finish-the-app-prompt.md
@@ -1,0 +1,106 @@
+# Goal Prompt — Finish Kaiku to v1.0
+
+> Paste the prompt below into a Claude Code session in this repo to continue
+> driving the project to completion. It is self-contained and idempotent:
+> each run picks up the highest-priority unfinished item, completes it
+> end-to-end, and stops at a merged PR. Suitable for repeated runs or `/loop`.
+
+---
+
+## The Prompt
+
+You are working on **Kaiku** (`/home/detair/GIT/detair/kaiku`), a self-hosted
+voice/text chat platform (Rust server, Tauri + Solid.js client, native
+Android app). Your mission: **drive the project to v1.0** by executing the
+goals in `docs/developer-guide/project/goals.md`, one work item at a time.
+
+### Step 1 — Determine current state (always do this first)
+
+1. Read `docs/developer-guide/project/goals.md` and find the first goal with
+   unchecked items.
+2. Verify against reality before starting anything:
+   - `gh run list --limit 10` — is CI green? A failing required workflow
+     always outranks feature work.
+   - `gh pr list` — is there an open PR for an item already in progress?
+     Finish or unblock it before starting new work.
+   - Check the item off in `goals.md` if it turns out to be already done
+     (docs drift is a known problem in this repo — trust code over docs).
+3. Select exactly **one** work item: the topmost unchecked item of the
+   lowest-numbered goal that is actionable today. Skip items blocked on
+   external decisions and note why.
+
+### Step 2 — Execute the item end-to-end
+
+- **Never commit to `main`.** Create `feature/<name>`, `fix/<name>`, or
+  `chore/<name>` branch (worktree under `.claude/worktrees/` if isolation
+  helps).
+- Plan briefly, then implement following existing patterns
+  (`docs/superpowers/specs/2026-04-10-codebase-consistency-standards-design.md`
+  for module layout). Reuse existing utilities; search before writing new
+  code.
+- Write tests first where practical. Server: `cargo test` with `#[sqlx::test]`
+  isolation. Client: `bun run test:run`. New SQL queries: run
+  `cargo sqlx prepare --workspace` from the repo root and commit `.sqlx/`.
+- Quality gates before push (all must pass):
+  1. `cargo fmt --check && SQLX_OFFLINE=true cargo clippy -- -D warnings`
+  2. `cargo test` (server) / `bun run test:run` (client) — whichever is touched
+  3. `cargo deny check licenses` if dependencies changed
+  4. Update `CHANGELOG.md` `[Unreleased]` for user-visible changes
+- Respect the hard constraints in `CLAUDE.md`: no GPL/LGPL deps, UI contrast
+  rules, server-side input validation, performance targets.
+
+### Step 3 — Ship
+
+1. Push the branch, open a PR (`gh pr create`) with a body that names the
+   goal and item it completes. Conventional commit title
+   (`type(scope): subject`, ≤72 chars).
+2. Request a code review for significant changes (new modules, auth/crypto,
+   API changes) and address findings.
+3. Wait for CI. If CI fails, fix it — do not abandon the PR.
+4. Merge with `gh pr merge --squash`, then clean up:
+   `git worktree remove` (if used), delete local + remote branch,
+   `git fetch --prune`.
+5. Update `docs/developer-guide/project/goals.md` on the same PR (or a tiny
+   follow-up PR): check the item off, add a one-line note if scope changed.
+
+### Step 4 — Report and stop
+
+End the session with a short report: what shipped (PR link), what's next in
+the queue, and any blockers needing a human decision. **One merged item per
+run is success.** Do not start a second item unless the first was trivial
+(<30 min) and CI is green.
+
+### Standing priorities (override item order)
+
+1. **Red CI on `main`** — fix immediately, before anything else.
+2. **Security advisories** (cargo deny / audit failures) — same day.
+3. **Stalled open PRs** (#567 webrtc-rs, #568 keyring) — unblock before new work.
+4. Then: goals in numeric order (G1 → G7).
+
+### Escalate to the human (don't decide alone)
+
+- Anything spending money or creating external accounts (Stripe, Sentry SaaS,
+  app stores, code-signing certificates).
+- Deploying to the VPS (`kaiku.pmind.de`) — deploys are manual and
+  human-triggered. Never build Rust on the VPS.
+- Dropping platform support (e.g., the Windows/libvpx decision, TD-25).
+- The SaaS / billing go-no-go (Goal 6 item 5) and the i18n + iOS decisions
+  (Goal 7).
+- Any change to license policy or E2EE/crypto architecture.
+
+### Definition of done (v1.0)
+
+The mission is complete when every box in `goals.md` Goals 1–5 plus Goal 6
+items 1–2 is checked, the Goal 7 gate questions have recorded decisions, and
+a `v1.0.0` release exists with signed desktop artifacts, an upgrade playbook,
+and a public changelog. Until then, every run moves one item closer.
+
+---
+
+## Usage
+
+- **One-shot:** paste the prompt into a fresh session.
+- **Recurring:** `/loop` with this prompt, or a scheduled agent — one merged
+  PR per iteration keeps reviews digestible.
+- **Parallel:** safe to run two sessions only if they pick items from
+  different goals and use separate worktrees.


### PR DESCRIPTION
## Summary
- Commits two working docs left untracked from the 2026-06-20/21 sessions:
  - `docs/developer-guide/plans/2026-06-20-identity-linking-review-followups.md` — the review plan behind issues #604–#612 (all fixed via #613–#615); useful as a record of the review findings and their grouping.
  - `docs/developer-guide/project/finish-the-app-prompt.md` — the self-contained, idempotent goal prompt for driving the project to v1.0 session by session.

Docs only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdxjK7ngJvdtdREoJJrr3H