### PR TITLE
fix(infra): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Opening a channel with unreads scrolls to your last read position
 
 ### Security
+- Update `crossbeam-epoch` 0.9.18 → 0.9.20 (RUSTSEC-2026-0204, invalid pointer dereference in a `fmt::Pointer` impl; transitive, lockfile-only), restoring the Security Audit / License Compliance checks to green
 - Hardened login against username enumeration: a login attempt now performs the same Argon2 password verification whether or not the account exists, so response timing no longer reveals valid usernames
 - CORS with `CORS_ALLOWED_ORIGINS=*` no longer sends `Access-Control-Allow-Credentials`; mirroring the Origin with credentials would have let any website make credentialed cross-origin requests. Same-origin app traffic is unaffected; set explicit origins for trusted credentialed cross-origin access
 - The web client's HTML sanitizers (chat messages and wiki pages) now use isolated DOMPurify instances instead of sharing one with global hooks, and wiki pages no longer allow arbitrary CSS `class` attributes (prevents cross-context sanitizer drift and CSS-based UI redressing)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2447,9 +2447,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary
New advisory **RUSTSEC-2026-0204** (crossbeam-epoch invalid pointer dereference in a `fmt::Pointer` impl, fixed in 0.9.20) turned `cargo deny check advisories` red on every PR, including the docs-only spec PR #634 — it scans the unchanged `Cargo.lock` against the live advisory DB. `crossbeam-epoch` is a transitive dependency; this is a lockfile-only patch bump (0.9.18 → 0.9.20).

## Test plan
- [x] `cargo deny check advisories` — ok
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdxjK7ngJvdtdREoJJrr3H