### PR TITLE
fix(infra): pin Caddy to TLS 1.3 only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Opening a channel with unreads scrolls to your last read position
 
 ### Security
+- The bundled Caddy reverse-proxy config now pins TLS to 1.3 only (Caddy's default also accepted TLS 1.2); all supported clients already negotiate TLS 1.3
 - Update `quinn-proto` 0.11.14 → 0.11.15 (RUSTSEC-2026-0185, remote memory exhaustion via unbounded out-of-order stream reassembly; lockfile-only — quinn is an uncompiled optional reqwest HTTP/3 dependency), `quick-xml` 0.37.5/0.38.4 → 0.41.0 via `tauri-winrt-notification` 0.7.3 (RUSTSEC-2026-0194/-0195; used only for desktop notification/bundle XML), and `anyhow` 1.0.102 → 1.0.103 (RUSTSEC-2026-0190, `downcast_mut` unsoundness), restoring the weekly Security Audit and License Compliance checks to green
 - Update `lettre` 0.11.19 → 0.11.22 to resolve RUSTSEC-2026-0141 (TLS hostname verification bypass in the `boring-tls` backend; Kaiku uses `native-tls` and was not exploitable, but the update clears the advisory and unblocks the weekly security audit)
 - Update `openssl` 0.10.76 → 0.10.80 (2026 OpenSSL CVE batch), `actix-http` 3.12.0 → 3.12.1 (GHSA-xhj4-vrgc-hr34; lockfile-only, never compiled), and `mermaid` 11.14.0 → 11.15.0 (four XSS-class CVEs), clearing all remaining OSV scanner findings

--- a/infra/compose/Caddyfile
+++ b/infra/compose/Caddyfile
@@ -3,6 +3,13 @@
 }
 
 {$DOMAIN} {
+	# TLS 1.3 only (project security baseline — see CLAUDE.md); Caddy's
+	# default also allows TLS 1.2. All shipped clients (browsers, desktop
+	# rustls webview, Android with enforced TLS 1.3) negotiate 1.3.
+	tls {
+		protocols tls1.3
+	}
+
 	# API, auth, health, WebSocket — proxy to Rust backend
 	handle /api/* {
 		reverse_proxy server:8080


### PR DESCRIPTION
## Summary
Smoke tests against the beta found `kaiku.pmind.de` accepting TLS 1.2 connections. The Caddyfile never set `tls.protocols`, so Caddy's default minimum (1.2) applied — the project baseline (CLAUDE.md Security-Basics) is TLS 1.3 for all connections. This pins the site to TLS 1.3 only.

Client compatibility: browsers ≥2020, the desktop client (rustls / system webview), and Android (which already enforces TLS 1.3 client-side) all negotiate 1.3.

Applies on the VPS at the next deploy (`git pull` + Caddy reload).

## Test plan
- [x] `caddy validate` (caddy:2 container, DOMAIN/ACME_EMAIL set) — valid configuration
- [ ] Post-deploy: `curl --tls-max 1.2 https://kaiku.pmind.de/health` fails, `--tlsv1.3` succeeds (in the smoke suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdxjK7ngJvdtdREoJJrr3H