### PR TITLE
chore(client): fix all eslint errors and gate lint in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,6 +305,9 @@ jobs:
       - name: Type check
         run: bunx tsc --noEmit
 
+      - name: Lint (fails on errors; warnings allowed)
+        run: bun run lint
+
       - name: Run tests
         run: bun run test:run
 

--- a/client/src/components/OnboardingWizard.tsx
+++ b/client/src/components/OnboardingWizard.tsx
@@ -280,7 +280,7 @@ const OnboardingWizard: Component = () => {
         <div
           ref={dialogRef}
           class="w-[36rem] max-h-[85vh] rounded-xl border border-white/10 shadow-2xl flex flex-col overflow-hidden"
-          style="background-color: var(--color-surface-layer2)"
+          style={{"background-color":"var(--color-surface-layer2)"}}
         >
           {/* Progress dots */}
           <div

--- a/client/src/components/SetupWizard.tsx
+++ b/client/src/components/SetupWizard.tsx
@@ -64,12 +64,15 @@ async function fetchSetupConfig(): Promise<SetupConfig> {
   } catch (parseError) {
     // Distinguish between JSON syntax errors and other unexpected errors
     if (parseError instanceof SyntaxError) {
-      throw new Error(`Server returned invalid JSON: ${parseError.message}`);
+      throw new Error(`Server returned invalid JSON: ${parseError.message}`, {
+        cause: parseError,
+      });
     } else {
       // Unexpected error (OOM, extension interference, etc.)
       console.error("[SetupWizard] Unexpected error parsing JSON:", parseError);
       throw new Error(
         `Failed to parse server response: ${parseError instanceof Error ? parseError.message : "Unknown error"}`,
+        { cause: parseError },
       );
     }
   }
@@ -80,7 +83,7 @@ async function completeSetup(config: SetupConfig): Promise<void> {
   const serverUrl = getServerUrl();
 
   // Get access token
-  let accessToken: string | null = null;
+  let accessToken: string | null;
   if (isTauri) {
     const { invoke } = await import("@tauri-apps/api/core");
     accessToken = await invoke<string>("get_access_token");
@@ -295,7 +298,7 @@ const SetupWizard: Component = () => {
           {/* Loading state */}
           <Show when={isLoadingConfig()}>
             <div class="flex items-center justify-center p-8">
-              <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-accent-primary"></div>
+              <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-accent-primary" />
             </div>
           </Show>
 

--- a/client/src/components/admin/AdminQuickModal.tsx
+++ b/client/src/components/admin/AdminQuickModal.tsx
@@ -106,7 +106,7 @@ const AdminQuickModal: Component<AdminQuickModalProps> = (props) => {
         {/* Modal */}
         <div
           class="relative rounded-xl border border-white/10 w-[400px] shadow-2xl animate-[fadeIn_0.15s_ease-out]"
-          style="background-color: var(--color-surface-layer1)"
+          style={{"background-color":"var(--color-surface-layer1)"}}
         >
           {/* Header */}
           <div class="flex items-center justify-between px-5 py-4 border-b border-white/10">

--- a/client/src/components/admin/AdminSettings.tsx
+++ b/client/src/components/admin/AdminSettings.tsx
@@ -296,7 +296,7 @@ const AdminSettings: Component = () => {
         <Show when={state.error}>
           <div
             class="p-3 rounded-lg text-sm"
-            style="background-color: var(--color-error-bg); border: 1px solid var(--color-error-border); color: var(--color-error-text)"
+            style={{"background-color":"var(--color-error-bg)","border":"1px solid var(--color-error-border)","color":"var(--color-error-text)"}}
           >
             {state.error}
           </div>

--- a/client/src/components/admin/GuildsPanel.tsx
+++ b/client/src/components/admin/GuildsPanel.tsx
@@ -794,7 +794,7 @@ const GuildsPanel: Component = () => {
           {/* Dialog */}
           <div
             class="relative rounded-xl border border-white/10 w-[400px] shadow-2xl animate-[fadeIn_0.15s_ease-out]"
-            style="background-color: var(--color-surface-layer1)"
+            style={{"background-color":"var(--color-surface-layer1)"}}
           >
             <div class="p-5 space-y-4">
               <h3 class="text-lg font-bold text-text-primary">Suspend Guild</h3>
@@ -855,7 +855,7 @@ const GuildsPanel: Component = () => {
           {/* Dialog */}
           <div
             class="relative rounded-xl border border-white/10 w-[400px] shadow-2xl animate-[fadeIn_0.15s_ease-out]"
-            style="background-color: var(--color-surface-layer1)"
+            style={{"background-color":"var(--color-surface-layer1)"}}
           >
             <div class="p-5 space-y-4">
               <h3 class="text-lg font-bold text-text-primary">
@@ -924,7 +924,7 @@ const GuildsPanel: Component = () => {
           {/* Dialog */}
           <div
             class="relative rounded-xl border border-white/10 w-[400px] shadow-2xl animate-[fadeIn_0.15s_ease-out]"
-            style="background-color: var(--color-surface-layer1)"
+            style={{"background-color":"var(--color-surface-layer1)"}}
           >
             <div class="p-5 space-y-4">
               <h3 class="text-lg font-bold text-status-error">Delete Guild</h3>

--- a/client/src/components/admin/ReportsPanel.tsx
+++ b/client/src/components/admin/ReportsPanel.tsx
@@ -403,7 +403,7 @@ const ReportsPanel: Component = () => {
           />
           <div
             class="relative rounded-xl border border-white/10 w-[400px] shadow-2xl"
-            style="background-color: var(--color-surface-layer1)"
+            style={{"background-color":"var(--color-surface-layer1)"}}
           >
             <div class="flex items-center justify-between px-5 py-4 border-b border-white/10">
               <h3 class="text-lg font-bold text-text-primary">

--- a/client/src/components/admin/UsersPanel.tsx
+++ b/client/src/components/admin/UsersPanel.tsx
@@ -736,7 +736,7 @@ const UsersPanel: Component = () => {
           {/* Dialog */}
           <div
             class="relative rounded-xl border border-white/10 w-[400px] shadow-2xl animate-[fadeIn_0.15s_ease-out]"
-            style="background-color: var(--color-surface-layer1)"
+            style={{"background-color":"var(--color-surface-layer1)"}}
           >
             <div class="p-5 space-y-4">
               <h3 class="text-lg font-bold text-text-primary">Ban User</h3>
@@ -797,7 +797,7 @@ const UsersPanel: Component = () => {
           {/* Dialog */}
           <div
             class="relative rounded-xl border border-white/10 w-[400px] shadow-2xl animate-[fadeIn_0.15s_ease-out]"
-            style="background-color: var(--color-surface-layer1)"
+            style={{"background-color":"var(--color-surface-layer1)"}}
           >
             <div class="p-5 space-y-4">
               <h3 class="text-lg font-bold text-text-primary">
@@ -866,7 +866,7 @@ const UsersPanel: Component = () => {
           {/* Dialog */}
           <div
             class="relative rounded-xl border border-white/10 w-[400px] shadow-2xl animate-[fadeIn_0.15s_ease-out]"
-            style="background-color: var(--color-surface-layer1)"
+            style={{"background-color":"var(--color-surface-layer1)"}}
           >
             <div class="p-5 space-y-4">
               <h3 class="text-lg font-bold text-status-error">Delete User</h3>

--- a/client/src/components/auth/SessionExpiredModal.tsx
+++ b/client/src/components/auth/SessionExpiredModal.tsx
@@ -33,7 +33,7 @@ const SessionExpiredModal: Component = () => {
 
           <div
             class="relative rounded-xl border border-white/10 w-[400px] shadow-2xl animate-[fadeIn_0.15s_ease-out]"
-            style="background-color: var(--color-surface-layer1)"
+            style={{"background-color":"var(--color-surface-layer1)"}}
           >
             <div class="flex items-center gap-3 px-5 py-4 border-b border-white/10">
               <div class="w-9 h-9 rounded-lg bg-status-warning/20 flex items-center justify-center">

--- a/client/src/components/channels/ChannelItem.tsx
+++ b/client/src/components/channels/ChannelItem.tsx
@@ -9,7 +9,7 @@
  * - Smooth hover transitions
  */
 
-import { Component, Show, createSignal, createMemo } from "solid-js";
+import { Component, Show, createSignal, createMemo, For } from "solid-js";
 import {
   Hash,
   Volume2,
@@ -320,13 +320,12 @@ const ChannelItem: Component<ChannelItemProps> = (props) => {
             {participantCount() === 1 ? "member" : "members"}
           </p>
           <div class="space-y-0.5">
-            {participants()
-              .slice(0, 5)
-              .map((participant) => (
+            <For each={participants()
+              .slice(0, 5)}>{(participant) => (
                 <p class="text-sm text-text-primary truncate">
                   {participant.user_id.slice(0, 8)}...
                 </p>
-              ))}
+              )}</For>
             <Show when={participantCount() > 5}>
               <p class="text-xs text-text-secondary italic">
                 +{participantCount() - 5} more

--- a/client/src/components/channels/ChannelList.tsx
+++ b/client/src/components/channels/ChannelList.tsx
@@ -372,8 +372,8 @@ const ChannelList: Component<ChannelListProps> = (props) => {
       style={{ height: props.active ? "8px" : "0px" }}
     >
       <div class="flex items-center h-full px-1">
-        <div class="w-2.5 h-2.5 rounded-full shrink-0" style="background-color: var(--color-accent-primary)" />
-        <div class="flex-1 rounded-full" style="height: 3px; background-color: var(--color-accent-primary)" />
+        <div class="w-2.5 h-2.5 rounded-full shrink-0" style={{"background-color":"var(--color-accent-primary)"}} />
+        <div class="flex-1 rounded-full" style={{"height":"3px","background-color":"var(--color-accent-primary)"}} />
       </div>
     </div>
   );
@@ -690,7 +690,7 @@ const ChannelList: Component<ChannelListProps> = (props) => {
       <Show when={channelsState.error}>
         <div
           class="px-2 py-4 text-center text-sm"
-          style="color: var(--color-error-text)"
+          style={{"color":"var(--color-error-text)"}}
         >
           {channelsState.error}
         </div>

--- a/client/src/components/channels/ChannelPermissions.tsx
+++ b/client/src/components/channels/ChannelPermissions.tsx
@@ -192,7 +192,7 @@ const ChannelPermissions: Component<ChannelPermissionsProps> = (props) => {
                   <div
                     data-testid="channel-permissions-role-picker"
                     class="absolute right-0 top-full mt-1 py-1 rounded-lg border border-white/10 shadow-xl z-10 w-48"
-                    style="background-color: var(--color-surface-layer2)"
+                    style={{"background-color":"var(--color-surface-layer2)"}}
                   >
                     <Show
                       when={rolesWithoutOverrides().length > 0}
@@ -249,7 +249,7 @@ const ChannelPermissions: Component<ChannelPermissionsProps> = (props) => {
                         data-role-id={role.id}
                         data-role-name={role.is_default ? "@everyone" : role.name}
                         class="flex items-center gap-3 p-3 rounded-lg border border-white/10 hover:bg-white/5 transition-colors group"
-                        style="background-color: var(--color-surface-layer1)"
+                        style={{"background-color":"var(--color-surface-layer1)"}}
                       >
                         <div
                           class="w-3 h-3 rounded-full flex-shrink-0"

--- a/client/src/components/channels/ChannelSettingsModal.tsx
+++ b/client/src/components/channels/ChannelSettingsModal.tsx
@@ -64,7 +64,7 @@ const ChannelSettingsModal: Component<ChannelSettingsModalProps> = (props) => {
       >
         <div
           class="border border-white/10 rounded-2xl w-[550px] max-h-[80vh] flex flex-col shadow-2xl"
-          style="background-color: var(--color-surface-base)"
+          style={{"background-color":"var(--color-surface-base)"}}
         >
           {/* Header */}
           <div class="flex items-center justify-between px-6 py-4 border-b border-white/10">
@@ -129,7 +129,7 @@ const ChannelSettingsModal: Component<ChannelSettingsModalProps> = (props) => {
                   </label>
                   <div
                     class="px-3 py-2 rounded-lg border border-white/10 text-text-primary"
-                    style="background-color: var(--color-surface-layer1)"
+                    style={{"background-color":"var(--color-surface-layer1)"}}
                   >
                     {channel()?.name}
                   </div>

--- a/client/src/components/channels/CreateChannelModal.tsx
+++ b/client/src/components/channels/CreateChannelModal.tsx
@@ -91,7 +91,7 @@ const CreateChannelModal: Component<CreateChannelModalProps> = (props) => {
       <div class="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
         <div
           class="border border-white/10 rounded-2xl w-[440px] flex flex-col shadow-2xl"
-          style="background-color: var(--color-surface-base)"
+          style={{"background-color":"var(--color-surface-base)"}}
         >
           {/* Header */}
           <div class="flex items-center justify-between p-6 border-b border-white/10">
@@ -130,7 +130,7 @@ const CreateChannelModal: Component<CreateChannelModalProps> = (props) => {
                   >
                     <div
                       class="w-10 h-10 rounded-lg flex items-center justify-center"
-                      style="background-color: var(--color-surface-layer2)"
+                      style={{"background-color":"var(--color-surface-layer2)"}}
                     >
                       <Hash size={20} class="text-text-primary" />
                     </div>
@@ -157,7 +157,7 @@ const CreateChannelModal: Component<CreateChannelModalProps> = (props) => {
                   >
                     <div
                       class="w-10 h-10 rounded-lg flex items-center justify-center"
-                      style="background-color: var(--color-surface-layer2)"
+                      style={{"background-color":"var(--color-surface-layer2)"}}
                     >
                       <Mic size={20} class="text-text-primary" />
                     </div>
@@ -199,7 +199,7 @@ const CreateChannelModal: Component<CreateChannelModalProps> = (props) => {
                       channelType() === "text" ? "general-chat" : "voice-lounge"
                     }
                     class="w-full pl-11 pr-4 py-3 border border-white/10 rounded-lg text-text-input placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-accent-primary focus:border-transparent"
-                    style="background-color: var(--color-surface-layer2)"
+                    style={{"background-color":"var(--color-surface-layer2)"}}
                     maxLength={64}
                     disabled={isCreating()}
                     autofocus
@@ -214,9 +214,9 @@ const CreateChannelModal: Component<CreateChannelModalProps> = (props) => {
               <Show when={error()}>
                 <div
                   class="p-3 rounded-lg"
-                  style="background-color: var(--color-error-bg); border: 1px solid var(--color-error-border)"
+                  style={{"background-color":"var(--color-error-bg)","border":"1px solid var(--color-error-border)"}}
                 >
-                  <p class="text-sm" style="color: var(--color-error-text)">
+                  <p class="text-sm" style={{"color":"var(--color-error-text)"}}>
                     {error()}
                   </p>
                 </div>

--- a/client/src/components/chat/E2EESetupModal.tsx
+++ b/client/src/components/chat/E2EESetupModal.tsx
@@ -200,7 +200,7 @@ const E2EESetupModal: Component<E2EESetupModalProps> = (props) => {
         >
           <div
             class="border border-white/10 rounded-2xl w-[500px] shadow-2xl animate-[fadeIn_0.15s_ease-out]"
-            style="background-color: var(--color-surface-layer1)"
+            style={{"background-color":"var(--color-surface-layer1)"}}
             onClick={(e) => e.stopPropagation()}
           >
             {/* Header */}

--- a/client/src/components/clipboard/ClipboardToast.tsx
+++ b/client/src/components/clipboard/ClipboardToast.tsx
@@ -136,7 +136,7 @@ const ClipboardToast: Component<ClipboardToastProps> = (props) => {
     <Show when={currentStatus()?.has_sensitive_content}>
       <div
         class="fixed bottom-4 right-4 z-50 w-80 rounded-xl shadow-lg border border-white/10 overflow-hidden"
-        style="background-color: var(--color-surface-layer1)"
+        style={{"background-color":"var(--color-surface-layer1)"}}
       >
         {/* Header */}
         <div class="flex items-center justify-between px-4 py-3">
@@ -170,7 +170,7 @@ const ClipboardToast: Component<ClipboardToastProps> = (props) => {
             {/* Progress bar */}
             <div
               class="h-1.5 rounded-full overflow-hidden"
-              style="background-color: var(--color-surface-base)"
+              style={{"background-color":"var(--color-surface-base)"}}
             >
               <div
                 class="h-full rounded-full transition-all duration-1000"

--- a/client/src/components/clipboard/TamperWarningModal.tsx
+++ b/client/src/components/clipboard/TamperWarningModal.tsx
@@ -55,7 +55,7 @@ const TamperWarningModal: Component<TamperWarningModalProps> = (props) => {
       >
         <div
           class="border border-danger/30 rounded-2xl w-[450px] shadow-2xl"
-          style="background-color: var(--color-surface-layer1)"
+          style={{"background-color":"var(--color-surface-layer1)"}}
         >
           {/* Header */}
           <div class="flex items-center justify-between px-6 py-4 border-b border-white/10">
@@ -85,7 +85,7 @@ const TamperWarningModal: Component<TamperWarningModalProps> = (props) => {
 
             <div
               class="flex gap-3 p-3 rounded-lg"
-              style="background-color: var(--color-surface-base)"
+              style={{"background-color":"var(--color-surface-base)"}}
             >
               <div class="text-sm">
                 <p class="text-text-secondary">What you copied:</p>

--- a/client/src/components/guilds/CategoriesTab.tsx
+++ b/client/src/components/guilds/CategoriesTab.tsx
@@ -225,7 +225,7 @@ const CategoriesTab: Component<CategoriesTabProps> = (props) => {
           disabled={isCreating()}
         />
         <div class="flex rounded-lg border border-white/10 overflow-hidden shrink-0">
-          {(["mixed", "text", "voice"] as const).map((t) => (
+          <For each={["mixed", "text", "voice"] as const}>{(t) => (
             <button
               onClick={() => setNewCategoryType(t)}
               class="px-2 py-2 text-xs transition-colors"
@@ -237,7 +237,7 @@ const CategoriesTab: Component<CategoriesTabProps> = (props) => {
             >
               {typeIcon(t)}
             </button>
-          ))}
+          )}</For>
         </div>
         <button
           onClick={handleCreate}

--- a/client/src/components/guilds/CreateGuildModal.tsx
+++ b/client/src/components/guilds/CreateGuildModal.tsx
@@ -188,7 +188,7 @@ const CreateGuildModal: Component<CreateGuildModalProps> = (props) => {
       <div class="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
         <div
           class="border border-white/10 rounded-2xl w-[480px] max-h-[640px] flex flex-col shadow-2xl"
-          style="background-color: var(--color-surface-base)"
+          style={{"background-color":"var(--color-surface-base)"}}
         >
           {/* Header */}
           <div class="flex items-center justify-between p-6 border-b border-white/10">
@@ -237,7 +237,7 @@ const CreateGuildModal: Component<CreateGuildModalProps> = (props) => {
                     onInput={(e) => setName(e.currentTarget.value)}
                     placeholder="My Awesome Server"
                     class="w-full px-4 py-3 border border-white/10 rounded-lg text-text-input placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-accent-primary focus:border-transparent"
-                    style="background-color: var(--color-surface-layer2)"
+                    style={{"background-color":"var(--color-surface-layer2)"}}
                     maxLength={100}
                     disabled={isCreating()}
                     autofocus
@@ -258,7 +258,7 @@ const CreateGuildModal: Component<CreateGuildModalProps> = (props) => {
                     onInput={(e) => setDescription(e.currentTarget.value)}
                     placeholder="Tell us about your server..."
                     class="w-full px-4 py-3 border border-white/10 rounded-lg text-text-input placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-accent-primary focus:border-transparent resize-none"
-                    style="background-color: var(--color-surface-layer2)"
+                    style={{"background-color":"var(--color-surface-layer2)"}}
                     rows={3}
                     maxLength={1000}
                     disabled={isCreating()}
@@ -272,9 +272,9 @@ const CreateGuildModal: Component<CreateGuildModalProps> = (props) => {
                 <Show when={error()}>
                   <div
                     class="p-3 rounded-lg"
-                    style="background-color: var(--color-error-bg); border: 1px solid var(--color-error-border)"
+                    style={{"background-color":"var(--color-error-bg)","border":"1px solid var(--color-error-border)"}}
                   >
-                    <p class="text-sm" style="color: var(--color-error-text)">
+                    <p class="text-sm" style={{"color":"var(--color-error-text)"}}>
                       {error()}
                     </p>
                   </div>
@@ -400,7 +400,7 @@ const CreateGuildModal: Component<CreateGuildModalProps> = (props) => {
                     </Show>
 
                     <Show when={tagError()}>
-                      <p class="text-xs mt-2" style="color: var(--color-error-text)">
+                      <p class="text-xs mt-2" style={{"color":"var(--color-error-text)"}}>
                         {tagError()}
                       </p>
                     </Show>
@@ -550,9 +550,9 @@ const CreateGuildModal: Component<CreateGuildModalProps> = (props) => {
                 <Show when={error()}>
                   <div
                     class="p-3 rounded-lg"
-                    style="background-color: var(--color-error-bg); border: 1px solid var(--color-error-border)"
+                    style={{"background-color":"var(--color-error-bg)","border":"1px solid var(--color-error-border)"}}
                   >
-                    <p class="text-sm" style="color: var(--color-error-text)">
+                    <p class="text-sm" style={{"color":"var(--color-error-text)"}}>
                       {error()}
                     </p>
                   </div>

--- a/client/src/components/guilds/GuildSettingsModal.tsx
+++ b/client/src/components/guilds/GuildSettingsModal.tsx
@@ -147,7 +147,7 @@ const GuildSettingsModal: Component<GuildSettingsModalProps> = (props) => {
       >
         <div
           class="border border-white/10 rounded-2xl w-[90vw] max-w-[900px] overflow-x-hidden max-h-[85vh] flex flex-col shadow-2xl"
-          style="background-color: var(--color-surface-base)"
+          style={{"background-color":"var(--color-surface-base)"}}
         >
           {/* Header */}
           <div class="flex items-center justify-between px-6 py-4 border-b border-white/10">

--- a/client/src/components/guilds/InvitesTab.tsx
+++ b/client/src/components/guilds/InvitesTab.tsx
@@ -94,7 +94,7 @@ const InvitesTab: Component<InvitesTabProps> = (props) => {
       {/* Create Invite */}
       <div
         class="p-4 rounded-xl border border-white/10"
-        style="background-color: var(--color-surface-layer1)"
+        style={{"background-color":"var(--color-surface-layer1)"}}
       >
         <h3 class="text-sm font-semibold text-text-primary mb-3">
           Create New Invite
@@ -110,7 +110,7 @@ const InvitesTab: Component<InvitesTabProps> = (props) => {
                 setExpiresIn(e.currentTarget.value as InviteExpiry)
               }
               class="w-full px-3 py-2 rounded-lg border border-white/10 text-text-primary"
-              style="background-color: var(--color-surface-layer2)"
+              style={{"background-color":"var(--color-surface-layer2)"}}
             >
               <For each={EXPIRY_OPTIONS}>
                 {(opt) => <option value={opt.value}>{opt.label}</option>}
@@ -148,7 +148,7 @@ const InvitesTab: Component<InvitesTabProps> = (props) => {
               {(invite) => (
                 <div
                   class="flex items-center justify-between p-3 rounded-lg border border-white/5"
-                  style="background-color: var(--color-surface-layer1)"
+                  style={{"background-color":"var(--color-surface-layer1)"}}
                 >
                   <div class="flex-1 min-w-0">
                     <code data-testid="invite-code" class="text-sm text-accent-primary font-mono truncate block">

--- a/client/src/components/guilds/JoinGuildModal.tsx
+++ b/client/src/components/guilds/JoinGuildModal.tsx
@@ -75,7 +75,7 @@ const JoinGuildModal: Component<JoinGuildModalProps> = (props) => {
       <div class="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
         <div
           class="border border-white/10 rounded-2xl w-[480px] max-h-[600px] flex flex-col shadow-2xl"
-          style="background-color: var(--color-surface-base)"
+          style={{"background-color":"var(--color-surface-base)"}}
         >
           {/* Header */}
           <div class="flex items-center justify-between p-6 border-b border-white/10">
@@ -106,7 +106,7 @@ const JoinGuildModal: Component<JoinGuildModalProps> = (props) => {
                   }}
                   placeholder="https://example.com/invite/aBcD1234 or aBcD1234"
                   class="w-full px-4 py-3 border border-white/10 rounded-lg text-text-input placeholder:text-text-secondary focus:outline-none focus:ring-2 focus:ring-accent-primary focus:border-transparent"
-                  style="background-color: var(--color-surface-layer2)"
+                  style={{"background-color":"var(--color-surface-layer2)"}}
                   disabled={isJoining()}
                   autofocus
                 />
@@ -119,9 +119,9 @@ const JoinGuildModal: Component<JoinGuildModalProps> = (props) => {
               <Show when={error()}>
                 <div
                   class="p-3 rounded-lg"
-                  style="background-color: var(--color-error-bg); border: 1px solid var(--color-error-border)"
+                  style={{"background-color":"var(--color-error-bg)","border":"1px solid var(--color-error-border)"}}
                 >
-                  <p class="text-sm" style="color: var(--color-error-text)">
+                  <p class="text-sm" style={{"color":"var(--color-error-text)"}}>
                     {error()}
                   </p>
                 </div>

--- a/client/src/components/guilds/MemberRoleDropdown.tsx
+++ b/client/src/components/guilds/MemberRoleDropdown.tsx
@@ -116,7 +116,7 @@ const MemberRoleDropdown: Component<MemberRoleDropdownProps> = (props) => {
         <div
           data-testid="member-role-dropdown"
           class="absolute right-0 top-full mt-1 py-1 rounded-lg border border-white/10 shadow-xl z-20 min-w-[200px]"
-          style="background-color: var(--color-surface-layer2)"
+          style={{"background-color":"var(--color-surface-layer2)"}}
         >
           <Show when={canManageRolesPermission()}>
             <>

--- a/client/src/components/guilds/MembersTab.tsx
+++ b/client/src/components/guilds/MembersTab.tsx
@@ -146,7 +146,7 @@ const MembersTab: Component<MembersTabProps> = (props) => {
           onInput={(e) => setSearch(e.currentTarget.value)}
           placeholder="Search members..."
           class="w-full pl-10 pr-4 py-2 rounded-lg border border-white/10 text-text-primary placeholder-text-secondary"
-          style="background-color: var(--color-surface-layer1)"
+          style={{"background-color":"var(--color-surface-layer1)"}}
         />
       </div>
 

--- a/client/src/components/guilds/RoleEditor.tsx
+++ b/client/src/components/guilds/RoleEditor.tsx
@@ -247,7 +247,7 @@ const RoleEditor: Component<RoleEditorProps> = (props) => {
             disabled={isEveryoneRole()}
             placeholder="Enter role name..."
             class="w-full px-3 py-2 rounded-lg border border-white/10 text-text-primary placeholder-text-secondary disabled:opacity-50"
-            style="background-color: var(--color-surface-layer1)"
+            style={{"background-color":"var(--color-surface-layer1)"}}
           />
         </div>
 
@@ -264,7 +264,7 @@ const RoleEditor: Component<RoleEditorProps> = (props) => {
                 "border-accent-primary": color() === null,
                 "border-white/20": color() !== null,
               }}
-              style="background-color: var(--color-surface-layer1)"
+              style={{"background-color":"var(--color-surface-layer1)"}}
               title="No color"
             />
             <For each={colorPresets}>
@@ -321,7 +321,7 @@ const RoleEditor: Component<RoleEditorProps> = (props) => {
                                   canEdit && handlePermissionToggle(perm.bit)
                                 }
                                 class="mt-1 w-4 h-4 rounded border-white/20 text-accent-primary focus:ring-accent-primary focus:ring-offset-0"
-                                style="background-color: var(--color-surface-layer1)"
+                                style={{"background-color":"var(--color-surface-layer1)"}}
                               />
                               <div class="flex-1">
                                 <div class="text-sm font-medium text-text-primary">
@@ -366,7 +366,7 @@ const RoleEditor: Component<RoleEditorProps> = (props) => {
                 <Show when={showMemberPicker()}>
                   <div
                     class="absolute right-0 top-full mt-1 py-1 rounded-lg border border-white/10 shadow-xl z-10 w-64 max-h-48 overflow-y-auto"
-                    style="background-color: var(--color-surface-layer2)"
+                    style={{"background-color":"var(--color-surface-layer2)"}}
                   >
                     <Show
                       when={availableMembers().length > 0}

--- a/client/src/components/guilds/RolesTab.tsx
+++ b/client/src/components/guilds/RolesTab.tsx
@@ -191,7 +191,7 @@ const RolesTab: Component<RolesTabProps> = (props) => {
                     dropTargetId() === role.id,
                   "opacity-50": draggedRoleId() === role.id,
                 }}
-                style="background-color: var(--color-surface-layer1)"
+                style={{"background-color":"var(--color-surface-layer1)"}}
                 draggable={canManageRoles() && canReorderRole(role)}
                 onDragStart={(e) => handleDragStart(e, role.id)}
                 onDragOver={(e) => handleDragOver(e, role)}
@@ -253,7 +253,7 @@ const RolesTab: Component<RolesTabProps> = (props) => {
                         <Show when={menuOpen() === role.id}>
                           <div
                             class="absolute right-0 top-full mt-1 py-1 rounded-lg border border-white/10 shadow-xl z-10 min-w-[160px]"
-                            style="background-color: var(--color-surface-layer2)"
+                            style={{"background-color":"var(--color-surface-layer2)"}}
                           >
                             <button
                               onClick={() => {

--- a/client/src/components/guilds/SafetyTab.tsx
+++ b/client/src/components/guilds/SafetyTab.tsx
@@ -280,7 +280,7 @@ const SafetyTab: Component<SafetyTabProps> = (props) => {
       {/* Section Tabs */}
       <div
         class="flex gap-1 p-1 rounded-lg"
-        style="background-color: var(--color-surface-raised)"
+        style={{"background-color":"var(--color-surface-raised)"}}
       >
         <button
           onClick={() => setActiveSection("categories")}
@@ -353,7 +353,7 @@ const SafetyTab: Component<SafetyTabProps> = (props) => {
                 return (
                   <div
                     class="flex items-center justify-between p-4 rounded-xl border border-white/10"
-                    style="background-color: var(--color-surface-raised)"
+                    style={{"background-color":"var(--color-surface-raised)"}}
                   >
                     <div class="flex-1">
                       <div class="flex items-center gap-2">
@@ -446,7 +446,7 @@ const SafetyTab: Component<SafetyTabProps> = (props) => {
             <Show when={showAddPattern()}>
               <div
                 class="p-4 rounded-xl border border-accent-primary/30 space-y-3"
-                style="background-color: var(--color-surface-raised)"
+                style={{"background-color":"var(--color-surface-raised)"}}
               >
                 <div>
                   <label class="text-sm text-text-secondary block mb-1">
@@ -511,7 +511,7 @@ const SafetyTab: Component<SafetyTabProps> = (props) => {
               {(pattern) => (
                 <div
                   class="flex items-center justify-between p-3 rounded-lg border border-white/5"
-                  style="background-color: var(--color-surface-raised)"
+                  style={{"background-color":"var(--color-surface-raised)"}}
                 >
                   <div class="flex-1 min-w-0">
                     <div class="flex items-center gap-2">
@@ -655,7 +655,7 @@ const SafetyTab: Component<SafetyTabProps> = (props) => {
               {(entry) => (
                 <div
                   class="p-3 rounded-lg border border-white/5 space-y-1"
-                  style="background-color: var(--color-surface-raised)"
+                  style={{"background-color":"var(--color-surface-raised)"}}
                 >
                   <div class="flex items-center justify-between">
                     <div class="flex items-center gap-2">

--- a/client/src/components/home/HomeSidebar.tsx
+++ b/client/src/components/home/HomeSidebar.tsx
@@ -53,7 +53,7 @@ const HomeSidebar: Component = () => {
         <button
           onClick={() => setShowDMSearch(true)}
           class="w-full px-3 py-2 rounded-xl text-sm text-text-muted text-left outline-none border border-white/5"
-          style="background-color: var(--color-surface-base)"
+          style={{"background-color":"var(--color-surface-base)"}}
         >
           Find conversation...
         </button>

--- a/client/src/components/home/NewMessageModal.tsx
+++ b/client/src/components/home/NewMessageModal.tsx
@@ -86,7 +86,7 @@ const NewMessageModal: Component<NewMessageModalProps> = (props) => {
       >
         <div
           class="border border-white/10 rounded-2xl w-full max-w-md flex flex-col max-h-[80vh]"
-          style="background-color: var(--color-surface-base)"
+          style={{"background-color":"var(--color-surface-base)"}}
           onClick={(e) => e.stopPropagation()}
         >
           {/* Header */}
@@ -111,7 +111,7 @@ const NewMessageModal: Component<NewMessageModalProps> = (props) => {
                 onInput={(e) => setSearch(e.currentTarget.value)}
                 placeholder="Search friends..."
                 class="w-full pl-9 pr-4 py-2 border border-white/10 rounded-lg text-text-input placeholder-text-secondary focus:outline-none focus:border-accent-primary"
-                style="background-color: var(--color-surface-layer1)"
+                style={{"background-color":"var(--color-surface-layer1)"}}
               />
             </div>
             <Show when={selectedIds().length > 0}>
@@ -149,7 +149,7 @@ const NewMessageModal: Component<NewMessageModalProps> = (props) => {
           <Show when={error()}>
             <div
               class="mx-4 mb-2 p-3 rounded-lg text-sm"
-              style="background-color: var(--color-error-bg); border: 1px solid var(--color-error-border); color: var(--color-error-text)"
+              style={{"background-color":"var(--color-error-bg)","border":"1px solid var(--color-error-border)","color":"var(--color-error-text)"}}
             >
               {error()}
             </div>

--- a/client/src/components/layout/CommandPalette.tsx
+++ b/client/src/components/layout/CommandPalette.tsx
@@ -153,13 +153,14 @@ const CommandPalette: Component = () => {
         setSelectedIndex((prev) => (prev > 0 ? prev - 1 : prev));
         break;
 
-      case "Enter":
+      case "Enter": {
         e.preventDefault();
         const selected = filteredItems()[selectedIndex()];
         if (selected) {
           selected.action();
         }
         break;
+      }
     }
   };
 
@@ -193,7 +194,7 @@ const CommandPalette: Component = () => {
         <div
           data-testid="command-palette"
           class="w-[600px] border border-white/10 shadow-2xl rounded-xl overflow-hidden animate-slide-up"
-          style="background-color: var(--color-surface-layer2)"
+          style={{"background-color":"var(--color-surface-layer2)"}}
         >
           {/* Input */}
           <div class="border-b border-white/5">

--- a/client/src/components/layout/Sidebar.tsx
+++ b/client/src/components/layout/Sidebar.tsx
@@ -125,7 +125,7 @@ const Sidebar: Component<SidebarProps> = (props) => {
           <button
             onClick={() => setShowSearch(true)}
             class="w-full flex items-center gap-2 px-3 py-2 rounded-xl text-sm text-text-muted border border-white/5 hover:border-white/10 transition-colors"
-            style="background-color: var(--color-surface-base)"
+            style={{"background-color":"var(--color-surface-base)"}}
           >
             <Search class="w-4 h-4" />
             <span>Search messages...</span>
@@ -134,7 +134,7 @@ const Sidebar: Component<SidebarProps> = (props) => {
         <Show when={!activeGuild()}>
           <div
             class="w-full px-3 py-2 rounded-xl text-sm text-text-muted border border-white/5"
-            style="background-color: var(--color-surface-base)"
+            style={{"background-color":"var(--color-surface-base)"}}
           >
             Search...
           </div>

--- a/client/src/components/messages/MessageActions.tsx
+++ b/client/src/components/messages/MessageActions.tsx
@@ -5,7 +5,7 @@
  * Appears at the top-right of messages.
  */
 
-import { Component, createSignal, Show } from "solid-js";
+import { Component, createSignal, Show, For } from "solid-js";
 import { SmilePlus, MoreHorizontal, MessageSquareMore, Pencil } from "lucide-solid";
 import PositionedEmojiPicker from "@/components/emoji/PositionedEmojiPicker";
 
@@ -47,7 +47,7 @@ const MessageActions: Component<MessageActionsProps> = (props) => {
   return (
     <div data-testid="message-action-bar" class="absolute top-0 right-4 -translate-y-1/2 flex items-center gap-1 bg-surface-layer2 border border-white/10 rounded-lg shadow-xl px-1 py-1 opacity-0 group-hover:opacity-100 transition-opacity">
       {/* Quick emoji reactions */}
-      {QUICK_EMOJIS.map((emoji) => (
+      <For each={QUICK_EMOJIS}>{(emoji) => (
         <button
           class="w-7 h-7 flex items-center justify-center rounded hover:bg-white/10 transition-colors"
           onClick={() => handleQuickReaction(emoji)}
@@ -56,7 +56,7 @@ const MessageActions: Component<MessageActionsProps> = (props) => {
         >
           <span class="text-base leading-none">{emoji}</span>
         </button>
-      ))}
+      )}</For>
 
       {/* Emoji picker button */}
       <button

--- a/client/src/components/messages/MessageInput.tsx
+++ b/client/src/components/messages/MessageInput.tsx
@@ -557,7 +557,7 @@ const MessageInput: Component<MessageInputProps> = (props) => {
         </div>
       </Show>
 
-      <div class="relative flex flex-col rounded-xl border border-white/5 focus-within:border-accent-primary/30 transition-colors" style="background-color: var(--color-surface-layer2)">
+      <div class="relative flex flex-col rounded-xl border border-white/5 focus-within:border-accent-primary/30 transition-colors" style={{"background-color":"var(--color-surface-layer2)"}}>
         {/* Formatting toolbar */}
         <div class="flex items-center gap-1 px-2 py-1 border-b border-white/5">
           <button type="button" class="p-1.5 rounded hover:bg-white/10 text-text-primary/50 hover:text-text-primary transition-colors" title="Bold (Ctrl+B)" aria-label="Bold (Ctrl+B)" onClick={() => insertFormatting("**", "**")}>
@@ -649,7 +649,7 @@ const MessageInput: Component<MessageInputProps> = (props) => {
 
       {/* Error display */}
       <Show when={messagesState.error}>
-        <div class="mt-2 text-sm" style="color: var(--color-error-text)">
+        <div class="mt-2 text-sm" style={{"color":"var(--color-error-text)"}}>
           Failed to send: {messagesState.error}
         </div>
       </Show>

--- a/client/src/components/messages/MessageItem.tsx
+++ b/client/src/components/messages/MessageItem.tsx
@@ -172,8 +172,10 @@ function highlightMentions(text: string): string {
     },
   );
 
-  // Restore inline code spans
+  // Restore inline code spans. The \x00 sentinel is a deliberate,
+  // non-user-reachable placeholder (matches the protect step above).
   processed = processed.replace(
+    // eslint-disable-next-line no-control-regex
     /\x00CODE(\d+)\x00/g,
     (_, idx) => codeSpans[parseInt(idx)],
   );
@@ -768,7 +770,7 @@ const MessageItem: Component<MessageItemProps> = (props) => {
         {/* Attachments */}
         <Show when={props.message.attachments?.length > 0}>
           <div class="mt-2 flex flex-wrap gap-3">
-            {props.message.attachments.map((attachment) => (
+            <For each={props.message.attachments}>{(attachment) => (
               <div class="group/attachment relative">
                 <Show
                   when={isImage(attachment.mime_type)}
@@ -899,7 +901,7 @@ const MessageItem: Component<MessageItemProps> = (props) => {
                   })()}
                 </Show>
               </div>
-            ))}
+            )}</For>
           </div>
         </Show>
 

--- a/client/src/components/messages/MessageList.tsx
+++ b/client/src/components/messages/MessageList.tsx
@@ -607,8 +607,7 @@ const MessageList: Component<MessageListProps> = (props) => {
                 >
                   {(() => {
                     const data = item();
-                    return data ? (
-                      <>
+                    return <Show when={data}><>
                         <Show when={data.isFirstUnread}>
                           <div class="flex items-center gap-2 px-4 py-1 my-1">
                             <div class="flex-1 h-px bg-accent-danger" />
@@ -624,8 +623,7 @@ const MessageList: Component<MessageListProps> = (props) => {
                           guildId={props.guildId}
                           threadsEnabled={areThreadsEnabled(props.guildId)}
                         />
-                      </>
-                    ) : null;
+                      </></Show>;
                   })()}
                 </div>
               );

--- a/client/src/components/messages/TypingIndicator.tsx
+++ b/client/src/components/messages/TypingIndicator.tsx
@@ -29,15 +29,15 @@ const TypingIndicator: Component<TypingIndicatorProps> = (props) => {
           <div class="flex gap-0.5">
             <span
               class="w-1.5 h-1.5 bg-text-muted rounded-full animate-bounce"
-              style="animation-delay: 0ms"
+              style={{"animation-delay":"0ms"}}
             />
             <span
               class="w-1.5 h-1.5 bg-text-muted rounded-full animate-bounce"
-              style="animation-delay: 150ms"
+              style={{"animation-delay":"150ms"}}
             />
             <span
               class="w-1.5 h-1.5 bg-text-muted rounded-full animate-bounce"
-              style="animation-delay: 300ms"
+              style={{"animation-delay":"300ms"}}
             />
           </div>
           <span>{typingText()}</span>

--- a/client/src/components/modals/BlockConfirmModal.tsx
+++ b/client/src/components/modals/BlockConfirmModal.tsx
@@ -57,7 +57,7 @@ const BlockConfirmModal: Component<BlockConfirmModalProps> = (props) => {
 
         <div
           class="relative rounded-xl border border-white/10 w-[400px] shadow-2xl animate-[fadeIn_0.15s_ease-out]"
-          style="background-color: var(--color-surface-layer1)"
+          style={{"background-color":"var(--color-surface-layer1)"}}
         >
           {/* Header */}
           <div class="flex items-center justify-between px-5 py-4 border-b border-white/10">

--- a/client/src/components/modals/ReportModal.tsx
+++ b/client/src/components/modals/ReportModal.tsx
@@ -85,7 +85,7 @@ const ReportModal: Component<ReportModalProps> = (props) => {
 
         <div
           class="relative rounded-xl border border-white/10 w-[440px] shadow-2xl animate-[fadeIn_0.15s_ease-out]"
-          style="background-color: var(--color-surface-layer1)"
+          style={{"background-color":"var(--color-surface-layer1)"}}
         >
           {/* Header */}
           <div class="flex items-center justify-between px-5 py-4 border-b border-white/10">

--- a/client/src/components/pages/MarkdownCheatSheet.tsx
+++ b/client/src/components/pages/MarkdownCheatSheet.tsx
@@ -4,7 +4,7 @@
  * Quick reference panel for markdown syntax.
  */
 
-import { Show, createSignal } from "solid-js";
+import { Show, createSignal, For } from "solid-js";
 import { ChevronDown, ChevronUp } from "lucide-solid";
 
 interface MarkdownCheatSheetProps {
@@ -89,23 +89,23 @@ export default function MarkdownCheatSheet(props: MarkdownCheatSheetProps) {
 
       <Show when={isExpanded()}>
         <div class="px-4 pb-4 space-y-4">
-          {sections.map((section) => (
+          <For each={sections}>{(section) => (
             <div>
               <h4 class="text-xs font-semibold text-zinc-400 uppercase tracking-wide mb-2">
                 {section.title}
               </h4>
               <div class="space-y-1">
-                {section.items.map((item) => (
+                <For each={section.items}>{(item) => (
                   <div class="flex items-start gap-3 text-xs">
                     <code class="bg-zinc-900 px-1.5 py-0.5 rounded text-emerald-400 font-mono whitespace-pre">
                       {item.syntax}
                     </code>
                     <span class="text-zinc-400">{item.description}</span>
                   </div>
-                ))}
+                )}</For>
               </div>
             </div>
-          ))}
+          )}</For>
         </div>
       </Show>
     </div>

--- a/client/src/components/pages/PageEditor.tsx
+++ b/client/src/components/pages/PageEditor.tsx
@@ -344,7 +344,7 @@ export default function PageEditor(props: PageEditorProps) {
 
       {/* Toolbar */}
       <div class="px-4 py-2 flex items-center gap-1 border-b border-zinc-700">
-        {toolbarButtons.map((btn) => (
+        <For each={toolbarButtons}>{(btn) => (
           <button
             type="button"
             onClick={btn.action}
@@ -353,7 +353,7 @@ export default function PageEditor(props: PageEditorProps) {
           >
             <btn.icon class="w-4 h-4" />
           </button>
-        ))}
+        )}</For>
         <div class="flex-1" />
         <div class="text-xs text-zinc-500 mr-2">
           {contentSize().toLocaleString()} / {MAX_CONTENT_SIZE.toLocaleString()}{" "}

--- a/client/src/components/settings/MfaSetupModal.tsx
+++ b/client/src/components/settings/MfaSetupModal.tsx
@@ -195,7 +195,7 @@ const MfaSetupModal: Component<MfaSetupModalProps> = (props) => {
                 <Show when={error()}>
                   <div
                     class="p-3 rounded-md text-sm"
-                    style="background-color: var(--color-error-bg); border: 1px solid var(--color-error-border); color: var(--color-error-text)"
+                    style={{"background-color":"var(--color-error-bg)","border":"1px solid var(--color-error-border)","color":"var(--color-error-text)"}}
                   >
                     {error()}
                   </div>
@@ -254,7 +254,7 @@ const MfaSetupModal: Component<MfaSetupModalProps> = (props) => {
                 <Show when={error()}>
                   <div
                     class="p-3 rounded-md text-sm"
-                    style="background-color: var(--color-error-bg); border: 1px solid var(--color-error-border); color: var(--color-error-text)"
+                    style={{"background-color":"var(--color-error-bg)","border":"1px solid var(--color-error-border)","color":"var(--color-error-text)"}}
                   >
                     {error()}
                   </div>

--- a/client/src/components/settings/RecoveryKeyModal.tsx
+++ b/client/src/components/settings/RecoveryKeyModal.tsx
@@ -72,7 +72,7 @@ const RecoveryKeyModal: Component<RecoveryKeyModalProps> = (props) => {
       <div class="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50">
         <div
           class="border border-white/10 rounded-2xl w-[500px] shadow-2xl animate-[fadeIn_0.15s_ease-out]"
-          style="background-color: var(--color-surface-layer1)"
+          style={{"background-color":"var(--color-surface-layer1)"}}
         >
           {/* Header */}
           <div class="flex items-center justify-between px-6 py-4 border-b border-white/10">

--- a/client/src/components/settings/SecuritySettings.tsx
+++ b/client/src/components/settings/SecuritySettings.tsx
@@ -472,7 +472,7 @@ const SecuritySettings: Component<SecuritySettingsProps> = (props) => {
               <Show when={disableError()}>
                 <div
                   class="p-2 mb-3 rounded-md text-sm"
-                  style="background-color: var(--color-error-bg); border: 1px solid var(--color-error-border); color: var(--color-error-text)"
+                  style={{"background-color":"var(--color-error-bg)","border":"1px solid var(--color-error-border)","color":"var(--color-error-text)"}}
                 >
                   {disableError()}
                 </div>

--- a/client/src/components/settings/SettingsModal.tsx
+++ b/client/src/components/settings/SettingsModal.tsx
@@ -143,7 +143,7 @@ const SettingsModal: Component<SettingsModalProps> = (props) => {
       >
         <div
           class="border border-white/10 rounded-2xl w-[700px] max-h-[600px] flex flex-col shadow-2xl animate-[fadeIn_0.15s_ease-out]"
-          style="background-color: var(--color-surface-layer1)"
+          style={{"background-color":"var(--color-surface-layer1)"}}
         >
           {/* Header */}
           <div class="flex items-center justify-between px-6 py-4 border-b border-white/10">

--- a/client/src/components/social/AddFriend.tsx
+++ b/client/src/components/social/AddFriend.tsx
@@ -104,7 +104,7 @@ const AddFriend: Component<AddFriendProps> = (props) => {
                 onInput={(e) => setUsername(e.currentTarget.value)}
                 placeholder="Enter username..."
                 class="w-full px-4 py-2 border border-white/10 rounded-lg text-text-input placeholder-text-secondary focus:outline-none focus:border-accent-primary transition-colors"
-                style="background-color: var(--color-surface-layer1)"
+                style={{"background-color":"var(--color-surface-layer1)"}}
                 disabled={isSubmitting()}
                 autocomplete="off"
               />
@@ -114,7 +114,7 @@ const AddFriend: Component<AddFriendProps> = (props) => {
             {error() && (
               <div
                 class="p-3 rounded-lg text-sm"
-                style="background-color: var(--color-error-bg); border: 1px solid var(--color-error-border); color: var(--color-error-text)"
+                style={{"background-color":"var(--color-error-bg)","border":"1px solid var(--color-error-border)","color":"var(--color-error-text)"}}
               >
                 {error()}
               </div>

--- a/client/src/components/ui/KeyboardShortcutsDialog.tsx
+++ b/client/src/components/ui/KeyboardShortcutsDialog.tsx
@@ -105,7 +105,7 @@ const KeyboardShortcutsDialog: Component<KeyboardShortcutsDialogProps> = (props)
     >
       <div
         class="w-[560px] max-h-[80vh] border border-white/10 shadow-2xl rounded-xl overflow-hidden flex flex-col"
-        style="background-color: var(--color-surface-layer2)"
+        style={{"background-color":"var(--color-surface-layer2)"}}
       >
         {/* Header */}
         <div class="px-6 py-4 border-b border-white/5 flex items-center justify-between">

--- a/client/src/components/voice/AudioDeviceSettings.tsx
+++ b/client/src/components/voice/AudioDeviceSettings.tsx
@@ -524,9 +524,9 @@ const AudioDeviceSettings: Component<AudioDeviceSettingsProps> = (props) => {
           <Show when={error() && !isLoading()}>
             <div
               class="px-4 py-3 rounded-xl"
-              style="background-color: var(--color-error-bg); border: 1px solid var(--color-error-border)"
+              style={{"background-color":"var(--color-error-bg)","border":"1px solid var(--color-error-border)"}}
             >
-              <p class="text-sm" style="color: var(--color-error-text)">
+              <p class="text-sm" style={{"color":"var(--color-error-text)"}}>
                 {error()}
               </p>
             </div>

--- a/client/src/components/voice/MicTestPanel.tsx
+++ b/client/src/components/voice/MicTestPanel.tsx
@@ -274,7 +274,7 @@ function MicTestPanel(props: MicTestPanelProps) {
       <Show when={error()}>
         <div
           class="p-3 rounded-lg text-sm"
-          style="background-color: var(--color-error-bg); border: 1px solid var(--color-error-border); color: var(--color-error-text)"
+          style={{"background-color":"var(--color-error-bg)","border":"1px solid var(--color-error-border)","color":"var(--color-error-text)"}}
         >
           {getErrorMessage(error()!)}
         </div>

--- a/client/src/components/voice/MicrophoneTest.tsx
+++ b/client/src/components/voice/MicrophoneTest.tsx
@@ -15,7 +15,7 @@ function MicrophoneTest(props: Props) {
     <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
       <div
         class="rounded-xl shadow-xl max-w-md w-full mx-4 border border-white/10"
-        style="background-color: var(--color-surface-layer2)"
+        style={{"background-color":"var(--color-surface-layer2)"}}
       >
         {/* Header */}
         <div class="flex items-center justify-between p-4 border-b border-white/5">

--- a/client/src/lib/tauri/auth.ts
+++ b/client/src/lib/tauri/auth.ts
@@ -515,7 +515,7 @@ export async function uploadAvatar(file: File): Promise<User> {
       "[uploadAvatar] Failed to parse success response:",
       parseError,
     );
-    throw new Error("Server returned invalid response");
+    throw new Error("Server returned invalid response", { cause: parseError });
   }
 }
 

--- a/client/src/lib/tauri/dms.ts
+++ b/client/src/lib/tauri/dms.ts
@@ -84,7 +84,7 @@ export async function uploadDMAvatar(
       "[uploadDMAvatar] Failed to parse success response:",
       parseError,
     );
-    throw new Error("Server returned invalid response");
+    throw new Error("Server returned invalid response", { cause: parseError });
   }
 }
 

--- a/client/src/lib/tauri/guilds.ts
+++ b/client/src/lib/tauri/guilds.ts
@@ -459,7 +459,7 @@ export async function uploadGuildEmoji(
       "[uploadGuildEmoji] Failed to parse success response:",
       parseError,
     );
-    throw new Error("Server returned invalid response");
+    throw new Error("Server returned invalid response", { cause: parseError });
   }
 }
 

--- a/client/src/lib/tauri/messages.ts
+++ b/client/src/lib/tauri/messages.ts
@@ -256,7 +256,7 @@ export async function uploadFile(messageId: string, file: File): Promise<any> {
     return await response.json();
   } catch (parseError) {
     console.error("[uploadFile] Failed to parse success response:", parseError);
-    throw new Error("Server returned invalid response");
+    throw new Error("Server returned invalid response", { cause: parseError });
   }
 }
 
@@ -330,7 +330,7 @@ export async function uploadMessageWithFile(
       "[uploadMessageWithFile] Failed to parse success response:",
       parseError,
     );
-    throw new Error("Server returned invalid response");
+    throw new Error("Server returned invalid response", { cause: parseError });
   }
 }
 

--- a/client/src/lib/webrtc/browser.ts
+++ b/client/src/lib/webrtc/browser.ts
@@ -212,6 +212,7 @@ export class BrowserVoiceAdapter implements VoiceAdapter {
           );
           throw new Error(
             "Failed to connect to server. Please refresh the page.",
+            { cause: err },
           );
         }
       }

--- a/client/src/pages/ThemeDemo.tsx
+++ b/client/src/pages/ThemeDemo.tsx
@@ -1,4 +1,4 @@
-import { Component } from "solid-js";
+import { Component, For } from "solid-js";
 import { availableThemes, theme as currentTheme, setTheme } from "@/stores/theme";
 import CodeBlock from "@/components/ui/CodeBlock";
 
@@ -44,7 +44,7 @@ print(calculate_fibonacci(10))`,
           </p>
 
           <div class="space-y-3">
-            {availableThemes.map((theme) => (
+            <For each={availableThemes}>{(theme) => (
               <button
                 onClick={() => setTheme(theme.id)}
                 class="w-full text-left p-4 rounded-xl border-2 transition-all"
@@ -84,7 +84,7 @@ print(calculate_fibonacci(10))`,
                   </div>
                 </div>
               </button>
-            ))}
+            )}</For>
           </div>
         </div>
 

--- a/client/src/stores/auth.ts
+++ b/client/src/stores/auth.ts
@@ -261,11 +261,11 @@ export async function login(
         mfaRequired: true,
         serverUrl,
       });
-      throw new Error("MFA_REQUIRED");
+      throw new Error("MFA_REQUIRED", { cause: err });
     }
 
     setAuthState({ isLoading: false, error });
-    throw new Error(error);
+    throw new Error(error, { cause: err });
   }
 }
 
@@ -321,7 +321,7 @@ export async function register(
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);
     setAuthState({ isLoading: false, error });
-    throw new Error(error);
+    throw new Error(error, { cause: err });
   }
 }
 
@@ -384,7 +384,7 @@ export async function loginWithOidc(
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);
     setAuthState({ isLoading: false, error });
-    throw new Error(error);
+    throw new Error(error, { cause: err });
   }
 }
 

--- a/client/src/stores/favorites.ts
+++ b/client/src/stores/favorites.ts
@@ -183,7 +183,7 @@ export async function addFavorite(
       message: "Could not add favorite. Please try again.",
       duration: 8000,
     });
-    throw new Error(message);
+    throw new Error(message, { cause: error });
   }
 }
 
@@ -202,7 +202,7 @@ export async function removeFavorite(channelId: string): Promise<boolean> {
       message: "Could not remove favorite. Please try again.",
       duration: 8000,
     });
-    throw new Error(message);
+    throw new Error(message, { cause: error });
   }
 }
 

--- a/client/src/stores/websocket/index.ts
+++ b/client/src/stores/websocket/index.ts
@@ -1357,7 +1357,7 @@ async function handleServerEvent(event: ServerEvent): Promise<void> {
       }
       break;
 
-    case "command_response_timeout":
+    case "command_response_timeout": {
       console.warn("[WebSocket] Command response timeout:", event.command_name);
       const { showToast } = await import("@/components/ui/Toast");
       showToast({
@@ -1368,6 +1368,7 @@ async function handleServerEvent(event: ServerEvent): Promise<void> {
         id: `cmd-timeout-${event.command_name}`,
       });
       break;
+    }
 
     default:
       console.log("Unhandled server event:", event.type);

--- a/client/src/views/ForgotPassword.tsx
+++ b/client/src/views/ForgotPassword.tsx
@@ -94,7 +94,7 @@ const ForgotPassword: Component = () => {
               <div
                 role="alert"
                 class="p-3 rounded-md text-sm"
-                style="background-color: var(--color-error-bg); border: 1px solid var(--color-error-border); color: var(--color-error-text)"
+                style={{"background-color":"var(--color-error-bg)","border":"1px solid var(--color-error-border)","color":"var(--color-error-text)"}}
               >
                 {error()}
               </div>
@@ -129,7 +129,7 @@ const ForgotPassword: Component = () => {
         <Show when={success()}>
           <div
             class="p-4 rounded-md text-sm mb-4"
-            style="background-color: var(--color-success-bg, rgba(34,197,94,0.1)); border: 1px solid var(--color-success-border, rgba(34,197,94,0.3)); color: var(--color-success-text, #22c55e)"
+            style={{"background-color":"var(--color-success-bg, rgba(34,197,94,0.1))","border":"1px solid var(--color-success-border, rgba(34,197,94,0.3))","color":"var(--color-success-text, #22c55e)"}}
           >
             If an account with that email exists, a reset code has been sent.
             Check your inbox.

--- a/client/src/views/InviteJoin.tsx
+++ b/client/src/views/InviteJoin.tsx
@@ -41,11 +41,11 @@ const InviteJoin: Component = () => {
   return (
     <div
       class="h-screen flex items-center justify-center"
-      style="background-color: var(--color-surface-base)"
+      style={{"background-color":"var(--color-surface-base)"}}
     >
       <div
         class="text-center p-8 rounded-2xl border border-white/10 max-w-md"
-        style="background-color: var(--color-surface-layer1)"
+        style={{"background-color":"var(--color-surface-layer1)"}}
       >
         <Show when={status() === "loading"}>
           <div class="text-text-primary text-lg mb-2">Joining guild...</div>

--- a/client/src/views/Login.tsx
+++ b/client/src/views/Login.tsx
@@ -246,7 +246,7 @@ const Login: Component = () => {
               <div
                 role="alert"
                 class="p-3 rounded-md text-sm"
-                style="background-color: var(--color-error-bg); border: 1px solid var(--color-error-border); color: var(--color-error-text)"
+                style={{"background-color":"var(--color-error-bg)","border":"1px solid var(--color-error-border)","color":"var(--color-error-text)"}}
               >
                 {error()}
               </div>
@@ -378,7 +378,7 @@ const Login: Component = () => {
                   role="alert"
                   class="p-3 rounded-md text-sm"
                   data-testid="login-error"
-                  style="background-color: var(--color-error-bg); border: 1px solid var(--color-error-border); color: var(--color-error-text)"
+                  style={{"background-color":"var(--color-error-bg)","border":"1px solid var(--color-error-border)","color":"var(--color-error-text)"}}
                 >
                   {error()}
                 </div>
@@ -410,7 +410,7 @@ const Login: Component = () => {
             <div
               role="alert"
               class="p-3 rounded-md text-sm"
-              style="background-color: var(--color-error-bg); border: 1px solid var(--color-error-border); color: var(--color-error-text)"
+              style={{"background-color":"var(--color-error-bg)","border":"1px solid var(--color-error-border)","color":"var(--color-error-text)"}}
             >
               {error()}
             </div>

--- a/client/src/views/Main.tsx
+++ b/client/src/views/Main.tsx
@@ -167,7 +167,7 @@ const Main: Component = () => {
           />
           <div
             class="relative w-[640px] h-[70vh] rounded-xl border border-white/10 shadow-2xl overflow-hidden"
-            style="background-color: var(--color-surface-layer2)"
+            style={{"background-color":"var(--color-surface-layer2)"}}
           >
             <SearchPanel
               mode="global"

--- a/client/src/views/Register.tsx
+++ b/client/src/views/Register.tsx
@@ -367,7 +367,7 @@ const Register: Component = () => {
               <div
                 role="alert"
                 class="p-3 rounded-md text-sm"
-                style="background-color: var(--color-error-bg); border: 1px solid var(--color-error-border); color: var(--color-error-text)"
+                style={{"background-color":"var(--color-error-bg)","border":"1px solid var(--color-error-border)","color":"var(--color-error-text)"}}
               >
                 {error()}
               </div>
@@ -405,7 +405,7 @@ const Register: Component = () => {
           <div
             role="alert"
             class="p-3 rounded-md text-sm"
-            style="background-color: var(--color-error-bg); border: 1px solid var(--color-error-border); color: var(--color-error-text)"
+            style={{"background-color":"var(--color-error-bg)","border":"1px solid var(--color-error-border)","color":"var(--color-error-text)"}}
           >
             {error()}
           </div>

--- a/client/src/views/ResetPassword.tsx
+++ b/client/src/views/ResetPassword.tsx
@@ -147,7 +147,7 @@ const ResetPassword: Component = () => {
               <div
                 role="alert"
                 class="p-3 rounded-md text-sm"
-                style="background-color: var(--color-error-bg); border: 1px solid var(--color-error-border); color: var(--color-error-text)"
+                style={{"background-color":"var(--color-error-bg)","border":"1px solid var(--color-error-border)","color":"var(--color-error-text)"}}
               >
                 {error()}
               </div>
@@ -182,7 +182,7 @@ const ResetPassword: Component = () => {
         <Show when={success()}>
           <div
             class="p-4 rounded-md text-sm mb-4"
-            style="background-color: var(--color-success-bg, rgba(34,197,94,0.1)); border: 1px solid var(--color-success-border, rgba(34,197,94,0.3)); color: var(--color-success-text, #22c55e)"
+            style={{"background-color":"var(--color-success-bg, rgba(34,197,94,0.1))","border":"1px solid var(--color-success-border, rgba(34,197,94,0.3))","color":"var(--color-success-text, #22c55e)"}}
           >
             Password has been reset successfully. You can now log in with your
             new password.

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "useDefineForClassFields": true,
     "module": "ESNext",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2020", "ES2022.Error", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,


### PR DESCRIPTION
## Summary
The client accumulated **26 eslint errors** (+ ~234 warnings) because CI's Frontend job ran `tsc`/tests/build but **not lint**. This clears the errors and adds the gate.

- **`eslint --fix`** resolved most `solid/style-prop` warnings (`style="..."` string → object form, Solid-idiomatic). Verified: `tsc` clean, build ok, all 610 tests pass unchanged.
- **26 errors fixed by hand** where `--fix` couldn't:
  - `preserve-caught-error` (14): rethrows now attach the caught error as `cause`. Required the `ES2022.Error` lib for the `Error(msg, { cause })` overload — added to `tsconfig.json` (runtime supported on every browser the app targets; build target is esnext).
  - `no-case-declarations` (2): `switch` cases with lexical declarations are now brace-scoped (removes a real cross-case leak footgun).
  - `no-control-regex` (1): the deliberate `\x00` code-span sentinel in the message renderer gets a scoped `eslint-disable`.
  - `no-useless-assignment` (1): dropped a dead `= null` initializer.
- **CI**: added a `Lint` step to the Frontend job. `eslint src` exits non-zero only on **errors**, so the 136 remaining cosmetic warnings don't block CI, but any new error will.

Pure consistency cleanup — no runtime behavior change (no CHANGELOG per convention).

## Test plan
- [x] `bun run lint` — 0 errors (136 warnings)
- [x] `tsc --noEmit` clean
- [x] `bun run test:run` — 610 pass
- [x] `bun run build` ok
- [ ] CI (now includes the lint gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdxjK7ngJvdtdREoJJrr3H