### PR TITLE
fix(security): address deep-review findings (CORS, login timing, sanitizer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Opening a channel with unreads scrolls to your last read position
 
 ### Security
+- Hardened login against username enumeration: a login attempt now performs the same Argon2 password verification whether or not the account exists, so response timing no longer reveals valid usernames
+- CORS with `CORS_ALLOWED_ORIGINS=*` no longer sends `Access-Control-Allow-Credentials`; mirroring the Origin with credentials would have let any website make credentialed cross-origin requests. Same-origin app traffic is unaffected; set explicit origins for trusted credentialed cross-origin access
+- The web client's HTML sanitizers (chat messages and wiki pages) now use isolated DOMPurify instances instead of sharing one with global hooks, and wiki pages no longer allow arbitrary CSS `class` attributes (prevents cross-context sanitizer drift and CSS-based UI redressing)
 - The bundled Caddy reverse-proxy config now pins TLS to 1.3 only (Caddy's default also accepted TLS 1.2); all supported clients already negotiate TLS 1.3
 - Update `quinn-proto` 0.11.14 → 0.11.15 (RUSTSEC-2026-0185, remote memory exhaustion via unbounded out-of-order stream reassembly; lockfile-only — quinn is an uncompiled optional reqwest HTTP/3 dependency), `quick-xml` 0.37.5/0.38.4 → 0.41.0 via `tauri-winrt-notification` 0.7.3 (RUSTSEC-2026-0194/-0195; used only for desktop notification/bundle XML), and `anyhow` 1.0.102 → 1.0.103 (RUSTSEC-2026-0190, `downcast_mut` unsoundness), restoring the weekly Security Audit and License Compliance checks to green
 - Update `lettre` 0.11.19 → 0.11.22 to resolve RUSTSEC-2026-0141 (TLS hostname verification bypass in the `boring-tls` backend; Kaiku uses `native-tls` and was not exploitable, but the update clears the advisory and unblocks the weekly security audit)

--- a/client/src/components/messages/MessageItem.tsx
+++ b/client/src/components/messages/MessageItem.tsx
@@ -10,7 +10,7 @@ import {
   createResource,
 } from "solid-js";
 import { marked } from "marked";
-import DOMPurify from "dompurify";
+import { createIsolatedPurifier } from "@/lib/sanitizer";
 import {
   File,
   Download,
@@ -114,13 +114,17 @@ const PURIFY_CONFIG = {
   RETURN_TRUSTED_TYPE: false as const,
 };
 
+// Isolated DOMPurify instance (shared link-hardening hook pre-registered);
+// hooks below apply only to message sanitization, not other consumers.
+const purifier = createIsolatedPurifier();
+
 // Restrict class attribute values to prevent CSS-based UI spoofing
 const ALLOWED_CLASSES = new Set([
   "mention-everyone",
   "mention-user",
   "spoiler",
 ]);
-DOMPurify.addHook("uponSanitizeAttribute", (_node, data) => {
+purifier.addHook("uponSanitizeAttribute", (_node, data) => {
   if (data.attrName === "class") {
     const filtered = data.attrValue
       .split(/\s+/)
@@ -132,7 +136,7 @@ DOMPurify.addHook("uponSanitizeAttribute", (_node, data) => {
 });
 
 const sanitizeHtml = (html: string): string => {
-  return DOMPurify.sanitize(html, PURIFY_CONFIG) as string;
+  return purifier.sanitize(html, PURIFY_CONFIG) as string;
 };
 
 /**
@@ -456,7 +460,7 @@ const MessageItem: Component<MessageItemProps> = (props) => {
     } catch (err) {
       console.error("Failed to parse message content:", err);
       // Fallback: render plain text safely
-      const safeText = DOMPurify.sanitize(content, {
+      const safeText = purifier.sanitize(content, {
         ALLOWED_TAGS: [],
         ALLOWED_ATTR: [],
       }) as string;

--- a/client/src/components/pages/MarkdownPreview.tsx
+++ b/client/src/components/pages/MarkdownPreview.tsx
@@ -10,7 +10,7 @@
 
 import { createSignal, createEffect, onMount, Show } from "solid-js";
 import { Marked } from "marked";
-import DOMPurify from "dompurify";
+import { createIsolatedPurifier } from "@/lib/sanitizer";
 // Mermaid is loaded dynamically to avoid bundling ~1.8MB in the main chunk.
 // It's only needed when the Pages feature is actually used.
 let mermaidModule: Awaited<typeof import("mermaid")> | undefined;
@@ -88,7 +88,10 @@ const ALLOWED_ATTR = [
   "src",
   "alt",
   "title",
-  "class",
+  // `class` intentionally omitted: arbitrary classes on user-authored page
+  // content could pull in utility CSS (e.g. `fixed inset-0 z-50`) for
+  // clickjacking / UI-redress. Code-fence `language-*` hints are cosmetic and
+  // not currently styled, so nothing user-facing is lost.
   "id",
   "target",
   "rel",
@@ -169,18 +172,15 @@ const MARKDOWN_PURIFY_CONFIG = {
   ADD_ATTR: ["target"],
 };
 
-// Global hook: opens external links in new tab with noopener.
-// Intentionally global — this behavior is desirable for all sanitized contexts.
-DOMPurify.addHook("afterSanitizeAttributes", (node) => {
-  if (node.tagName === "A") {
-    const href = node.getAttribute("href") || "";
-    // External links open in new tab
-    if (href.startsWith("http://") || href.startsWith("https://")) {
-      node.setAttribute("target", "_blank");
-      node.setAttribute("rel", "noopener noreferrer");
-    }
-  }
-});
+// Isolated DOMPurify instance. The shared external-link hardening hook
+// (target=_blank + rel=noopener) is pre-registered by createIsolatedPurifier;
+// hooks added here do not leak into other sanitization contexts (e.g. the
+// message renderer) and vice-versa. Note `class` is intentionally absent from
+// MARKDOWN_PURIFY_CONFIG's ALLOWED_ATTR below, so user-authored pages cannot
+// carry arbitrary classes (which could pull in utility CSS like `fixed inset-0`
+// for clickjacking/UI-redress). The separate MERMAID_SVG_CONFIG still allows
+// `class` for diagram theming.
+const purifier = createIsolatedPurifier();
 
 // SVG-specific sanitization for mermaid diagrams — explicit allowlist (not additive).
 // foreignObject, script, and style are excluded as XSS/CSS-injection vectors.
@@ -298,7 +298,7 @@ export default function MarkdownPreview(props: MarkdownPreviewProps) {
       }
 
       // Sanitize HTML using DOMPurify with inline config (not global setConfig)
-      const sanitizedHtml = DOMPurify.sanitize(rawHtml, MARKDOWN_PURIFY_CONFIG);
+      const sanitizedHtml = purifier.sanitize(rawHtml, MARKDOWN_PURIFY_CONFIG);
       setHtml(sanitizedHtml);
       setError(null);
     } catch (err) {
@@ -342,7 +342,7 @@ export default function MarkdownPreview(props: MarkdownPreviewProps) {
         const wrapper = document.createElement("div");
         wrapper.className = "mermaid-diagram";
         // Security: SVG is sanitized through DOMPurify with strict SVG-only allowlist
-        wrapper.innerHTML = DOMPurify.sanitize(svg, MERMAID_SVG_CONFIG);
+        wrapper.innerHTML = purifier.sanitize(svg, MERMAID_SVG_CONFIG);
         pre.replaceWith(wrapper);
       } catch (err) {
         // Only show error if this is still the current render

--- a/client/src/lib/__tests__/sanitizer.test.ts
+++ b/client/src/lib/__tests__/sanitizer.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for the isolated DOMPurify factory (createIsolatedPurifier).
+ *
+ * Covers the two properties the security-review fix relies on:
+ *  1. The shared external-link hardening hook (target=_blank + rel=noopener)
+ *     runs on every instance — message links must not lose this when the
+ *     renderers stopped sharing one global DOMPurify.
+ *  2. Instances are isolated — a hook added to one does not affect another.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createIsolatedPurifier } from "../sanitizer";
+
+describe("createIsolatedPurifier", () => {
+  it("hardens external links with target and rel=noopener", () => {
+    const p = createIsolatedPurifier();
+    const out = p.sanitize('<a href="https://evil.example/x">click</a>', {
+      ALLOWED_TAGS: ["a"],
+      ALLOWED_ATTR: ["href", "target", "rel"],
+    });
+    expect(out).toContain('target="_blank"');
+    expect(out).toContain('rel="noopener noreferrer"');
+  });
+
+  it("does not add target/rel to non-http(s) (relative) links", () => {
+    const p = createIsolatedPurifier();
+    const out = p.sanitize('<a href="/channels/1">go</a>', {
+      ALLOWED_TAGS: ["a"],
+      ALLOWED_ATTR: ["href", "target", "rel"],
+    });
+    expect(out).not.toContain("target=");
+    expect(out).not.toContain("rel=");
+  });
+
+  it("isolates hooks between instances", () => {
+    const a = createIsolatedPurifier();
+    const b = createIsolatedPurifier();
+
+    // Register a class-stripping hook on instance A only.
+    a.addHook("uponSanitizeAttribute", (_node, data) => {
+      if (data.attrName === "class") {
+        data.attrValue = "";
+        data.keepAttr = false;
+      }
+    });
+
+    const cfg = { ALLOWED_TAGS: ["span"], ALLOWED_ATTR: ["class"] };
+    // A strips the class...
+    expect(a.sanitize('<span class="keep">x</span>', cfg)).not.toContain(
+      "class=",
+    );
+    // ...but B (isolated) is unaffected.
+    expect(b.sanitize('<span class="keep">x</span>', cfg)).toContain(
+      'class="keep"',
+    );
+  });
+
+  it("still removes script/dangerous content (baseline XSS)", () => {
+    const p = createIsolatedPurifier();
+    const out = p.sanitize('<img src=x onerror=alert(1)><script>alert(2)</script>ok', {
+      ALLOWED_TAGS: ["p"],
+      ALLOWED_ATTR: [],
+    });
+    expect(out).not.toContain("onerror");
+    expect(out).not.toContain("<script");
+    expect(out).toContain("ok");
+  });
+});

--- a/client/src/lib/sanitizer.ts
+++ b/client/src/lib/sanitizer.ts
@@ -1,0 +1,34 @@
+import DOMPurify from "dompurify";
+
+/**
+ * Create an **isolated** DOMPurify instance.
+ *
+ * `DOMPurify.addHook` registers hooks on the shared default instance, so a hook
+ * added by one consumer runs on *every* `sanitize()` call across the app. That
+ * cross-contamination is fragile: e.g. the message renderer's class allowlist
+ * would silently strip classes in the wiki-page renderer, and each context ends
+ * up depending on hooks another module happens to register. Giving every
+ * consumer its own instance makes each sanitization self-contained.
+ *
+ * The shared external-link hardening hook — `target="_blank"` +
+ * `rel="noopener noreferrer"` on `http(s)` links, which prevents reverse
+ * tabnabbing — is pre-registered here so every context gets it consistently.
+ * Callers add any context-specific hooks (e.g. a class-value allowlist) to the
+ * returned instance.
+ */
+export function createIsolatedPurifier() {
+  const purifier = DOMPurify(window);
+
+  purifier.addHook("afterSanitizeAttributes", (node) => {
+    const el = node as Element;
+    if (el.tagName === "A") {
+      const href = el.getAttribute("href") || "";
+      if (href.startsWith("http://") || href.startsWith("https://")) {
+        el.setAttribute("target", "_blank");
+        el.setAttribute("rel", "noopener noreferrer");
+      }
+    }
+  });
+
+  return purifier;
+}

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -131,16 +131,24 @@ pub fn create_router(state: AppState) -> Router {
         ];
 
         if state.config.cors_allowed_origins.iter().any(|o| o == "*") {
-            // Wildcard `*` is incompatible with `allow_credentials(true)` per the
-            // CORS spec, so mirror the request Origin header instead.
+            // Wildcard `*` mirrors the request Origin, but credentials MUST be
+            // disabled in that mode. Mirroring the Origin *with* credentials
+            // would let any website make credentialed cross-origin calls (e.g.
+            // POST /auth/refresh with the victim's HttpOnly cookie) and read the
+            // response — a full session-hijack primitive. Same-origin requests
+            // (the actual app) are unaffected: CORS never gates same-origin, so
+            // cookies still flow there. Cross-origin callers simply get no
+            // credentials. Configure CORS_ALLOWED_ORIGINS explicitly to allow
+            // trusted cross-origin credentialed access.
             tracing::warn!(
-                "CORS wildcard mirrors Origin header; set CORS_ALLOWED_ORIGINS explicitly in production"
+                "CORS_ALLOWED_ORIGINS='*' mirrors the Origin header with credentials DISABLED; \
+                 set explicit origins to enable credentialed cross-origin requests"
             );
             CorsLayer::new()
                 .allow_origin(AllowOrigin::mirror_request())
                 .allow_methods(allowed_methods)
                 .allow_headers(allowed_headers)
-                .allow_credentials(true)
+                .allow_credentials(false)
         } else {
             // Production mode: restrict to configured origins
             let origins: Vec<_> = state

--- a/server/src/auth/login.rs
+++ b/server/src/auth/login.rs
@@ -86,32 +86,31 @@ pub async fn login(
         };
     }
 
-    // Find user by username
-    let user = if let Some(u) = find_user_by_username(&state.db, &body.username).await? {
-        u
-    } else {
-        record_failed_auth!();
-        crate::observability::metrics::record_auth_login_attempt(false);
-        return Err(AuthError::InvalidCredentials);
+    // Look up the user, then ALWAYS run a password verification — against the
+    // real hash if the account exists with a local password, otherwise against
+    // a dummy hash of identical Argon2 cost. This keeps the response time the
+    // same whether the username exists or not, closing the timing side-channel
+    // that would otherwise reveal valid usernames (enumeration).
+    let user_opt = find_user_by_username(&state.db, &body.username).await?;
+    let stored_hash = user_opt
+        .as_ref()
+        .and_then(|u| u.password_hash.as_deref())
+        .unwrap_or_else(|| super::password::DUMMY_PASSWORD_HASH.as_str());
+    // A malformed stored hash (verify error) is treated as a non-match rather
+    // than a distinct 500, so it cannot be used as an oracle either.
+    let password_valid = verify_password(&body.password, stored_hash).unwrap_or(false);
+
+    let user = match user_opt {
+        // Local account whose password matched.
+        Some(u) if u.password_hash.is_some() && password_valid => u,
+        // Missing user, non-local (OIDC) account, or wrong password — all
+        // indistinguishable to the caller.
+        _ => {
+            record_failed_auth!();
+            crate::observability::metrics::record_auth_login_attempt(false);
+            return Err(AuthError::InvalidCredentials);
+        }
     };
-
-    // Verify password (only for local auth)
-    let password_hash = if let Some(h) = user.password_hash.as_ref() {
-        h
-    } else {
-        record_failed_auth!();
-        crate::observability::metrics::record_auth_login_attempt(false);
-        return Err(AuthError::InvalidCredentials);
-    };
-
-    let valid =
-        verify_password(&body.password, password_hash).map_err(|_| AuthError::PasswordHash)?;
-
-    if !valid {
-        record_failed_auth!();
-        crate::observability::metrics::record_auth_login_attempt(false);
-        return Err(AuthError::InvalidCredentials);
-    }
 
     // Check MFA if enabled
     if let Some(ref encrypted_secret) = user.mfa_secret {

--- a/server/src/auth/password.rs
+++ b/server/src/auth/password.rs
@@ -1,8 +1,25 @@
 //! Password Hashing with Argon2id
 
+use std::sync::LazyLock;
+
 use argon2::password_hash::rand_core::OsRng;
 use argon2::password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString};
 use argon2::Argon2;
+
+/// A dummy Argon2id hash used to equalize login timing.
+///
+/// When a login targets a non-existent user (or an account with no local
+/// password), the handler still verifies the submitted password against this
+/// hash so the request costs the same Argon2 work as a real check. Without it,
+/// missing users return before any hashing and are distinguishable by response
+/// time (username enumeration). Computed once via [`hash_password`], so its
+/// cost parameters match every real hash exactly.
+pub static DUMMY_PASSWORD_HASH: LazyLock<String> = LazyLock::new(|| {
+    // The plaintext is irrelevant and never compared to a user input that could
+    // match — only the hash's Argon2 cost parameters matter for timing.
+    hash_password("kaiku-login-timing-equalizer")
+        .expect("Argon2 dummy hash generation must not fail")
+});
 
 /// Hash a password using Argon2id.
 pub fn hash_password(password: &str) -> Result<String, argon2::password_hash::Error> {
@@ -19,4 +36,25 @@ pub fn verify_password(password: &str, hash: &str) -> Result<bool, argon2::passw
     Ok(Argon2::default()
         .verify_password(password.as_bytes(), &parsed_hash)
         .is_ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_verifies() {
+        let hash = hash_password("correct horse battery staple").unwrap();
+        assert!(verify_password("correct horse battery staple", &hash).unwrap());
+        assert!(!verify_password("wrong password", &hash).unwrap());
+    }
+
+    #[test]
+    fn dummy_hash_is_valid_and_never_matches_trivially() {
+        // Must be a well-formed Argon2 hash (so the login timing-equalizer path
+        // returns Ok(false), not an error) and must not accept an empty guess.
+        let dummy = DUMMY_PASSWORD_HASH.as_str();
+        assert!(!verify_password("", dummy).unwrap());
+        assert!(!verify_password("some-guess", dummy).unwrap());
+    }
 }


### PR DESCRIPTION
## Summary
Implements fixes for the three findings from the deep security review.

### 1 — CORS `*` + credentials footgun (Medium) — `server/src/api/mod.rs`
When an operator sets `CORS_ALLOWED_ORIGINS=*`, the layer mirrored any request `Origin` **with `allow_credentials(true)`** — any website could make credentialed cross-origin calls (e.g. `POST /auth/refresh` with the victim's `HttpOnly` cookie) and read the access token. Now `allow_credentials(false)` in wildcard mode. Same-origin app traffic is unaffected (CORS never gates same-origin); explicit origins still enable trusted credentialed cross-origin access.

### 2 — Login username enumeration via timing (Low) — `auth/login.rs`, `auth/password.rs`
A non-existent username returned before any Argon2 work, so valid usernames were distinguishable by response time. Login now **always** runs a password verification — against the real hash, or a dummy hash of identical Argon2 cost (`DUMMY_PASSWORD_HASH`, generated once via the app's own `hash_password` so params match) — before branching on the result. Missing user / OIDC account / wrong password are now timing-indistinguishable. Unit tests added.

### 3 — DOMPurify global-hook cross-contamination (Low/robustness) — client
`DOMPurify.addHook` mutates the shared singleton, so the message renderer's class-allowlist hook and the wiki-page renderer's link hook each ran on the other's output — the message renderer even *depended* on the page renderer's leaked link hardening for `rel=noopener`. Added `createIsolatedPurifier()` (a per-consumer instance with the shared external-link hardening hook pre-registered); each renderer now uses its own. Wiki pages additionally stop allowing arbitrary `class` (prevents utility-CSS UI-redress; code-fence `language-*` hints were cosmetic and unstyled). New tests lock in link-hardening + instance isolation.

## Test plan
- [x] `cargo test -p vc-server` — 539 integration + password unit tests green
- [x] `cargo clippy --all-targets -D warnings` + nightly fmt clean
- [x] `bun run test:run` — 610 client tests (added 4 sanitizer isolation tests)
- [x] `tsc --noEmit` clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdxjK7ngJvdtdREoJJrr3H