### PR TITLE
fix(infra): key macOS cargo caches by Xcode version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,8 +422,19 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      # macOS runner images rotate Xcode versions; build-script outputs cache
+      # absolute toolchain paths (e.g. -lclang_rt.osx with -L .../clang/<N>/
+      # lib/darwin), so a cargo cache built under one Xcode fails to link
+      # under another ("ld: library 'clang_rt.osx' not found"). Key the cache
+      # by Xcode version so image rollouts start a fresh cache.
+      - name: Compute Xcode cache key (macOS)
+        if: matrix.platform == 'macos-latest'
+        run: echo "XCODE_CACHE_KEY=$(xcodebuild -version | tr -d ' \n')" >> "$GITHUB_ENV"
+
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ env.XCODE_CACHE_KEY }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -54,10 +54,20 @@ jobs:
         with:
           bun-version: "1.3"
 
+      # macOS runner images rotate Xcode versions; build-script outputs cache
+      # absolute toolchain paths (e.g. -lclang_rt.osx with -L .../clang/<N>/
+      # lib/darwin), so a cargo cache built under one Xcode fails to link
+      # under another ("ld: library 'clang_rt.osx' not found"). Key the cache
+      # by Xcode version so image rollouts start a fresh cache.
+      - name: Compute Xcode cache key (macOS)
+        if: startsWith(matrix.os, 'macos')
+        run: echo "XCODE_CACHE_KEY=$(xcodebuild -version | tr -d ' \n')" >> "$GITHUB_ENV"
+
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: client/src-tauri
+          key: ${{ env.XCODE_CACHE_KEY }}
 
       # Linux dependencies
       - name: Install Linux dependencies


### PR DESCRIPTION
## Summary
`Tauri macos-latest` went red on main (since the #622 push) and on PR #624 with:

```
ld: warning: search path '/Applications/Xcode_16.4.app/.../clang/17/lib/darwin' not found
ld: library 'clang_rt.osx' not found
```

GitHub is rolling a new Xcode image across `macos-latest` runners. Cargo build-script outputs cached under Xcode 16.4 embed absolute clang-runtime linker paths; restored on a newer-image runner, the link fails. (The Tauri Build workflow passed at the same time — runner lottery during the rollout.)

Fix: add `xcodebuild -version` (trusted runner-local output, no event input) to the `Swatinem/rust-cache` `key` on macOS jobs in `ci.yml` and `tauri-build.yml`, so each Xcode image gets its own cache. I've also deleted the current poisoned Darwin cache entries so in-flight PRs rebuild cleanly.

## Test plan
- [x] This PR's own macOS CI job exercises the new key (fresh cache build)
- [ ] CI green incl. Tauri macos-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdxjK7ngJvdtdREoJJrr3H