### PR TITLE
docs: record v1.0 scope decisions (English-only, Android-only, self-hosted)

### DIFF
--- a/docs/developer-guide/project/goals.md
+++ b/docs/developer-guide/project/goals.md
@@ -272,15 +272,17 @@ the SaaS path is actually pursued:
        issues (#604–#612), all fixed. NOTE: before any change that writes
        `users.external_id` on link, demote its UNIQUE constraint (tech-debt
        TD-31) — linking does not write it today, so it is not yet a problem.
-5. [ ] **Billing & subscriptions (Stripe)** — defer until a SaaS launch
-       decision is made; do not build speculatively.
+5. [ ] **Billing & subscriptions (Stripe)** — **decided 2026-07-04: post-1.0**
+       (v1.0 is self-hosted-only, see `v1.0-definition.md`); do not build
+       speculatively.
 
 ## Goal 7 — Define and ship v1.0
 
 **A concrete v1.0 definition now exists: `v1.0-definition.md`** (written
 2026-06-12). It records what's already done, the buildable remainder
 (Android beta, operator drill, release dry-run), and the three product
-decisions that block v1.0 and need maintainer input (i18n, iOS, SaaS).
+decisions (i18n, iOS, SaaS) — **decided 2026-07-04**: v1.0 is self-hosted,
+desktop + Android beta, English-only; i18n / iOS / SaaS are post-1.0.
 
 Original proposed gate (kept for reference):
 

--- a/docs/developer-guide/project/v1.0-definition.md
+++ b/docs/developer-guide/project/v1.0-definition.md
@@ -18,8 +18,8 @@
 | Self-hosted sovereignty (STUN/TURN) | ✅ done |
 | Android public beta with feature matrix | ◻ milestone defined, beta not shipped |
 | Windows desktop: fixed or formally dropped | ✅ green in CI (TD-25 resolved) — **keep**, not drop |
-| Product decisions: i18n, iOS, SaaS/billing | ⛔ **maintainer input required** |
-| `v1.0.0` release: signed artifacts + upgrade playbook + public changelog | ◻ blocked on the above |
+| Product decisions: i18n, iOS, SaaS/billing | ✅ **decided 2026-07-04** (see below) |
+| `v1.0.0` release: signed artifacts + upgrade playbook + public changelog | ◻ blocked on Android beta rollout + release dry-run |
 
 ## What is already true (no further work)
 
@@ -52,30 +52,29 @@ These are buildable without a product decision:
 4. **Back up the Tauri updater signing key** (`~/.tauri/kaiku.key`) — losing
    it permanently breaks auto-update for installed clients.
 
-## Product decisions blocking v1.0 (maintainer only)
+## Product decisions (decided by maintainer, 2026-07-04)
 
-These cannot be resolved by engineering judgment — they set scope:
+v1.0 is scoped as **self-hosted, desktop + Android beta, English-only**:
 
-- **i18n**: the client is English-only with no i18n framework. Decide:
-  ship v1.0 English-only (document as a known limitation), or make i18n a
-  v1.0 gate (a substantial addition).
-- **iOS**: no iOS client exists. Decide: Android-only for v1.0, or hold v1.0
-  for iOS parity.
-- **SaaS / billing**: the Stripe/billing track (Goal 6 item 5) is unstarted.
-  Decide: v1.0 is self-hosted-only (recommended — matches the project's
-  sovereignty thesis), with SaaS as a post-1.0 track.
+- **i18n**: v1.0 ships **English-only**, documented as a known limitation.
+  An i18n framework and string extraction are a post-1.0 roadmap item.
+- **iOS**: v1.0 is **Android-only** on mobile (public beta). An iOS client
+  is a post-1.0 roadmap item.
+- **SaaS / billing**: v1.0 is **self-hosted-only**, matching the project's
+  sovereignty thesis. The Stripe/billing track (Goal 6 item 5) stays
+  unstarted and moves to a post-1.0 track; do not build speculatively.
 
-**Recommendation:** scope v1.0 as **self-hosted, desktop + Android beta,
-English-only**, with i18n / iOS / SaaS explicitly deferred to a documented
-post-1.0 roadmap. That ships the sovereignty-first product the codebase is
-already built for, without gating on speculative SaaS work.
+With these recorded, the v1.0 gate reduces to the engineering remainder
+above (Android beta rollout, operator drill, release dry-run, key backup).
 
 ## Release checklist (when the gate is met)
 
 - [ ] Android beta criteria met (above)
 - [ ] Operator restore drill performed and logged
 - [ ] `v1.0.0-rc` dry-run validates signed artifacts + updater manifest
-- [ ] Product decisions recorded in this doc
+- [x] Product decisions recorded in this doc (2026-07-04: self-hosted,
+      desktop + Android beta, English-only; i18n / iOS / SaaS deferred
+      post-1.0)
 - [ ] `CHANGELOG.md` `[Unreleased]` → `[1.0.0]` with a curated highlight list
 - [ ] Tag `v1.0.0`; verify the Release workflow publishes signed desktop
       builds, Docker image, and `latest.json`


### PR DESCRIPTION
## Summary
Records the maintainer's 2026-07-04 product decisions in `v1.0-definition.md` (and mirrors them in `goals.md`):

- **i18n**: v1.0 ships English-only (documented limitation); i18n is post-1.0.
- **iOS**: v1.0 is Android-only on mobile; iOS client is post-1.0.
- **SaaS/billing**: v1.0 is self-hosted-only; the Stripe track stays unstarted, post-1.0.

This checks off "Product decisions recorded in this doc" on the release checklist. The v1.0 gate now reduces to: Android beta rollout, operator restore drill, `v1.0.0-rc` dry-run, and updater key backup.

Docs only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdxjK7ngJvdtdREoJJrr3H