### PR TITLE
feat(admin): populate monitoring vital signs + add system stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release note structure source: `docs/project/RELEASE_NOTES_TEMPLATE.md`
 
 ### Added
+- Admin Command Center now shows request latency and error-rate vital signs (previously always blank — the underlying HTTP request/latency metrics were declared but never recorded), plus a new **System** section and trend charts for CPU %, process/system memory, disk, 1-minute load average, thread count, and open file descriptors
 - Account settings now manage your **linked accounts** — the external sign-in providers (e.g. Google, GitHub) connected to your profile. You can link an additional provider so you can sign in with any of them, and unlink ones you no longer use. Removing the only login method of a password-less account is blocked so you can't lock yourself out.
 - Android: react to messages — long-pressing a message and choosing "React" now opens an emoji picker (16 common reactions) that adds your reaction, instead of doing nothing
 - Android: direct messages are now accessible — a new envelope button on the home screen opens a conversation list (avatar, name, last-message preview, unread badge); tapping a conversation opens it like any channel

--- a/client/src/components/admin/CommandCenterPanel.tsx
+++ b/client/src/components/admin/CommandCenterPanel.tsx
@@ -26,6 +26,11 @@ import {
   ChevronDown,
   Search,
   Heart,
+  Cpu,
+  MemoryStick,
+  HardDrive,
+  Gauge,
+  Layers,
 } from "lucide-solid";
 import uPlot from "uplot";
 import "uplot/dist/uPlot.min.css";
