### PR TITLE
chore(stress): k6 load/stress harness (bootstrap)

### DIFF
--- a/stress/README.md
+++ b/stress/README.md
@@ -1,0 +1,85 @@
+# Kaiku load & stress harness (k6)
+
+Reusable [k6](https://k6.io) scenarios for load- and stress-testing the server.
+Each gap feature adds one scenario for its new endpoints; every scenario shares
+the same auth helper, metrics, and pass/fail thresholds.
+
+## Install k6
+
+k6 is a single standalone binary — no toolchain added to the repo.
+
+```bash
+# Arch / CachyOS
+sudo pacman -S k6           # or: yay -S k6-bin
+# Debian/Ubuntu
+sudo gpg -k && \
+  curl -s https://dl.k6.io/key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/k6-archive-keyring.gpg && \
+  echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list && \
+  sudo apt-get update && sudo apt-get install k6
+# Or grab the release binary: https://github.com/grafana/k6/releases
+```
+
+## Run
+
+```bash
+# 1) Validate the harness itself (do this first).
+BASE_URL=http://localhost:8080 k6 run stress/scenarios/smoke.js
+
+# 2) A feature scenario.
+BASE_URL=http://localhost:8080 k6 run stress/scenarios/reaction-roles.js
+
+# Tune the load.
+VUS=50 DURATION=2m BASE_URL=http://localhost:8080 k6 run stress/scenarios/<name>.js
+```
+
+### Environment variables
+
+| Var | Default | Meaning |
+|---|---|---|
+| `BASE_URL` | `http://localhost:8080` | Server under test |
+| `VUS` | `10` | Virtual users (concurrency) |
+| `DURATION` | `30s` | Run length |
+| `LOAD_USER` / `LOAD_PASS` | `k6_load_test` / … | Dedicated load-test account (created if registration is open) |
+
+## Reading results
+
+Thresholds (in `lib/config.js`) are the pass/fail gate — k6 exits non-zero if any fails:
+
+- **`server_errors` < 1%** — rate of 5xx. This is the real failure signal.
+- **`http_req_duration` p95 < 800ms** — latency budget.
+- **`checks` > 95%** — scenario assertions passing.
+
+A **429** is *not* a failure — it's the rate limiter correctly shedding load. It's
+tracked separately as `rate_limited` (informational). A healthy stress result is
+"low 5xx, bounded p95, 429s appearing only once you exceed the configured
+limits."
+
+While a run is in flight, watch the **admin Command Center** (Settings → Admin →
+Command Center): CPU %, memory, p95 latency, and error rate should stay bounded.
+A query-count / N+1 regression shows up as **latency climbing with VUs** while
+throughput plateaus.
+
+## ⚠️ Running against the beta
+
+The beta (`kaiku.pmind.de`) shares a host with game servers and enforces per-IP
+and per-user rate limits. So:
+
+- Use a **dedicated** `LOAD_USER`, never a real account.
+- Keep beta runs **short and bounded** (low `VUS`, ≤30s) — enough to sanity-check
+  a deploy, not to saturate.
+- Do **heavy** runs against a **local** server (`docker-compose.dev` + a local
+  build), where you can push high `VUS` without impacting the beta or tripping
+  shared rate limits.
+
+## Layout
+
+```
+stress/
+  lib/
+    config.js    # BASE_URL, load shape, thresholds
+    metrics.js   # server_errors (5xx) vs rate_limited (429)
+    auth.js      # authenticate() -> bearer token (use in setup())
+  scenarios/
+    smoke.js     # validates the harness (run first)
+    _template.js # copy per feature
+```

--- a/stress/lib/auth.js
+++ b/stress/lib/auth.js
@@ -1,0 +1,63 @@
+// Shared auth helper: obtain a bearer token for a dedicated load-test user.
+//
+// Call authenticate() from a scenario's setup() (runs once, before the VUs) so
+// all VUs reuse one token and the login/register calls don't themselves hammer
+// the auth rate limiter. The token is passed to the default function via the
+// setup return value.
+
+import http from "k6/http";
+import { check } from "k6";
+import { BASE_URL } from "./config.js";
+
+const JSON_HEADERS = { "Content-Type": "application/json" };
+
+// A dedicated throwaway account. Override for CI/beta with env vars.
+const USER = __ENV.LOAD_USER || "k6_load_test";
+const PASS = __ENV.LOAD_PASS || "k6-Load-Test-Pass-9271";
+
+/**
+ * Log in the load-test user, registering it first if it doesn't exist.
+ * Returns a bearer access token. Throws (fails setup) if auth can't succeed.
+ */
+export function authenticate() {
+  let res = http.post(
+    `${BASE_URL}/auth/login`,
+    JSON.stringify({ username: USER, password: PASS }),
+    { headers: JSON_HEADERS },
+  );
+
+  if (res.status !== 200) {
+    // Register (best-effort; open-registration servers only) then log in again.
+    http.post(
+      `${BASE_URL}/auth/register`,
+      JSON.stringify({
+        username: USER,
+        password: PASS,
+        display_name: "k6 Load Test",
+      }),
+      { headers: JSON_HEADERS },
+    );
+    res = http.post(
+      `${BASE_URL}/auth/login`,
+      JSON.stringify({ username: USER, password: PASS }),
+      { headers: JSON_HEADERS },
+    );
+  }
+
+  check(res, { "auth: login 200": (r) => r.status === 200 });
+  const token = res.json("access_token");
+  if (!token) {
+    throw new Error(
+      `authenticate(): no access_token (status ${res.status}). ` +
+        `Is registration open, or the account already MFA-protected?`,
+    );
+  }
+  return token;
+}
+
+/** Headers for an authenticated JSON request. */
+export function authHeaders(token) {
+  return {
+    headers: { ...JSON_HEADERS, Authorization: `Bearer ${token}` },
+  };
+}

--- a/stress/lib/config.js
+++ b/stress/lib/config.js
@@ -1,0 +1,32 @@
+// Shared k6 configuration for the Kaiku load/stress harness.
+//
+// Target is chosen by env var so the same scenarios run against a local server
+// or the beta:  BASE_URL=https://kaiku.pmind.de k6 run stress/scenarios/smoke.js
+//
+// See stress/README.md for usage and the rate-limit / beta caveats.
+
+export const BASE_URL = __ENV.BASE_URL || "http://localhost:8080";
+
+// Load shape, overridable per run.  Kept small by default so an accidental beta
+// run stays bounded.
+export const VUS = Number(__ENV.VUS || 10);
+export const DURATION = __ENV.DURATION || "30s";
+
+// Pass/fail gates. The real failure signal is server errors (5xx) and latency;
+// a 429 is the rate limiter working *correctly* under stress, so it is tracked
+// separately (see lib/metrics.js) and does NOT fail the run. This is why we
+// gate on `server_errors` rather than k6's built-in `http_req_failed` (which
+// counts every 4xx, including expected 429s, as a failure).
+export const thresholds = {
+  server_errors: ["rate<0.01"], // < 1% of requests return 5xx
+  http_req_duration: ["p(95)<800"], // p95 latency under 800ms
+  checks: ["rate>0.95"], // > 95% of scenario assertions pass
+};
+
+export const baseOptions = {
+  vus: VUS,
+  duration: DURATION,
+  thresholds,
+  // Abort a run early if the error gate is already blown — fail fast.
+  abortOnFail: true,
+};

--- a/stress/lib/metrics.js
+++ b/stress/lib/metrics.js
@@ -1,0 +1,18 @@
+// Custom k6 metrics that separate real failures from expected back-pressure.
+//
+// Under stress the server *should* start returning 429 (rate limited) — that is
+// correct behavior, not a failure. So we track:
+//   - server_errors : rate of 5xx responses  (the real failure gate)
+//   - rate_limited  : rate of 429 responses  (informational; expected under load)
+// Call recordResponse(res) after every request in a scenario.
+
+import { Rate } from "k6/metrics";
+
+export const serverErrors = new Rate("server_errors");
+export const rateLimited = new Rate("rate_limited");
+
+export function recordResponse(res) {
+  serverErrors.add(res.status >= 500);
+  rateLimited.add(res.status === 429);
+  return res;
+}

--- a/stress/scenarios/_template.js
+++ b/stress/scenarios/_template.js
@@ -1,0 +1,45 @@
+// Per-feature scenario TEMPLATE. Copy to `<feature>.js` and fill in.
+//
+// Each gap feature adds one scenario here that exercises its new endpoints under
+// concurrent load. Keep to the shared config/metrics/auth helpers so every
+// scenario reports the same thresholds and the same 5xx-vs-429 distinction.
+//
+//   cp stress/scenarios/_template.js stress/scenarios/reaction-roles.js
+//   BASE_URL=http://localhost:8080 k6 run stress/scenarios/reaction-roles.js
+//
+// Checklist for a feature scenario:
+//   - Drive the feature's hot path(s): the write endpoint(s) + a read/list.
+//   - Use setup() for one-time fixtures (a guild, a channel, a message, a role)
+//     so per-VU iterations only hit the endpoint under test.
+//   - Assert correctness under load (status + a body check), not just latency.
+//   - Watch the admin Command Center (CPU / memory / p95 / error rate) during
+//     the run; a query-count/N+1 regression shows up as latency growth with VUs.
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { BASE_URL, baseOptions } from "../lib/config.js";
+import { authenticate, authHeaders } from "../lib/auth.js";
+import { recordResponse } from "../lib/metrics.js";
+
+export const options = baseOptions;
+
+export function setup() {
+  const token = authenticate();
+  // TODO: create the fixtures this feature needs (guild/channel/message/role…)
+  // and return their ids alongside the token.
+  return { token };
+}
+
+export default function (data) {
+  const h = authHeaders(data.token);
+
+  // TODO: replace with the feature's endpoint(s).
+  const res = recordResponse(http.get(`${BASE_URL}/api/me/unread`, h));
+  check(res, { "ok or rate-limited": (r) => r.status < 500 });
+
+  sleep(1);
+}
+
+export function teardown() {
+  // TODO: delete any fixtures created in setup() (guild delete cascades most).
+}

--- a/stress/scenarios/smoke.js
+++ b/stress/scenarios/smoke.js
@@ -1,0 +1,42 @@
+// Smoke scenario — validates the harness itself, not a feature.
+//
+// Proves: config/target resolves, the auth helper obtains a token, requests
+// fire, custom metrics record, and thresholds evaluate. Run this first after
+// installing k6 and before trusting any feature scenario.
+//
+//   BASE_URL=http://localhost:8080 k6 run stress/scenarios/smoke.js
+//
+// Small, bounded load (safe against the beta). Override with VUS / DURATION.
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { BASE_URL, thresholds } from "../lib/config.js";
+import { authenticate, authHeaders } from "../lib/auth.js";
+import { recordResponse } from "../lib/metrics.js";
+
+export const options = {
+  vus: Number(__ENV.VUS || 5),
+  duration: __ENV.DURATION || "20s",
+  thresholds,
+};
+
+export function setup() {
+  return { token: authenticate() };
+}
+
+export default function (data) {
+  // Unauthenticated liveness endpoint.
+  const health = recordResponse(http.get(`${BASE_URL}/health`));
+  check(health, { "health: 200": (r) => r.status === 200 });
+
+  // Authenticated read endpoint (accepts 429 under load — the rate limiter
+  // working is not a smoke failure).
+  const unread = recordResponse(
+    http.get(`${BASE_URL}/api/me/unread`, authHeaders(data.token)),
+  );
+  check(unread, {
+    "unread: 200 or 429": (r) => r.status === 200 || r.status === 429,
+  });
+
+  sleep(1);
+}


### PR DESCRIPTION
## Summary
Bootstraps the reusable k6 load/stress harness under `stress/` — the foundation every gap feature's stress test builds on (Step 2 of the "ship all six gap features" workstream).

- **`lib/config.js`** — `BASE_URL`-driven target, load shape (`VUS`/`DURATION`), and pass/fail thresholds.
- **`lib/metrics.js`** — separates `server_errors` (5xx, the real failure gate) from `rate_limited` (429, expected back-pressure — *not* a failure). This is the key design choice: under stress the rate limiter working is correct, so we gate on 5xx + latency, not k6's built-in `http_req_failed`.
- **`lib/auth.js`** — `authenticate()` → bearer token, run once in `setup()` so VUs share a token and don't hammer the auth limiter.
- **`scenarios/smoke.js`** — validates the harness against `/health` + an authed endpoint (run first). **`scenarios/_template.js`** — per-feature copy target.
- **`README.md`** — install, run, reading results against thresholds + the admin Command Center, and the beta rate-limit/load caveats (heavy runs local, bounded runs against the beta).

**Verified working against the beta** (bounded 3 VUs / 10s): all thresholds green — checks 100%, p95 ~80ms, `server_errors` 0%, `rate_limited` 0% at that load.

No app code touched; k6 is a standalone binary (no toolchain added to the repo).

## Test plan
- [x] `k6 run stress/scenarios/smoke.js` against the beta — all thresholds pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdxjK7ngJvdtdREoJJrr3H