### PR TITLE
docs(spec): design specs for the top-6 feature gaps

### DIFF
--- a/docs/superpowers/specs/2026-07-07-forum-and-announcement-channels-design.md
+++ b/docs/superpowers/specs/2026-07-07-forum-and-announcement-channels-design.md
@@ -33,14 +33,21 @@ mechanism, the only genuinely new machinery here.
 
 ## Data Model
 
-```sql
--- migration: 20260707000002_forum_announcement_channels.sql
+`channel_type` is a **Postgres ENUM** (`CREATE TYPE channel_type AS ENUM
+('text','voice','dm')`), not a VARCHAR — so new variants are added with
+`ALTER TYPE … ADD VALUE`. Caveat: `ALTER TYPE … ADD VALUE` **cannot run in the
+same transaction that uses the new value**, and sqlx runs each migration in a
+transaction. So the enum extension is its **own** migration, committed before any
+migration/code references `'forum'`/`'announcement'`:
 
--- Extend the channel type. channel_type is a VARCHAR mapped in code, plus a
--- CHECK; add the two values.
-ALTER TABLE channels DROP CONSTRAINT IF EXISTS channels_type_check;
-ALTER TABLE channels ADD  CONSTRAINT channels_type_check
-    CHECK (channel_type IN ('text','voice','forum','announcement'));
+```sql
+-- migration: 20260707000002a_channel_type_forum_announcement.sql  (enum only)
+ALTER TYPE channel_type ADD VALUE IF NOT EXISTS 'forum';
+ALTER TYPE channel_type ADD VALUE IF NOT EXISTS 'announcement';
+```
+
+```sql
+-- migration: 20260707000002b_forum_announcement_channels.sql  (tables)
 
 -- Forum posts. The post's root message lives in `messages` (parent_id NULL,
 -- channel_id = the forum channel); thread replies hang off it as today.