@@ -68,6 +73,19 @@ function formatUptime(seconds: number): string {
   if (days > 0) return `${days}d ${hours}h`;
   if (hours > 0) return `${hours}h ${mins}m`;
   return `${mins}m`;
+}
+
+/** Human-readable bytes (e.g. 1.5 GB); "N/A" for null. */
+function formatBytes(bytes: number | null | undefined): string {
+  if (bytes == null) return "N/A";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let v = bytes;
+  let u = 0;
+  while (v >= 1024 && u < units.length - 1) {
+    v /= 1024;
+    u += 1;
+  }
+  return `${v.toFixed(u === 0 ? 0 : 1)} ${units[u]}`;
 }
 
 function formatTimestamp(iso: string): string {
@@ -447,6 +465,7 @@ const CommandCenterPanel: Component = () => {
   const summary = () => adminState.obsSummary;
   const vitals = () => summary()?.vital_signs;
   const meta = () => summary()?.server_metadata;
+  const sys = () => summary()?.system;
 
   return (
     <div class="flex-1 p-6 overflow-auto">
@@ -572,6 +591,80 @@ const CommandCenterPanel: Component = () => {
           </section>
         </Show>
 
+        {/* System Resources */}
+        <Show when={sys()}>
+          <section>
+            <h3 class="text-base font-semibold text-text-primary mb-3">
+              System
+            </h3>
+            <div class="grid grid-cols-3 md:grid-cols-6 gap-3">
+              <VitalCard
+                label="CPU"
+                value={
+                  sys()?.process_cpu_percent != null
+                    ? `${sys()!.process_cpu_percent!.toFixed(1)}%`
+                    : "N/A"
+                }
+                icon={Cpu}
+                color="#f97316"
+                loading={adminState.isObsSummaryLoading && !summary()}
+              />
+              <VitalCard
+                label="Process Mem"
+                value={formatBytes(sys()?.process_memory_bytes)}
+                icon={MemoryStick}
+                color="#22c55e"
+                loading={adminState.isObsSummaryLoading && !summary()}
+              />
+              <VitalCard
+                label="Sys Mem"
+                value={
+                  sys()?.system_memory_used_bytes != null &&
+                  sys()?.system_memory_total_bytes != null
+                    ? `${formatBytes(sys()!.system_memory_used_bytes)} / ${formatBytes(sys()!.system_memory_total_bytes)}`
+                    : "N/A"
+                }
+                icon={MemoryStick}
+                color="#14b8a6"
+                loading={adminState.isObsSummaryLoading && !summary()}
+              />
+              <VitalCard
+                label="Disk"
+                value={
+                  sys()?.disk_used_percent != null
+                    ? `${sys()!.disk_used_percent!.toFixed(0)}% (${formatBytes(sys()!.disk_used_bytes)}/${formatBytes(sys()!.disk_total_bytes)})`
+                    : "N/A"
+                }
+                icon={HardDrive}
+                color="#3b82f6"
+                loading={adminState.isObsSummaryLoading && !summary()}
+              />
+              <VitalCard
+                label="Load (1m)"
+                value={
+                  sys()?.load_average_1m != null
+                    ? sys()!.load_average_1m!.toFixed(2)
+                    : "N/A"
+                }
+                icon={Gauge}
+                color="#a855f7"
+                loading={adminState.isObsSummaryLoading && !summary()}
+              />
+              <VitalCard
+                label="Threads / FDs"
+                value={
+                  sys()?.thread_count != null || sys()?.open_file_descriptors != null
+                    ? `${sys()?.thread_count ?? "?"} / ${sys()?.open_file_descriptors ?? "?"}`
+                    : "N/A"
+                }
+                icon={Layers}
+                color="#64748b"
+                loading={adminState.isObsSummaryLoading && !summary()}
+              />
+            </div>
+          </section>
+        </Show>
+
         {/* Trends Section */}
         <section>
           <div class="flex items-center justify-between mb-4">
@@ -609,6 +702,20 @@ const CommandCenterPanel: Component = () => {
               dataKey="value_count"
               unit="sessions"
               color="#8b5cf6"
+            />
+            <TrendChart
+              title="CPU %"
+              metricName="kaiku_process_cpu_percent"
+              dataKey="value_count"
+              unit="%"
+              color="#f97316"
+            />
+            <TrendChart
+              title="Process Memory"
+              metricName="kaiku_process_memory_bytes"
+              dataKey="value_count"
+              unit="bytes"
+              color="#22c55e"
             />
           </div>
         </section>

--- a/client/src/lib/types/observability.ts
+++ b/client/src/lib/types/observability.ts
@@ -21,9 +21,23 @@ export interface ServerMetadata {
   guild_count: number;
 }
 
+export interface SystemStats {
+  process_memory_bytes: number | null;
+  process_cpu_percent: number | null;
+  system_memory_used_bytes: number | null;
+  system_memory_total_bytes: number | null;
+  load_average_1m: number | null;
+  open_file_descriptors: number | null;
+  thread_count: number | null;
+  disk_used_bytes: number | null;
+  disk_total_bytes: number | null;
+  disk_used_percent: number | null;
+}
+
 export interface ObservabilitySummary {
   vital_signs: VitalSigns;
   server_metadata: ServerMetadata;
+  system: SystemStats;
   voice_health_score: number | null;
   active_alert_count: number;
 }

--- a/client/src/stores/admin.ts
+++ b/client/src/stores/admin.ts
@@ -1465,6 +1465,8 @@ const DEFAULT_OBS_METRICS = [
   "kaiku_http_errors_total",
   "kaiku_ws_connections_active",
   "kaiku_voice_sessions_active",
+  "kaiku_process_cpu_percent",
+  "kaiku_process_memory_bytes",
 ];
 
 export async function loadObsSummary(): Promise<void> {

--- a/server/src/admin/observability.rs
+++ b/server/src/admin/observability.rs
@@ -156,8 +156,25 @@ pub struct TracesParams {
 pub struct SummaryResponse {
     pub vital_signs: VitalSigns,
     pub server_metadata: ServerMetadata,
+    pub system: SystemStats,
     pub voice_health_score: Option<f64>,
     pub active_alert_count: i64,
+}
+
+/// Live host/process resource usage, sampled at request time. Each field is
+/// `None` when unavailable (e.g. non-Linux host, or CPU not yet sampled).
+#[derive(Debug, Serialize)]
+pub struct SystemStats {
+    pub process_memory_bytes: Option<u64>,
+    pub process_cpu_percent: Option<f64>,
+    pub system_memory_used_bytes: Option<u64>,
+    pub system_memory_total_bytes: Option<u64>,
+    pub load_average_1m: Option<f64>,
+    pub open_file_descriptors: Option<u64>,
+    pub thread_count: Option<u64>,
+    pub disk_used_bytes: Option<u64>,
+    pub disk_total_bytes: Option<u64>,
+    pub disk_used_percent: Option<f64>,
 }
 
 #[derive(Debug, Serialize)]
@@ -289,6 +306,25 @@ pub async fn summary(
     // Voice health score (cached, refreshed every 10s — no DB query)
     let voice_health_score = crate::observability::voice::get_voice_health_score().await;
 
+    // Live system stats (cheap /proc reads + one `df`); missing pieces are None.
+    use crate::observability::sysinfo as sys;
+    let (mem_total, mem_avail) = sys::system_memory_bytes().unzip();
+    let disk = super::system::disk_usage().await;
+    let system = SystemStats {
+        process_memory_bytes: sys::process_rss_bytes(),
+        process_cpu_percent: sys::last_cpu_percent(),
+        system_memory_used_bytes: mem_total.zip(mem_avail).map(|(t, a)| t.saturating_sub(a)),
+        system_memory_total_bytes: mem_total,
+        load_average_1m: sys::load_average_1m(),
+        open_file_descriptors: sys::open_fds(),
+        thread_count: sys::thread_count(),
+        disk_used_bytes: disk
+            .as_ref()
+            .map(|d| d.total_bytes.saturating_sub(d.available_bytes)),
+        disk_total_bytes: disk.as_ref().map(|d| d.total_bytes),
+        disk_used_percent: disk.as_ref().map(|d| d.used_percent),
+    };
+
     Ok(Json(SummaryResponse {
         vital_signs: VitalSigns {
             latency_p95_ms: latency_p95,
@@ -303,6 +339,7 @@ pub async fn summary(
             active_user_count: user_count,
             guild_count,
         },
+        system,
         voice_health_score,
         active_alert_count,
     }))

--- a/server/src/admin/system.rs
+++ b/server/src/admin/system.rs
@@ -678,7 +678,7 @@ pub struct DiagnosticsResponse {
 /// Best-effort disk usage via `df` (no unsafe statvfs — the workspace
 /// forbids unsafe code). Returns `None` if `df` is unavailable or output
 /// is unparseable; diagnostics must degrade, not fail.
-async fn disk_usage() -> Option<DiskDiagnostics> {
+pub(crate) async fn disk_usage() -> Option<DiskDiagnostics> {
     let output = tokio::process::Command::new("df")
         .args(["-B1", "--output=size,avail", "/"])
         .output()

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -361,7 +361,7 @@ pub fn create_router(state: AppState) -> Router {
         .merge(app_routes)
         // Middleware
         .layer(from_fn(security_headers))
-        .layer(from_fn(http_error_counter))
+        .layer(from_fn(http_metrics))
         .layer(TraceLayer::new_for_http())
         .layer(CompressionLayer::new())
         .layer(cors)
@@ -428,15 +428,15 @@ pub(crate) async fn health_check(
 }
 
 /// Middleware that counts HTTP error responses (4xx/5xx).
-async fn http_error_counter(
+async fn http_metrics(
     request: Request<axum::body::Body>,
     next: axum::middleware::Next,
 ) -> Response {
+    let start = std::time::Instant::now();
     let response = next.run(request).await;
+    let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
     let status = response.status().as_u16();
-    if status >= 400 {
-        crate::observability::metrics::record_http_error(status);
-    }
+    crate::observability::metrics::record_http_request(status, duration_ms);
     response
 }
 

--- a/server/src/observability/metrics.rs
+++ b/server/src/observability/metrics.rs
@@ -305,6 +305,81 @@ pub fn register_process_memory_metric() {
         .build();
 }
 
+/// Register host/process system-statistic gauges.
+///
+/// CPU, memory, load, open FDs, and thread count. Each reads `/proc` on the
+/// metric-export cadence and feeds the native telemetry pipeline, so they
+/// appear as time series in the admin Command Center. No-ops silently on
+/// non-Linux hosts.
+pub fn register_system_metrics() {
+    use super::sysinfo;
+    let meter = meter("vc-server");
+
+    meter
+        .f64_observable_gauge("kaiku_process_cpu_percent")
+        .with_description("Process CPU usage percent (delta of utime+stime)")
+        .with_unit("percent")
+        .with_callback(|observer| {
+            // Samples and caches for the admin summary's point-in-time read.
+            if let Some(pct) = sysinfo::process_cpu_percent() {
+                observer.observe(pct, &[]);
+            }
+        })
+        .build();
+
+    meter
+        .u64_observable_gauge("kaiku_system_memory_used_bytes")
+        .with_description("System memory in use (MemTotal - MemAvailable)")
+        .with_unit("bytes")
+        .with_callback(|observer| {
+            if let Some((total, avail)) = sysinfo::system_memory_bytes() {
+                observer.observe(total.saturating_sub(avail), &[]);
+            }
+        })
+        .build();
+
+    meter
+        .u64_observable_gauge("kaiku_system_memory_total_bytes")
+        .with_description("Total system memory (MemTotal)")
+        .with_unit("bytes")
+        .with_callback(|observer| {
+            if let Some((total, _)) = sysinfo::system_memory_bytes() {
+                observer.observe(total, &[]);
+            }
+        })
+        .build();
+
+    meter
+        .f64_observable_gauge("kaiku_load_average_1m")
+        .with_description("1-minute system load average")
+        .with_callback(|observer| {
+            if let Some(load) = sysinfo::load_average_1m() {
+                observer.observe(load, &[]);
+            }
+        })
+        .build();
+
+    meter
+        .u64_observable_gauge("kaiku_process_open_fds")
+        .with_description("Open file descriptors held by the process")
+        .with_callback(|observer| {
+            if let Some(fds) = sysinfo::open_fds() {
+                observer.observe(fds, &[]);
+            }
+        })
+        .build();
+
+    meter
+        .u64_observable_gauge("kaiku_process_threads")
+        .with_description("OS thread count of the process")
+        .with_callback(|observer| {
+            if let Some(threads) = sysinfo::thread_count() {
+                observer.observe(threads, &[]);
+            }
+        })
+        .build();
+}
+
 // ============================================================================
 // Recording functions
 // ============================================================================
@@ -322,6 +397,25 @@ pub fn record_auth_login_attempt(success: bool) {
     let outcome = if success { "success" } else { "failure" };
     if let Some(counter) = AUTH_LOGIN_ATTEMPTS_TOTAL.get() {
         counter.add(1, &[KeyValue::new("outcome", outcome)]);
+    }
+}
+
+/// Record a completed HTTP request (count, latency, and error if >= 400).
+///
+/// Called for every request by the `http_metrics` middleware. Without this the
+/// `kaiku_http_requests_total` counter and `kaiku_http_request_duration_ms`
+/// histogram were declared but never fed, so the admin Command Center's
+/// latency-p95 and error-rate vital signs stayed empty even though the
+/// telemetry pipeline was running.
+pub fn record_http_request(status: u16, duration_ms: f64) {
+    if let Some(counter) = HTTP_REQUESTS_TOTAL.get() {
+        counter.add(1, &[]);
+    }
+    if let Some(hist) = HTTP_REQUEST_DURATION_MS.get() {
+        hist.record(duration_ms, &[]);
+    }
+    if status >= 400 {
+        record_http_error(status);
     }
 }
 

--- a/server/src/observability/mod.rs
+++ b/server/src/observability/mod.rs
@@ -21,6 +21,7 @@ pub mod metrics;
 pub mod retention;
 pub mod sqlx_metrics;
 pub mod storage;
+pub mod sysinfo;
 pub mod tracing;
 pub mod voice;
 
@@ -65,6 +66,7 @@ pub fn init(
     // so metrics are always registered.
     metrics::register_metrics();
     metrics::register_process_memory_metric();
+    metrics::register_system_metrics();
     (
         guard,
         meter_provider,

--- a/server/src/observability/sysinfo.rs
+++ b/server/src/observability/sysinfo.rs
@@ -1,0 +1,171 @@
+//! Lightweight Linux system statistics read from `/proc`.
+//!
+//! Pure `std` (no external crates). All readers return `Option`/`Result` and
+//! never panic, so a missing or unexpected `/proc` (e.g. a non-Linux dev host)
+//! simply yields `None` rather than breaking metrics collection.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::time::Instant;
+
+/// Clock ticks per second (`sysconf(_SC_CLK_TCK)`). 100 on every mainstream
+/// Linux; the server only ever runs on Linux (container + CI).
+const USER_HZ: f64 = 100.0;
+
+/// Resident set size of this process in bytes (`/proc/self/status` `VmRSS`).
+pub fn process_rss_bytes() -> Option<u64> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("VmRSS:") {
+            let kb: u64 = rest.trim().trim_end_matches("kB").trim().parse().ok()?;
+            return Some(kb * 1024);
+        }
+    }
+    None
+}
+
+/// System memory `(total_bytes, available_bytes)` from `/proc/meminfo`.
+pub fn system_memory_bytes() -> Option<(u64, u64)> {
+    let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
+    let mut total = None;
+    let mut available = None;
+    for line in meminfo.lines() {
+        if let Some(rest) = line.strip_prefix("MemTotal:") {
+            total = rest
+                .trim()
+                .trim_end_matches("kB")
+                .trim()
+                .parse::<u64>()
+                .ok();
+        } else if let Some(rest) = line.strip_prefix("MemAvailable:") {
+            available = rest
+                .trim()
+                .trim_end_matches("kB")
+                .trim()
+                .parse::<u64>()
+                .ok();
+        }
+        if total.is_some() && available.is_some() {
+            break;
+        }
+    }
+    Some((total? * 1024, available? * 1024))
+}
+
+/// 1-minute load average (first field of `/proc/loadavg`).
+pub fn load_average_1m() -> Option<f64> {
+    let loadavg = std::fs::read_to_string("/proc/loadavg").ok()?;
+    loadavg.split_whitespace().next()?.parse().ok()
+}
+
+/// Number of open file descriptors held by this process.
+pub fn open_fds() -> Option<u64> {
+    Some(std::fs::read_dir("/proc/self/fd").ok()?.count() as u64)
+}
+
+/// Number of OS threads in this process (`/proc/self/status` `Threads`).
+pub fn thread_count() -> Option<u64> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("Threads:") {
+            return rest.trim().parse().ok();
+        }
+    }
+    None
+}
+
+/// Total CPU time (user + system) consumed by this process, in clock ticks.
+/// Fields 14 (utime) and 15 (stime) of `/proc/self/stat`. The comm field
+/// (field 2) may contain spaces/parens, so parse after the final `)`.
+fn process_cpu_ticks() -> Option<u64> {
+    let stat = std::fs::read_to_string("/proc/self/stat").ok()?;
+    let after_comm = stat.rsplit_once(')')?.1;
+    let fields: Vec<&str> = after_comm.split_whitespace().collect();
+    // After ')' the next field is `state` (index 0 here = field 3). utime is
+    // field 14 → index 11, stime is field 15 → index 12.
+    let utime: u64 = fields.get(11)?.parse().ok()?;
+    let stime: u64 = fields.get(12)?.parse().ok()?;
+    Some(utime + stime)
+}
+
+/// Cache of the most recently computed CPU percent, so a point-in-time reader
+/// (the admin summary) can report it without needing two spaced samples.
+/// Stored as `f64` bits; `NaN` means "not yet sampled".
+static LAST_CPU_PCT: AtomicU64 = AtomicU64::new(0x7ff8_0000_0000_0000); // NaN bits
+
+/// Instantaneous process CPU usage percent.
+///
+/// Computed from the CPU-time delta since the previous call. Returns `None` on
+/// the first call (establishes a baseline) and caches every computed value for
+/// [`last_cpu_percent`].
+///
+/// Intended to be called on a fixed cadence (the metric-export interval), where
+/// the delta window equals the export interval and the result is a true rate.
+pub fn process_cpu_percent() -> Option<f64> {
+    static PREV: Mutex<Option<(u64, Instant)>> = Mutex::new(None);
+
+    let ticks = process_cpu_ticks()?;
+    let now = Instant::now();
+    let mut guard = PREV.lock().ok()?;
+    let pct = match *guard {
+        Some((prev_ticks, prev_t)) => {
+            let dt = now.duration_since(prev_t).as_secs_f64();
+            if dt <= 0.0 {
+                None
+            } else {
+                let d_ticks = ticks.saturating_sub(prev_ticks) as f64;
+                Some((d_ticks / USER_HZ) / dt * 100.0)
+            }
+        }
+        None => None,
+    };
+    *guard = Some((ticks, now));
+    if let Some(p) = pct {
+        LAST_CPU_PCT.store(p.to_bits(), Ordering::Relaxed);
+    }
+    pct
+}
+
+/// The most recently computed CPU percent (see [`process_cpu_percent`]), or
+/// `None` if it has not been sampled yet.
+pub fn last_cpu_percent() -> Option<f64> {
+    let v = f64::from_bits(LAST_CPU_PCT.load(Ordering::Relaxed));
+    if v.is_nan() {
+        None
+    } else {
+        Some(v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn reads_proc_values() {
+        assert!(process_rss_bytes().is_some_and(|b| b > 0));
+        assert!(thread_count().is_some_and(|t| t >= 1));
+        assert!(open_fds().is_some_and(|f| f >= 1));
+        assert!(load_average_1m().is_some_and(|l| l >= 0.0));
+        let (total, avail) = system_memory_bytes().expect("meminfo");
+        assert!(total > 0 && avail <= total);
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn cpu_percent_needs_two_samples() {
+        // First call establishes a baseline (None); a later call yields a value.
+        let _ = process_cpu_percent();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        // Busy a little so there is measurable CPU time.
+        let mut x: u64 = 0;
+        for i in 0..2_000_000 {
+            x = x.wrapping_add(i);
+        }
+        std::hint::black_box(x);
+        let pct = process_cpu_percent();
+        assert!(pct.is_some_and(|p| (0.0..=1000.0).contains(&p)));
+        assert!(last_cpu_percent().is_some());
+    }
+}


### PR DESCRIPTION
## Summary
Addresses two gaps in the admin **Command Center** monitoring.

### 1 — Vital signs were blank (latency p95, error rate)
`kaiku_http_requests_total` and `kaiku_http_request_duration_ms` were declared as instruments and queried by the summary endpoint, but **no code ever recorded them** — only `record_http_error` existed. So the telemetry tables were full (174k+ metric samples on the beta) yet the two headline vital signs always showed `N/A`.

Fix: add `record_http_request(status, duration_ms)` and rename the `http_error_counter` middleware to `http_metrics`, which now times every request and records total count + latency histogram + error. Latency-p95 and error-rate now populate.

### 2 — Only process memory was monitored; add system stats
New `observability::sysinfo` module (pure `/proc` reads, **no new deps**, no-ops off-Linux) + `register_system_metrics()` gauges:
- `kaiku_process_cpu_percent` (utime+stime delta), `kaiku_system_memory_used_bytes` / `_total_bytes`, `kaiku_load_average_1m`, `kaiku_process_open_fds`, `kaiku_process_threads`.

These feed the native telemetry pipeline (time series, graphable) and are also surfaced live in a new `SummaryResponse.system` block (with disk from the existing `df` helper). The client gains a **System** section (CPU, process mem, system mem, disk, load, threads/FDs) and **CPU %** + **Process Memory** trend charts.

## Test plan
- [x] `cargo test -p vc-server` — 451 lib (incl. 2 new `sysinfo` tests) + 539 integration green
- [x] `cargo clippy --all-targets -D warnings` + nightly fmt clean
- [x] `bun run test:run` — 610 client tests, `tsc --noEmit` clean, build ok
- [ ] Deploy to beta; verify summary returns latency/error-rate + system stats and the panel renders the System section
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdxjK7ngJvdtdREoJJrr3H