@@ -86,7 +93,17 @@ CREATE TABLE announcement_follows (
 `last_activity_at` bumps on new replies so the card list can sort by recent
 activity without scanning messages.
 
+**Rust-side code changes:** the sqlx-derived `db::ChannelType` enum gains
+`Forum` and `Announcement` variants, and the string mapping in
+`chat/channels.rs` (`"text" => Text`, `"voice" => Voice`, and the reverse) gains
+the two new cases. The existing `Voice`-specific branch in channel creation
+stays; `Forum` gets its own post-creation branch.
+
 ## Permissions
+
+Verified against `permissions/guild.rs`: `GuildPermissions` is a `u64` bitflags
+with bits 0–25 in use, so the new bits below take **1<<26** (`MANAGE_POSTS`) and
+**1<<27** (`SEND_ANNOUNCEMENTS`) — no collisions.
 
 - New permission bit **`MANAGE_POSTS`** (forum moderation: pin/lock/delete
   others' posts, manage tags). Creating a post needs `SEND_MESSAGES` in the

--- a/docs/superpowers/specs/2026-07-07-forum-and-announcement-channels-design.md
+++ b/docs/superpowers/specs/2026-07-07-forum-and-announcement-channels-design.md
@@ -1,0 +1,167 @@
+# Forum & Announcement Channels — Design
+
+> Status: design, awaiting approval. 2026-07-07, gap #3. Scope decision: forum
+> **and** announcement channels together, including cross-guild announcement
+> follow/crosspost.
+
+## Context
+
+Channels are `Text` or `Voice` only (`db::ChannelType`, string-mapped in
+`chat/channels.rs`). Communities miss two Discord channel types most: **forum
+channels** (organized topic posts) and **announcement channels** (broadcast +
+follow). Forum posts map cleanly onto Kaiku's existing thread system — `messages`
+already has `parent_id` (self-FK, cascade) and `thread_reply_count`
+(`20260206000000_message_threads.sql`), so a forum post *is* a thread starter.
+Announcement channels are a write-restricted text channel plus a follow/crosspost
+mechanism, the only genuinely new machinery here.
+
+## Goals
+
+- **Forum channel** (`ChannelType::Forum`): contains **posts**, each a
+  title + tags + a root message that opens a thread. Members browse a card list,
+  filter by tag, and reply inside a post (reusing thread replies).
+- **Announcement channel** (`ChannelType::Announcement`): a text channel where
+  posting needs a permission bit; any guild can **follow** it, so new
+  announcements **crosspost** into a chosen channel in the follower's guild.
+
+## Non-Goals (YAGNI)
+
+- Forum post reactions/upvote sorting beyond recent/active — start with
+  recent-activity + tag filter.
+- Default forum layout toggles (list vs gallery) — list only for v1.
+- Announcement scheduling — that's the scheduled-events/scheduled-messages track.
+
+## Data Model
+
+```sql
+-- migration: 20260707000002_forum_announcement_channels.sql
+
+-- Extend the channel type. channel_type is a VARCHAR mapped in code, plus a
+-- CHECK; add the two values.
+ALTER TABLE channels DROP CONSTRAINT IF EXISTS channels_type_check;
+ALTER TABLE channels ADD  CONSTRAINT channels_type_check
+    CHECK (channel_type IN ('text','voice','forum','announcement'));
+
+-- Forum posts. The post's root message lives in `messages` (parent_id NULL,
+-- channel_id = the forum channel); thread replies hang off it as today.
+CREATE TABLE forum_posts (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    channel_id  UUID NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+    root_message_id UUID NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    title       VARCHAR(128) NOT NULL,
+    author_id   UUID REFERENCES users(id) ON DELETE SET NULL,
+    pinned      BOOLEAN NOT NULL DEFAULT FALSE,
+    locked      BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_activity_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_forum_posts_channel ON forum_posts(channel_id, last_activity_at DESC);
+
+-- Forum tags: a small per-channel tag set; posts reference them.
+CREATE TABLE forum_tags (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    channel_id UUID NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+    name VARCHAR(32) NOT NULL,
+    emoji VARCHAR(64),
+    UNIQUE (channel_id, name)
+);
+CREATE TABLE forum_post_tags (
+    post_id UUID NOT NULL REFERENCES forum_posts(id) ON DELETE CASCADE,
+    tag_id  UUID NOT NULL REFERENCES forum_tags(id)  ON DELETE CASCADE,
+    PRIMARY KEY (post_id, tag_id)
+);
+
+-- Announcement follows: a follower guild subscribes one of its channels to a
+-- source announcement channel.
+CREATE TABLE announcement_follows (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    source_channel_id UUID NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+    target_channel_id UUID NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+    created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (source_channel_id, target_channel_id)
+);
+```
+
+`last_activity_at` bumps on new replies so the card list can sort by recent
+activity without scanning messages.
+
+## Permissions
+
+- New permission bit **`MANAGE_POSTS`** (forum moderation: pin/lock/delete
+  others' posts, manage tags). Creating a post needs `SEND_MESSAGES` in the
+  forum channel; replying needs the same, honoring `locked`.
+- Announcement posting reuses a new **`SEND_ANNOUNCEMENTS`** bit distinct from
+  `SEND_MESSAGES`. Following a source channel requires `MANAGE_CHANNELS` in the
+  **follower** guild and `VIEW_CHANNEL` on the source (public discovery only for
+  now — a source must be in a discoverable guild or reachable by invite).
+
+## Behavior
+
+**Forum posts** — creating a post is one transaction: insert the root `messages`
+row (parent_id NULL, the forum channel), the `forum_posts` row, and tag links.
+Replies use the **existing thread-reply endpoint** unchanged; a reply bumps
+`forum_posts.last_activity_at` and the existing `thread_reply_count`. Deleting
+the root message cascades the post; deleting the channel cascades everything.
+
+**Announcement crosspost** — publishing a message in an announcement channel (a
+normal message create, gated by `SEND_ANNOUNCEMENTS`) triggers a fan-out: for
+each `announcement_follows` row with that source, create a copy message in the
+target channel attributed to the source (a "forwarded from #source" header,
+original author preserved in metadata). Fan-out runs on the existing
+Redis-backed async path (like webhook delivery) so a slow follower can't block
+the publish. Follower unsubscribes via `DELETE` on the follow row.
+
+## Real-Time (WS)
+
+- Forum: reuse `MessageNew`/`MessageEdit` for post root + replies; add
+  `ForumPostCreated { channel_id, post }` and `ForumPostUpdated` so the card list
+  updates without refetch.
+- Announcement crossposts arrive in target channels as ordinary `MessageNew`
+  events (they *are* messages), so no client change is needed there.
+
+## API Surface
+
+New module `server/src/chat/forum.rs` (Tier-1 layout):
+`GET /api/channels/{id}/posts` (paginated, `?tag=` filter, sort recent/active),
+`POST /api/channels/{id}/posts`, `PATCH/DELETE /api/forum/posts/{post_id}`
+(pin/lock/delete), tag CRUD under the channel.
+Announcement follow: `POST /api/channels/{target}/follow {source_channel_id}`,
+`DELETE …/follow/{id}`, `GET …/followers` (source-side).
+
+## Client
+
+- **`components/channels/`** gains a forum channel view: post card list (title,
+  tags, author, reply count, last activity), tag filter chips, a "New Post"
+  composer (title + tags + body), and a post view that reuses the existing
+  thread UI for replies. Channel-create modal gains "Forum" and "Announcement"
+  types (extends the existing type picker).
+- Announcement channels render like text with a "Following" affordance and a
+  publish button gated on `SEND_ANNOUNCEMENTS`.
+
+## Edge Cases
+
+- Following a channel that later becomes private/deleted → follow row
+  cascade-removed or crosspost skipped with a logged warning.
+- Crosspost loops (A follows B follows A) → guard: a crossposted message is
+  flagged and never re-crossposted.
+- Forum post with all tags deleted → post keeps working, untagged.
+- Locked post → replies rejected with `403`; author/`MANAGE_POSTS` can still act.
+- Converting an existing text channel to forum → out of scope; forum channels
+  are created as forum.
+
+## Testing
+
+- Forum: create post (root message + post + tags in one tx), reply bumps
+  activity + count, tag filter, pin/lock permission gates, cascade on
+  channel/root delete.
+- Announcement: `SEND_ANNOUNCEMENTS` gate, follow creates crossposts to targets,
+  loop guard, unfollow stops crossposts, slow follower doesn't block publish.
+
+## Rollout
+
+Additive channel types + tables; existing text/voice channels untouched. The
+`channels_type_check` change is a constraint swap (safe, no data change). Ship
+server + client together so the new channel types render. Announcement
+cross-guild follow is the riskiest slice — it can be feature-flagged off while
+forum ships, if we want to de-risk the crosspost fan-out separately.

--- a/docs/superpowers/specs/2026-07-07-membership-screening-design.md
+++ b/docs/superpowers/specs/2026-07-07-membership-screening-design.md
@@ -71,8 +71,12 @@ guard in `permissions::helpers::get_member_permission_context`, so every existin
 `require_*` check inherits it — no per-endpoint changes. The only things a
 pending member can do: fetch the guild's rules and `POST` acceptance.
 
-Because permission context is not cached (verified this session), acceptance
-takes effect immediately on the next request/WS check.
+**WS coverage is automatic (verified):** the user WebSocket channel-subscribe
+handler calls `permissions::require_channel_access` (`ws/handlers.rs:528`), which
+resolves through `get_member_permission_context` — so the same short-circuit
+blocks a pending member from subscribing to guild channels; no separate WS gate
+is needed. And because permission context is **not cached** (verified this
+session), acceptance takes effect immediately on the next request/WS check.
 
 ## Acceptance & Approval
 
@@ -86,9 +90,15 @@ takes effect immediately on the next request/WS check.
 ## Real-Time (WS)
 
 New `MemberUpdated { guild_id, user_id, membership_state }` broadcast to the
-guild so admin member lists reflect pending→active live. (Complements the
-`MemberRolesUpdated` event from the reaction-roles spec — together they make the
-member list fully live.)
+guild so admin member lists reflect pending→active live.
+
+**Cross-spec coordination:** the reaction-roles spec introduces
+`MemberRolesUpdated { guild_id, user_id, role_ids }` for the same "member
+changed, update the list" purpose. Whichever ships **second** should extend the
+first's event into a single `MemberUpdated { guild_id, user_id, role_ids?,
+membership_state? }` (optional fields, full-value not delta) rather than add a
+parallel event — one reducer on the client, no overlap. This spec assumes that
+unification if reaction-roles landed first.
 
 ## API Surface
 

--- a/docs/superpowers/specs/2026-07-07-membership-screening-design.md
+++ b/docs/superpowers/specs/2026-07-07-membership-screening-design.md
@@ -1,0 +1,138 @@
+# Membership Screening (Rules Gate) — Design
+
+> Status: design, awaiting approval. 2026-07-07, gap #5b (split from scheduled
+> events).
+
+## Context
+
+Public/discoverable guilds want a gate: a new member must read and accept rules
+(and optionally clear a verification step) before they can participate. Kaiku
+joins a guild by inserting into `guild_members` in three places — invite redeem
+(`guild/queries/invites.rs`), discovery join (`discovery/queries.rs`), and guild
+create (`guild/queries/core.rs`) — with no notion of a pending member. This
+feature adds a **pending** state gated by rules acceptance, integrating with the
+existing permission system (a pending member gets no `VIEW_CHANNEL`) and the
+client onboarding UI.
+
+## Goals
+
+- A guild can enable **screening**: newly-joined members enter a **pending**
+  state and see only a rules/acceptance screen until they accept.
+- Pending members cannot read channels, send messages, join voice, or DM guild
+  members via the guild — enforced server-side, not just hidden in the UI.
+- Admins configure the rules text and toggle screening; they see and can approve
+  or kick pending members.
+
+## Non-Goals (YAGNI)
+
+- Application questions / manual approval queues — acceptance is
+  self-service-on-accept for v1 (approval-required is a later mode).
+- CAPTCHA / anti-bot verification — the structure allows a `verify` step later;
+  none shipped now.
+- Per-channel screening — guild-level only.
+
+## Data Model
+
+```sql
+-- migration: 20260707000005_membership_screening.sql
+
+-- Screening config + rules on the guild.
+ALTER TABLE guilds ADD COLUMN screening_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+CREATE TABLE guild_screening_rules (
+    guild_id UUID PRIMARY KEY REFERENCES guilds(id) ON DELETE CASCADE,
+    rules_md TEXT NOT NULL,                 -- markdown, rendered via the safe sanitizer
+    updated_by UUID REFERENCES users(id) ON DELETE SET NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Membership state. Default 'active' preserves all existing members.
+ALTER TABLE guild_members
+    ADD COLUMN membership_state VARCHAR(16) NOT NULL DEFAULT 'active'; -- 'active' | 'pending'
+ALTER TABLE guild_members ADD COLUMN accepted_rules_at TIMESTAMPTZ;
+```
+
+Existing members default to `active` (no backfill migration needed). Only new
+joins, when `screening_enabled`, become `pending`.
+
+## Join Flow Integration
+
+The three `INSERT INTO guild_members` sites converge on a single
+`add_guild_member(guild_id, user_id)` helper (small refactor to remove the
+duplication — a targeted consistency improvement while we're here). That helper
+sets `membership_state = 'pending'` when the guild has `screening_enabled`,
+else `'active'`.
+
+## Permission Enforcement
+
+The permission resolver already computes a member's effective permissions. Add a
+short-circuit: **a `pending` member has an empty permission set** (no
+`VIEW_CHANNEL`, no `SEND_MESSAGES`, no voice), regardless of roles. This is one
+guard in `permissions::helpers::get_member_permission_context`, so every existing
+`require_*` check inherits it — no per-endpoint changes. The only things a
+pending member can do: fetch the guild's rules and `POST` acceptance.
+
+Because permission context is not cached (verified this session), acceptance
+takes effect immediately on the next request/WS check.
+
+## Acceptance & Approval
+
+- `POST /api/guilds/{id}/screening/accept` → sets `membership_state = 'active'`,
+  `accepted_rules_at = now`, emits `MemberUpdated`. Requires the member to be
+  `pending` in a screening-enabled guild.
+- Admin view: `GET /api/guilds/{id}/members?state=pending`; admins may kick a
+  pending member (existing kick). (Manual approval mode — admin flips
+  pending→active — is a later toggle; not v1.)
+
+## Real-Time (WS)
+
+New `MemberUpdated { guild_id, user_id, membership_state }` broadcast to the
+guild so admin member lists reflect pending→active live. (Complements the
+`MemberRolesUpdated` event from the reaction-roles spec — together they make the
+member list fully live.)
+
+## API Surface
+
+New module `server/src/guild/screening.rs` (Tier-1 layout):
+`GET /api/guilds/{id}/screening` (config + rules; readable by a pending member),
+`PUT /api/guilds/{id}/screening` (`MANAGE_GUILD`: toggle + rules text),
+`POST /api/guilds/{id}/screening/accept` (the pending member).
+
+## Client
+
+- On entering a guild where the user is `pending`, the client shows a **rules
+  gate** screen (reusing the onboarding-wizard visual language) instead of the
+  channel view: rendered rules (safe markdown) + an "I agree" button →
+  `accept` → transitions into the normal guild view.
+- Guild settings gains a **Screening** section (toggle + rules editor) and a
+  **Pending Members** list (approve-by-nothing / kick).
+
+## Edge Cases
+
+- Screening enabled *after* members joined → existing members stay `active`
+  (only new joins are gated). Intentional; a "re-screen everyone" action is out
+  of scope.
+- Screening disabled while members are pending → pending members are promoted to
+  `active` on disable (one UPDATE), so nobody is stuck.
+- Owner/first member is always `active` (guild create path bypasses screening).
+- A pending member's WS connection must also be gated (can't subscribe to guild
+  channels) — the permission short-circuit covers WS subscription auth too.
+- Rules text is markdown → rendered through the isolated DOMPurify sanitizer
+  (no arbitrary classes), same as wiki pages.
+
+## Testing
+
+- New join to a screening guild is `pending`; pending member gets 403 on
+  channel read/send/voice; can read rules + accept.
+- Accept flips to active and unlocks access immediately (no cache staleness).
+- Disabling screening promotes pending members.
+- Owner bypass on guild create.
+- `MemberUpdated` fires on accept.
+- The unified `add_guild_member` helper is used by all three join paths.
+
+## Rollout
+
+Additive columns (defaulting existing members to `active`) + one resolver
+short-circuit + endpoints + client gate. The resolver change is the sensitive
+bit — it must be covered by the permission tests above so an active member is
+never accidentally gated. Ship server + client together so gated users get the
+acceptance screen rather than an empty guild.

--- a/docs/superpowers/specs/2026-07-07-mobile-push-notifications-design.md
+++ b/docs/superpowers/specs/2026-07-07-mobile-push-notifications-design.md
@@ -1,0 +1,151 @@
+# Mobile Push Notifications — Design
+
+> Status: design, awaiting approval. 2026-07-07, gap #4. Provider decision:
+> **provider-agnostic dispatcher, UnifiedPush/ntfy as the default backend**, FCM
+> as a pluggable backend later. Content-free pushes preserve E2EE.
+
+## Context
+
+The Android app has no push path today (no FCM in `mobile/android`), so it can
+only notify while foregrounded — users won't return to an app that can't reach
+them. Two forces shape the design: Kaiku's **E2EE DMs** (a push provider must
+never see message content) and its **sovereignty thesis** (avoid a hard Google
+dependency). The answer to both: send a **content-free wake signal**, let the
+app fetch and decrypt locally, and abstract the provider so a self-hostable
+transport (UnifiedPush/ntfy) is the default with FCM as an opt-in backend.
+
+## Goals
+
+- Deliver a push when a user should be notified while the app is
+  backgrounded/closed: DM message, @mention, and incoming DM voice call.
+- **Content-free**: the push carries only a type + minimal routing (e.g.
+  channel_id), never message text — the app wakes, syncs over its normal
+  authenticated channel, and renders the (decrypted) notification locally.
+- Respect the user's existing DND / quiet-hours / focus-engine settings and
+  per-guild mute state — those already gate in-app notifications; reuse them.
+- Provider-agnostic: one dispatcher, pluggable backends (UnifiedPush first).
+
+## Non-Goals (YAGNI)
+
+- iOS push (APNs) — arrives with the iOS client (deferred).
+- Rich/actionable notifications (reply-from-notification) — v2.
+- Web push — separate track; the abstraction leaves room.
+
+## Data Model
+
+```sql
+-- migration: 20260707000003_push_subscriptions.sql
+CREATE TABLE push_subscriptions (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id    UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    provider   VARCHAR(32) NOT NULL,       -- 'unifiedpush' | 'fcm' | ...
+    -- UnifiedPush: the distributor endpoint URL. FCM: the registration token.
+    endpoint   TEXT NOT NULL,
+    -- Optional client public key for payload encryption (UnifiedPush webpush).
+    public_key TEXT,
+    auth_key   TEXT,
+    device_label VARCHAR(64),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_used_at TIMESTAMPTZ,
+    UNIQUE (user_id, endpoint)
+);
+```
+
+Multiple rows per user (multi-device). `ON DELETE CASCADE` drops subscriptions
+when an account is deleted (GDPR-consistent).
+
+## Provider Abstraction
+
+A `push` module with a `PushProvider` trait:
+
+```rust
+#[async_trait]
+trait PushProvider {
+    fn name(&self) -> &'static str;
+    async fn send(&self, sub: &PushSubscription, signal: &WakeSignal)
+        -> Result<Delivery, PushError>; // Delivery::Gone => prune the sub
+}
+```
+
+- **UnifiedPushProvider** (default): POST the (optionally webpush-encrypted)
+  wake signal to the subscription `endpoint` (the user's distributor, e.g. a
+  self-hosted ntfy). Endpoints are user-supplied URLs → **reuse the existing
+  `webhooks::ssrf` guard** (private-IP/DNS-rebind protection) before every send.
+- **FcmProvider** (later): POST a `data`-only message (no `notification` block,
+  so the OS doesn't render provider-side content) to FCM with the token.
+
+The dispatcher selects the provider per subscription row, sends concurrently,
+and prunes subscriptions a backend reports as `Gone`.
+
+## Wake Signal (content-free)
+
+```
+{ "t": "dm" | "mention" | "call", "channel_id": "...", "count": 3 }
+```
+
+No sender name, no text. For E2EE DMs the app must decrypt locally; for
+non-E2EE guild mentions the app still fetches over its authenticated API rather
+than trusting push contents (uniform path, minimal push surface, no content
+leak to the transport).
+
+## Trigger & Gating
+
+Hook the points that already emit in-app notifications (message create →
+`MessageNew`, mention detection, DM call ring). For each recipient who is **not
+currently connected via WebSocket** (or is connected but backgrounded, signaled
+by the client), the notification service:
+
+1. Checks the user's existing notification gates: DND, quiet-hours, focus mode,
+   per-guild/channel mute. If suppressed, no push.
+2. Loads the user's `push_subscriptions` and dispatches the wake signal.
+
+Runs on the existing Redis-backed async worker pattern (like webhook delivery)
+so push latency never blocks message handling.
+
+## Android Client
+
+- On login / notification-permission grant, the app registers with its
+  UnifiedPush distributor and `POST`s the endpoint to
+  `POST /api/me/push-subscriptions`; unregisters on logout
+  (`DELETE …/{id}`).
+- On receiving a wake signal, a background worker syncs the referenced channel
+  over the normal authenticated (and E2EE-decrypting) path and posts a local
+  Android notification. Tapping deep-links into the channel.
+- Reuses the existing `VoiceCallService` foreground-service pattern for call
+  pushes (full-screen incoming-call intent).
+
+## API Surface
+
+`POST /api/me/push-subscriptions {provider, endpoint, public_key?, device_label?}`,
+`GET /api/me/push-subscriptions`, `DELETE /api/me/push-subscriptions/{id}` — all
+under the authenticated user; a user only manages their own devices.
+
+## Edge Cases
+
+- Stale endpoint (distributor uninstalled) → backend returns `Gone` → prune.
+- User on 5 devices, 2 unreachable → send to all, prune failures, don't fail the
+  batch.
+- User actively connected on desktop but phone backgrounded → still push the
+  phone (per-subscription, not per-user online state).
+- SSRF: a malicious `endpoint` pointing at internal infra → blocked by the
+  shared SSRF guard, identical to webhooks.
+- Rate/dedupe: collapse a burst of mentions in one channel into a single wake
+  signal with a `count`.
+
+## Testing
+
+- Dispatcher selects the right provider, sends concurrently, prunes `Gone`.
+- SSRF guard rejects an internal endpoint.
+- Gating: DND/quiet-hours/mute suppress the push; a connected+foreground session
+  suppresses; backgrounded does not.
+- Wake signal carries no message content (assert the payload shape).
+- Subscription CRUD is user-scoped (can't register/delete another user's device).
+
+## Rollout
+
+Server dispatcher + `push_subscriptions` table + endpoints first (inert without
+clients). Android client second. UnifiedPush ships as default; FCM backend lands
+behind config when/if Play-Store reach is prioritized. iOS/APNs slots into the
+same trait later. This is the highest-infra feature of the five and the one with
+an external-service tail — worth shipping the server abstraction early so client
+work can proceed in parallel.

--- a/docs/superpowers/specs/2026-07-07-reaction-roles-design.md
+++ b/docs/superpowers/specs/2026-07-07-reaction-roles-design.md
@@ -79,12 +79,16 @@ account deletion.
 
 ## Permissions & Safety
 
-All enforcement is at **binding-creation** time; self-assign at reaction time is
-intentionally unprivileged (that is the feature).
+All *binding* enforcement is at **creation** time; self-assign at reaction time
+is intentionally unprivileged (that is the feature). One existing gate still
+applies to self-assign, though: reacting already requires the **`ADD_REACTIONS`**
+permission (verified `permissions/guild.rs`, bit 1<<4) in that channel — a member
+who can't react in the channel can't self-assign, which is the correct behavior
+and needs no new code.
 
-Creating or editing a binding requires `MANAGE_ROLES` and reuses the existing
-`permissions::resolver::can_manage_role(actor_perms, actor_highest_position,
-target_role_position, None)`:
+Creating or editing a binding requires `MANAGE_ROLES` (existing bit 1<<15) and
+reuses the existing `permissions::resolver::can_manage_role(actor_perms,
+actor_highest_position, target_role_position, None)` (signature verified):
 
 1. Actor must hold `MANAGE_ROLES`.
 2. **Role-hierarchy guard** — the target role must be strictly below the actor's

--- a/docs/superpowers/specs/2026-07-07-reaction-roles-design.md
+++ b/docs/superpowers/specs/2026-07-07-reaction-roles-design.md
@@ -1,0 +1,213 @@
+# Self-Assignable (Reaction) Roles — Design
+
+> Status: design, awaiting approval. Synthesized 2026-07-07 from the feature-gap
+> analysis (Kaiku vs Discord/TeamSpeak). This is gap #1 of the top-5, chosen as
+> highest value-per-effort because it reuses the existing roles, reactions,
+> permissions, and WebSocket subsystems end-to-end.
+
+## Context
+
+Communities expect members to grant themselves opt-in roles (pronouns, regions,
+game pings, notification opt-ins, a color) without a moderator doing it by hand.
+Kaiku has roles, per-member role assignment, message reactions, and a permission
+system — but nothing binds a reaction to a role grant. This feature adds that
+binding.
+
+A secondary, load-bearing discovery shaped the design: **role assignment is
+currently silent over WebSocket.** `guild/roles.rs` calls
+`assign_role_to_member` / `remove_role_from_member` and returns, with no
+`ServerEvent` emitted, so other clients only see role changes on the next
+refetch. Self-assign must feel live, so we introduce a `MemberRolesUpdated`
+event and retrofit it into the existing admin assign/remove path too — closing
+that latent gap for all role changes.
+
+## Goals
+
+- Admins bind an emoji on a specific message to a role; members react to
+  grant/revoke that role themselves.
+- Two modes at launch:
+  - **`toggle`** — reacting grants the role, removing the reaction revokes it.
+  - **`unique`** — bindings sharing a `group_key` are mutually exclusive:
+    granting one revokes the others in the group (pick-one, e.g. a color).
+- Safe by construction: a member self-assigning can never gain a role the
+  binding's creator could not themselves grant.
+- Live updates: members and admins see role changes without refetching.
+
+## Non-Goals (YAGNI)
+
+- `add_only` / `remove_only` modes — deferred until asked for.
+- Button/dropdown "role panel" UX — deferred to gap #2b (interactive message
+  components). When that lands, a panel is a second frontend over the **same**
+  binding table; nothing here needs to change.
+- Auto-role-on-join, role icons, role-mention pings — separate features.
+
+## Data Model
+
+One new table, TimescaleDB-agnostic (plain table), following the existing
+migration and FK-cascade conventions.
+
+```sql
+-- migration: 20260707000000_reaction_role_bindings.sql
+CREATE TABLE reaction_role_bindings (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    guild_id     UUID NOT NULL REFERENCES guilds(id)   ON DELETE CASCADE,
+    channel_id   UUID NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+    message_id   UUID NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    -- Emoji key: unicode grapheme ("🎨") or custom emoji ref ("<:name:uuid>"),
+    -- the exact string form message_reactions already stores.
+    emoji        VARCHAR(128) NOT NULL,
+    role_id      UUID NOT NULL REFERENCES guild_roles(id) ON DELETE CASCADE,
+    -- Non-null groups bindings for `unique` (pick-one) behaviour.
+    group_key    VARCHAR(64),
+    mode         VARCHAR(16) NOT NULL DEFAULT 'toggle',  -- 'toggle' | 'unique'
+    created_by   UUID REFERENCES users(id) ON DELETE SET NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- At most one binding per emoji per message.
+    CONSTRAINT reaction_role_unique_emoji UNIQUE (message_id, emoji),
+    CONSTRAINT reaction_role_mode_valid   CHECK (mode IN ('toggle', 'unique'))
+);
+
+CREATE INDEX idx_reaction_role_message ON reaction_role_bindings(message_id);
+CREATE INDEX idx_reaction_role_guild   ON reaction_role_bindings(guild_id);
+```
+
+Cascades mean deleting a guild, channel, message, or role removes its bindings
+automatically — no orphan-cleanup code. `created_by` is `SET NULL` (consistent
+with `oidc_providers`/`server_config`) so a bound message survives the admin's
+account deletion.
+
+## Permissions & Safety
+
+All enforcement is at **binding-creation** time; self-assign at reaction time is
+intentionally unprivileged (that is the feature).
+
+Creating or editing a binding requires `MANAGE_ROLES` and reuses the existing
+`permissions::resolver::can_manage_role(actor_perms, actor_highest_position,
+target_role_position, None)`:
+
+1. Actor must hold `MANAGE_ROLES`.
+2. **Role-hierarchy guard** — the target role must be strictly below the actor's
+   highest role. This blocks the headline exploit: an admin binding `@Owner` (or
+   any role ≥ their own) to an emoji everyone can click.
+3. **Dangerous-permission guard** — reject binding a role whose permission
+   bitfield intersects a deny-list (`ADMINISTRATOR`, `MANAGE_GUILD`,
+   `MANAGE_ROLES`, `MANAGE_CHANNELS`, `KICK_MEMBERS`, `BAN_MEMBERS`). Even a
+   low-position role must not be self-grantable if it carries moderator power.
+   Returned as a distinct `ReactionRoleError::RoleNotSelfAssignable`.
+
+The `@everyone`/default role and managed/bot roles are not bindable.
+
+## Reaction-Time Behavior
+
+Hook the existing handlers in `server/src/chat/reactions.rs`:
+
+- **`add_reaction`** — after the reaction row is written, in the **same
+  transaction**, look up `reaction_role_bindings` for `(message_id, emoji)`:
+  - `toggle` / `unique` → `assign_role_to_member(guild_id, user_id, role_id,
+    assigned_by = user_id)` (idempotent; `ON CONFLICT DO NOTHING` already in the
+    query).
+  - `unique` additionally: for every sibling binding in the same `group_key`,
+    `remove_role_from_member` for that role, and remove the user's stored
+    reaction for the sibling emoji so the UI reflects the swap.
+  - Emit `MemberRolesUpdated`.
+- **`remove_reaction`** — symmetric: `toggle`/`unique` → `remove_role_from_member`
+  and emit `MemberRolesUpdated`. (Removing a `unique` reaction leaves the user
+  with no role in that group — acceptable; groups are opt-in, not mandatory.)
+
+Bindings only act on reactions to messages in a guild channel; DM reactions are
+ignored (no roles in DMs). If the reacting user is not a guild member (edge
+case: reacting to a bound message they can see but haven't joined), the grant is
+skipped.
+
+## WebSocket Event
+
+New variant in `server/src/ws/events.rs`:
+
+```rust
+MemberRolesUpdated {
+    guild_id: Uuid,
+    user_id: Uuid,
+    role_ids: Vec<Uuid>,   // the member's full role set after the change
+},
+```
+
+Broadcast to the guild's subscribers via the existing Redis pub-sub path. Sending
+the **full role set** (not a delta) makes the client update idempotent and
+tolerant of missed events.
+
+Emitted from:
+1. The reaction-role grant/revoke path above.
+2. **Retrofit:** `guild/roles.rs` `assign_role`/`remove_role` admin handlers,
+   which are silent today. This is the bonus latent-gap fix — after this,
+   *every* role change is live.
+
+Client (`stores/websocket`) handles `MemberRolesUpdated` by updating the cached
+member's `role_ids`, which drives member-list role chips and permission-derived
+UI.
+
+## API Surface
+
+New Tier-1 module `server/src/guild/reaction_roles.rs` (error / types / queries /
+handlers split, per the codebase consistency standards). All routes nested under
+the guild router and gated by `MANAGE_ROLES`:
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/api/guilds/{id}/reaction-roles` | List bindings (optionally `?message_id=`) |
+| `POST` | `/api/guilds/{id}/reaction-roles` | Create a binding (validates hierarchy + self-assignable) |
+| `DELETE` | `/api/guilds/{id}/reaction-roles/{binding_id}` | Remove a binding |
+
+`POST` body: `{ channel_id, message_id, emoji, role_id, mode, group_key? }`.
+Creating a binding also adds the bot/system reaction to the message so members
+have something to click (best-effort; failure to pre-seed the reaction is
+non-fatal and logged).
+
+## Client Changes
+
+- **`GuildSettingsModal`** → new "Reaction Roles" section: pick a channel +
+  message (or paste a message link), then add emoji↔role rows with a mode
+  selector and optional group label. Reuses the existing emoji picker and role
+  list components. Only roles the actor can manage and that pass the
+  self-assignable check are offered.
+- **`stores/websocket`** → handle `MemberRolesUpdated`.
+- Member-list role chips already render from `role_ids`; they simply become live.
+
+## Edge Cases
+
+- **Role deleted** → binding cascade-removed; existing grants of that role are
+  independently removed by the role's own delete cascade.
+- **Bound message deleted** → binding cascade-removed.
+- **Emoji un-bound while reactions exist** → future reactions no longer grant;
+  existing role grants are left untouched (no retroactive strip — least
+  surprise).
+- **User leaves guild** → membership cascade removes their roles; stale
+  reactions are cosmetic and cleared on message refetch.
+- **Rapid toggle spam** → the existing per-user reaction rate limit applies;
+  grant/revoke is idempotent so worst case is redundant no-op writes.
+- **`unique` group swap** → done in one transaction so a member is never
+  momentarily in two group roles or none.
+
+## Testing
+
+Integration tests (`#[sqlx::test]`, per the project's isolation pattern):
+
+- `toggle`: react grants role + emits event; un-react revokes.
+- `unique`: reacting a second emoji in a group revokes the first role and clears
+  the first reaction; single transaction.
+- Hierarchy guard: creating a binding for a role ≥ actor position → `403`.
+- Self-assignable guard: binding a role with `MANAGE_GUILD` → rejected.
+- Cascade: deleting the role / message / guild removes bindings.
+- Non-member reacting to a bound message → no grant.
+- `MemberRolesUpdated` fires on both reaction-role and admin assign/remove paths.
+
+Client: unit test the `MemberRolesUpdated` reducer updates the cached member's
+role set.
+
+## Rollout
+
+Additive migration + new endpoints + one new WS variant; no changes to existing
+message/reaction wire formats. The `MemberRolesUpdated` retrofit is backward-safe
+(clients that don't yet handle it ignore unknown variants, as the WS layer
+already tolerates). Ship server + client together so the live-update path is
+consistent, but there is no hard ordering requirement.

--- a/docs/superpowers/specs/2026-07-07-rich-embeds-and-components-design.md
+++ b/docs/superpowers/specs/2026-07-07-rich-embeds-and-components-design.md
@@ -72,6 +72,20 @@ Only **bots** and (later) incoming webhooks may set `components` — a human use
 message cannot carry buttons (prevents impersonating bot UIs). Embeds from bots
 only in v1.
 
+**Note on the existing `EMBED_LINKS` permission (verified `permissions/guild.rs`
+bit 1<<1):** that bit governs *user link-unfurling* (auto-previewing pasted
+URLs) and is unrelated to bot-authored rich embeds. Bot rich embeds need **no
+new permission** — bot identity + the channel's `SEND_MESSAGES` suffice. This
+spec does not touch `EMBED_LINKS`, and the distinction should be called out in
+docs so it isn't conflated.
+
+**Interaction model reuse (verified `ws/bot_gateway.rs`):** the gateway already
+has `BotServerEvent::CommandInvoked { interaction_id, … }`, a bot `respond`
+path keyed by `interaction_id` with ownership + expiry guards, and an
+intent filter (`intent_permits_event`, intents `messages`/`members`/`commands`).
+Components add exactly one server event (`ComponentInvoked`) and one intent
+(`components`) to that machinery — no new interaction subsystem.
+
 ## Interaction Loop (components)
 
 Reuses the slash-command machinery:

--- a/docs/superpowers/specs/2026-07-07-rich-embeds-and-components-design.md
+++ b/docs/superpowers/specs/2026-07-07-rich-embeds-and-components-design.md
@@ -1,0 +1,141 @@
+# Rich Embeds & Interactive Components — Design
+
+> Status: design, awaiting approval. 2026-07-07, gap #2 of the feature-gap
+> analysis. Scope decision: embeds **and** interactive components together, so
+> bots gain rich cards and buttons/menus in one coherent surface.
+
+## Context
+
+Bots and webhooks can only post plain markdown today, so third-party
+integrations look bare next to Discord's rich cards and interactive controls.
+The load-bearing enabler already exists: the **bot gateway already implements an
+interaction round-trip** — `BotServerEvent::CommandInvoked` carries an
+`interaction_id`, the bot replies over its gateway connection, and the server
+checks interaction ownership and expiry (`server/src/ws/bot_gateway.rs`). This
+was built for slash commands. Component interactions (button clicks, select
+choices) extend that exact model rather than inventing a new one.
+
+## Goals
+
+- **Embeds:** structured rich cards on a message — title, description, URL,
+  color, author, fields (name/value/inline), image/thumbnail, footer, timestamp.
+  Set by bots (message API) and, later, incoming webhooks.
+- **Components:** action rows containing buttons (styles: primary/secondary/
+  success/danger/link) and select menus. A user interaction routes to the owning
+  bot, which can reply (new message / ephemeral / update the source message).
+- Rendered safely — embeds are semi-trusted, attacker-influenced content.
+
+## Non-Goals (YAGNI)
+
+- Modals (component-triggered forms) — a fast follow once buttons ship.
+- Embed authoring by regular users in the composer — bots/webhooks only for v1.
+- Rich embeds from *incoming* webhooks — depends on adding incoming webhooks
+  (separate feature); the schema supports it from day one.
+
+## Data Model
+
+Two nullable JSONB columns on `messages` (which today is just
+`content`/`parent_id`/…):
+
+```sql
+-- migration: 20260707000001_message_embeds_components.sql
+ALTER TABLE messages ADD COLUMN embeds     JSONB;  -- Vec<Embed>, max 10
+ALTER TABLE messages ADD COLUMN components JSONB;  -- Vec<ActionRow>, max 5 rows
+```
+
+Typed server structs mirror Discord's shape so existing bot libraries feel
+familiar (`Embed`, `EmbedField`, `EmbedAuthor`, `EmbedFooter`, `ActionRow`,
+`Button`, `SelectMenu`, `SelectOption`). serde-(de)serialized, validated on
+write. JSONB (not a sidecar table) because embeds/components are always fetched
+with the message, are bounded, and are opaque to SQL queries.
+
+Component interaction state reuses the **existing interaction table/registry**
+that slash commands already use (interaction_id, bot_id, context, expiry) — a
+new `interaction_type` discriminator (`command` | `component`) and a
+`custom_id` field distinguish component clicks.
+
+## Validation & Safety (server-side, on message write)
+
+Bots/webhooks are semi-trusted, so every embed/component is validated before
+storage:
+
+- **Size caps** (Discord-parity): ≤10 embeds; embed total ≤6000 chars; title
+  ≤256; description ≤4096; ≤25 fields; field name ≤256 / value ≤1024; ≤5 action
+  rows; ≤5 buttons per row; ≤25 select options.
+- **URL fields** (`url`, `image`, `thumbnail`, `author.icon`, `footer.icon`)
+  must be `https://` and are stored verbatim but rendered through the existing
+  isolated DOMPurify link-hardening; no `javascript:`/`data:`.
+- **`custom_id`** ≤100 chars, opaque to the server (bot-defined routing key).
+- **Colors** are ints clamped to 24-bit.
+
+Only **bots** and (later) incoming webhooks may set `components` — a human user's
+message cannot carry buttons (prevents impersonating bot UIs). Embeds from bots
+only in v1.
+
+## Interaction Loop (components)
+
+Reuses the slash-command machinery:
+
+1. User clicks a button / picks a select option → client sends a WS
+   `ComponentInteraction { message_id, custom_id, values? }` frame.
+2. Server validates the component exists on that message, mints an
+   `interaction_id` (type `component`, short TTL), and routes a
+   `BotServerEvent::ComponentInvoked { interaction_id, custom_id, user, message,
+   values }` to the owning bot over its gateway (respecting `components` intent).
+3. Bot replies with the existing interaction-response `BotClientEvent`
+   (`respond`) — reply variants: `channel_message`, `ephemeral`
+   (visible only to the invoker), `update_message` (edit the source message's
+   embeds/components), `deferred` (ack now, edit later).
+4. Ownership + expiry are enforced by the existing guards ("Bot attempted to
+   respond to interaction it does not own", "Interaction not found or expired").
+
+Ephemeral replies are delivered only to the invoking user's WS session(s) and
+are not persisted as channel messages.
+
+## Client
+
+- **`components/messages/`** gains `<MessageEmbeds>` and `<MessageComponents>`
+  renderers. Embeds render as cards (all text through the **isolated DOMPurify
+  sanitizer** from #631 — this is exactly the attacker-influenced content that
+  motivated instance isolation). Components render as disabled-until-hydrated
+  buttons/selects; clicking dispatches the `ComponentInteraction` frame.
+- **`stores/websocket`** handles the ephemeral-reply and update-message events.
+- Message list already re-renders on `MessageEdit`; `update_message`
+  interactions reuse that path (embeds/components are part of the message body).
+
+## API Surface
+
+No new REST routes — embeds/components ride the existing message-create/edit API
+(`POST /api/messages/channel/{id}`, `PATCH /api/messages/{id}`) with optional
+`embeds` / `components` in the body, accepted only from bot-authenticated
+callers. The bot gateway gains the `ComponentInvoked` server event and the
+component branch of the interaction-response handler.
+
+## Edge Cases
+
+- Message with components edited to remove them → client drops the controls;
+  in-flight interactions expire harmlessly.
+- Bot offline when a button is clicked → interaction times out; client shows a
+  transient "interaction failed" and re-enables the control.
+- Source message deleted mid-interaction → response is dropped (message gone).
+- Oversized/invalid embed → `400` at message-create, nothing stored.
+- Select menu returning stale option values → bot validates; server only
+  guarantees `custom_id` integrity.
+
+## Testing
+
+- Serde round-trip + validation rejects (each size cap, non-https URL, human
+  user attempting `components`).
+- Interaction routing: `ComponentInvoked` reaches only the owning bot with
+  `components` intent; ownership/expiry rejects.
+- Response variants: ephemeral goes only to the invoker; `update_message`
+  rewrites the message embeds/components and broadcasts `MessageEdit`.
+- Client: embed renderer sanitizes a malicious embed; component click dispatches
+  the correct frame.
+
+## Rollout
+
+Additive columns + one WS server event + one interaction subtype; existing
+plain-text messages are unaffected (`embeds`/`components` NULL). Ship server +
+client together so clients can render what bots send. Bot-library authors get a
+short "embeds & components" doc mirroring Discord field names for easy porting.

--- a/docs/superpowers/specs/2026-07-07-scheduled-events-design.md
+++ b/docs/superpowers/specs/2026-07-07-scheduled-events-design.md
@@ -61,9 +61,12 @@ CREATE TABLE guild_event_rsvps (
 
 ## Permissions
 
-- Create/edit/cancel needs a new **`MANAGE_EVENTS`** bit (falls back to
+- Create/edit/cancel needs a new **`MANAGE_EVENTS`** bit (verified free:
+  `GuildPermissions` `u64` uses bits 0–25, so this takes **1<<28**; falls back to
   `MANAGE_GUILD` if we choose not to add a bit — but a dedicated bit is cleaner
-  and matches the granular model).
+  and matches the granular model). Coordinate the exact bit with the forum spec
+  (`MANAGE_POSTS` 1<<26, `SEND_ANNOUNCEMENTS` 1<<27) so whichever ships first
+  claims sequential bits.
 - Any member with `VIEW_CHANNEL`/guild membership can view and RSVP.
 
 ## Behavior

--- a/docs/superpowers/specs/2026-07-07-scheduled-events-design.md
+++ b/docs/superpowers/specs/2026-07-07-scheduled-events-design.md
@@ -1,0 +1,132 @@
+# Scheduled Events — Design
+
+> Status: design, awaiting approval. 2026-07-07, gap #5a (split from membership
+> screening per the scoping decision).
+
+## Context
+
+Communities schedule things — game nights, streams, meetings — and want members
+to see upcoming events and RSVP. Kaiku has none of this. It has the pieces:
+guilds/channels, the WebSocket event bus, and the background-task pattern
+(`tokio::interval` in `observability/voice.rs` / `retention.rs`) needed to fire
+reminders.
+
+## Goals
+
+- An admin/organizer creates a **guild event**: name, description, start (and
+  optional end) time, and a location — either a voice channel in the guild or an
+  external URL/text.
+- Members **RSVP** (interested / going) and see a count; the event list shows
+  upcoming events sorted by start time.
+- A **reminder** fires shortly before start (in-app now; mobile push once gap #4
+  lands — this feature degrades gracefully without it).
+
+## Non-Goals (YAGNI)
+
+- Recurring events — single occurrences for v1.
+- Auto-start (moving RSVPs into the voice channel at start) — v2.
+- Event cover images — optional later; schema leaves room.
+- Cross-guild/discoverable events — guild-scoped only.
+
+## Data Model
+
+```sql
+-- migration: 20260707000004_guild_events.sql
+CREATE TABLE guild_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    guild_id UUID NOT NULL REFERENCES guilds(id) ON DELETE CASCADE,
+    -- Voice-channel event when set; external event when NULL + location text.
+    channel_id UUID REFERENCES channels(id) ON DELETE SET NULL,
+    name VARCHAR(100) NOT NULL,
+    description VARCHAR(1000),
+    location TEXT,                          -- external URL/text (when channel_id NULL)
+    starts_at TIMESTAMPTZ NOT NULL,
+    ends_at   TIMESTAMPTZ,
+    status VARCHAR(16) NOT NULL DEFAULT 'scheduled', -- scheduled|active|completed|cancelled
+    created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    reminder_sent BOOLEAN NOT NULL DEFAULT FALSE
+);
+CREATE INDEX idx_guild_events_upcoming ON guild_events(guild_id, starts_at)
+    WHERE status = 'scheduled';
+
+CREATE TABLE guild_event_rsvps (
+    event_id UUID NOT NULL REFERENCES guild_events(id) ON DELETE CASCADE,
+    user_id  UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    response VARCHAR(16) NOT NULL,           -- 'interested' | 'going'
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (event_id, user_id)
+);
+```
+
+## Permissions
+
+- Create/edit/cancel needs a new **`MANAGE_EVENTS`** bit (falls back to
+  `MANAGE_GUILD` if we choose not to add a bit — but a dedicated bit is cleaner
+  and matches the granular model).
+- Any member with `VIEW_CHANNEL`/guild membership can view and RSVP.
+
+## Behavior
+
+- Create/edit validates `starts_at` in the future and `ends_at > starts_at`.
+- RSVP is an upsert (change interested↔going, or delete to clear). Counts are
+  aggregate queries; the event list returns `{ interested_count, going_count,
+  my_response }`.
+- A **scheduler task** (`spawn_event_reminder_task`, the existing
+  `tokio::interval` pattern, ~60s tick):
+  - Marks events `active` at `starts_at`, `completed` at `ends_at` (or
+    `starts_at + default` when no end).
+  - For events starting within the reminder window and `reminder_sent = false`,
+    notifies RSVP'd members (in-app `ServerEvent`; a push wake-signal once gap
+    #4 exists) and sets `reminder_sent`.
+
+## Real-Time (WS)
+
+New `ServerEvent`s broadcast to the guild: `GuildEventCreated`,
+`GuildEventUpdated` (includes status transitions + RSVP counts),
+`GuildEventCancelled`, and a per-user `GuildEventReminder`.
+
+## API Surface
+
+New module `server/src/guild/events.rs` (Tier-1 layout):
+`GET /api/guilds/{id}/events` (upcoming; `?scope=past` for history),
+`POST /api/guilds/{id}/events` (`MANAGE_EVENTS`),
+`PATCH/DELETE /api/guilds/{id}/events/{event_id}`,
+`PUT /api/guilds/{id}/events/{event_id}/rsvp {response}`,
+`DELETE …/rsvp`.
+
+## Client
+
+- An **Events** panel in the guild view (and an entry in the guild header): a
+  list of upcoming event cards (name, time, location, going count, RSVP button),
+  a create/edit modal (`MANAGE_EVENTS`), and a reminder toast/notification
+  handler in `stores/websocket`.
+- Voice-channel events link to the channel; external events show the location
+  link (through the existing safe-URL rendering).
+
+## Edge Cases
+
+- Event's voice channel deleted → `channel_id` SET NULL, event becomes an
+  external/placeholder event (or auto-cancel — pick auto-cancel with a logged
+  reason for clarity).
+- Organizer leaves/deleted → `created_by` SET NULL, event persists.
+- Server downtime across a reminder window → on restart the task still fires
+  reminders for not-yet-started events (idempotent via `reminder_sent`); events
+  whose start passed during downtime are marked `active`/`completed` without a
+  late reminder.
+- Timezone: all times are UTC in storage; the client localizes.
+
+## Testing
+
+- Create validates future start + end ordering; `MANAGE_EVENTS` gate.
+- RSVP upsert/clear; counts correct.
+- Scheduler: transitions scheduled→active→completed at the right times;
+  reminder fires once (idempotent), suppressed for cancelled events.
+- WS events broadcast on create/update/cancel.
+
+## Rollout
+
+Additive tables + one background task + endpoints + client panel. Reminders are
+in-app until mobile push (#4) lands, at which point the reminder path gains a
+push wake-signal with no schema change. No dependency ordering beyond that
+graceful enhancement.


### PR DESCRIPTION
## Summary
Design specs for the six feature gaps from the Kaiku-vs-Discord/TeamSpeak analysis, each grounded in the actual codebase and cross-checked for integration:

- **reaction-roles** — self-assignable roles (toggle + unique-group); reuses reactions/roles/permissions; adds `MemberRolesUpdated` WS event (retrofits the silent admin role path).
- **rich-embeds-and-components** — JSONB embeds + interactive buttons/menus on messages; extends the **existing** bot-gateway interaction model (`CommandInvoked`/`interaction_id`) with one `ComponentInvoked` event + `components` intent.
- **forum-and-announcement-channels** — `ChannelType::Forum` reuses the `parent_id` thread system (posts = thread starters + tags); Announcement adds `SEND_ANNOUNCEMENTS` + cross-guild follow/crosspost. (Migration uses `ALTER TYPE channel_type ADD VALUE` — it's a Postgres ENUM.)
- **scheduled-events** — `guild_events` + RSVPs + a `tokio::interval` reminder task; degrades gracefully until push lands.
- **membership-screening** — `pending` membership gated by a single permission-resolver short-circuit (covers WS subscribe via `require_channel_access`); unifies the 3 guild-join insert sites.
- **mobile-push-notifications** — provider-agnostic dispatcher, UnifiedPush default (FCM pluggable), content-free wake signals to preserve E2EE, reuses the webhook SSRF guard + DND/quiet-hours gating.

Integration verified against code: `GuildPermissions` is `u64` with bits 0–25 used (new bits `MANAGE_POSTS`=1<<26, `SEND_ANNOUNCEMENTS`=1<<27, `MANAGE_EVENTS`=1<<28); `assign_role_to_member` is idempotent; the bot-gateway interaction model + intents exist to reuse; the member-liveness events (`MemberRolesUpdated`/`MemberUpdated`) are coordinated into one.

Docs only — first step of the "ship all six gap features" workstream (spec set → k6 stress harness → feature-by-feature implement/deploy/test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdxjK7ngJvdtdREoJJrr3H