### PR TITLE
fix(auth): reaction-roles TOCTOU — re-check role safety at grant time

### DIFF
--- a/server/src/guild/queries/reaction_roles.rs
+++ b/server/src/guild/queries/reaction_roles.rs
@@ -222,6 +222,19 @@ pub async fn tx_member_role_ids(
     Ok(rows.into_iter().map(|(r,)| r).collect())
 }
 
+/// A role's current permission bits (transaction variant, reaction-time guard).
+/// `None` if the role no longer exists.
+pub async fn tx_role_permissions(
+    tx: &mut Transaction<'_, Postgres>,
+    role_id: Uuid,
+) -> Result<Option<i64>, ReactionRoleError> {
+    let row: Option<(i64,)> = sqlx::query_as("SELECT permissions FROM guild_roles WHERE id = $1")
+        .bind(role_id)
+        .fetch_optional(&mut **tx)
+        .await?;
+    Ok(row.map(|(p,)| p))
+}
+
 /// Whether the user is a member of the guild (transaction variant, hook guard).
 pub async fn is_member(
     tx: &mut Transaction<'_, Postgres>,

--- a/server/src/guild/reaction_roles.rs
+++ b/server/src/guild/reaction_roles.rs
@@ -330,6 +330,21 @@ pub async fn apply_on_reaction_add(
         return Ok(None);
     }
 
+    // Defense-in-depth: re-check the role's CURRENT permissions at grant time,
+    // not just at binding creation. If the role has since been escalated to
+    // carry a privileged permission, refuse to self-grant it — a member must
+    // never gain moderator power by reacting, even if an admin later made a
+    // bound role dangerous. Skips silently: the binding is inert until the role
+    // is made safe again.
+    match queries::tx_role_permissions(tx, binding.role_id).await? {
+        Some(bits) => {
+            if !is_role_self_assignable(GuildPermissions::from_bits_truncate(bits as u64)) {
+                return Ok(None);
+            }
+        }
+        None => return Ok(None), // role deleted mid-flight
+    }
+
     queries::tx_assign_role(tx, guild_id, user_id, binding.role_id, user_id).await?;
 
     let mut cleared_emojis = Vec::new();

--- a/server/tests/integration/reaction_roles.rs
+++ b/server/tests/integration/reaction_roles.rs
@@ -165,6 +165,51 @@ async fn non_manager_cannot_create_binding(pool: PgPool) {
 }
 
 #[sqlx::test]
+async fn reaction_does_not_grant_role_escalated_after_binding(pool: PgPool) {
+    // TOCTOU guard: a role that was safe when bound but has since gained a
+    // dangerous permission must NOT be self-grantable by reacting.
+    let app = TestApp::with_pool(pool.clone()).await;
+    let (owner, _) = create_test_user(&pool).await;
+    let guild = create_guild_with_default_role(
+        &pool,
+        owner,
+        GuildPermissions::ADD_REACTIONS | GuildPermissions::VIEW_CHANNEL,
+    )
+    .await;
+    let (member, _) = create_test_user(&pool).await;
+    add_guild_member(&pool, guild, member).await;
+    let channel = create_channel(&pool, guild, "general").await;
+    let msg = insert_message(&pool, channel, owner, "react").await;
+    // Bound while safe.
+    let role = insert_role(&pool, guild, GuildPermissions::SEND_MESSAGES, 5).await;
+    insert_binding_row(&pool, guild, channel, msg, "🎨", role, "toggle", None).await;
+
+    // Later escalated to carry a dangerous permission.
+    sqlx::query("UPDATE guild_roles SET permissions = $1 WHERE id = $2")
+        .bind(GuildPermissions::MANAGE_GUILD.bits() as i64)
+        .bind(role)
+        .execute(&pool)
+        .await
+        .expect("escalate role");
+
+    let token = token_for(&app, member);
+    let put = TestApp::request(
+        Method::PUT,
+        &format!("/api/channels/{channel}/messages/{msg}/reactions"),
+    )
+    .header("Authorization", format!("Bearer {token}"))
+    .header("Content-Type", "application/json")
+    .body(Body::from(json!({ "emoji": "🎨" }).to_string()))
+    .unwrap();
+    // Reaction itself succeeds, but the role is NOT granted.
+    let _ = app.oneshot(put).await;
+    assert!(
+        !has_role(&pool, guild, member, role).await,
+        "escalated role must not be self-granted"
+    );
+}
+
+#[sqlx::test]
 async fn toggle_reaction_grants_and_revokes_role(pool: PgPool) {
     let app = TestApp::with_pool(pool.clone()).await;
     let (owner, _) = create_test_user(&pool).await;

--- a/stress/scenarios/reaction-roles.js
+++ b/stress/scenarios/reaction-roles.js
@@ -1,0 +1,119 @@
+// Reaction-roles stress scenario.
+//
+// Drives the feature's hot paths under concurrent load:
+//   - GET  /api/guilds/{id}/reaction-roles          (list bindings, read)
+//   - PUT  /api/channels/{cid}/messages/{mid}/reactions   (react → grant role)
+//   - DELETE .../reactions/{emoji}                  (un-react → revoke role)
+//
+// The PUT/DELETE exercise the transactional reaction-role hook (binding lookup,
+// role grant/revoke, MemberRolesUpdated broadcast). setup() builds all fixtures
+// once (guild, channel, message, role, binding) so per-VU iterations only touch
+// the endpoints under test.
+//
+//   BASE_URL=http://localhost:8080 k6 run stress/scenarios/reaction-roles.js
+//   VUS=50 DURATION=1m BASE_URL=https://kaiku.pmind.de k6 run stress/scenarios/reaction-roles.js
+//
+// An ASCII token ("rr") is used as the "emoji" so the DELETE path needs no
+// URL-encoding; the server accepts any string ≤64 chars as a reaction key.
+
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { BASE_URL, baseOptions } from "../lib/config.js";
+import { authenticate, authHeaders } from "../lib/auth.js";
+import { recordResponse } from "../lib/metrics.js";
+
+export const options = baseOptions;
+
+const EMOJI = "rr";
+
+export function setup() {
+  const token = authenticate();
+  const h = authHeaders(token);
+  const jsonHeaders = { headers: { ...h.headers, "Content-Type": "application/json" } };
+
+  const guild = http.post(
+    `${BASE_URL}/api/guilds`,
+    JSON.stringify({ name: `rr-stress-${Date.now()}` }),
+    jsonHeaders,
+  );
+  check(guild, { "setup: guild created": (r) => r.status === 200 || r.status === 201 });
+  const guildId = guild.json("id");
+
+  const channel = http.post(
+    `${BASE_URL}/api/channels`,
+    JSON.stringify({ name: "rr-stress", channel_type: "text", guild_id: guildId }),
+    jsonHeaders,
+  );
+  check(channel, { "setup: channel created": (r) => r.status === 200 || r.status === 201 });
+  const channelId = channel.json("id");
+
+  const message = http.post(
+    `${BASE_URL}/api/messages/channel/${channelId}`,
+    JSON.stringify({ content: "React to get the role" }),
+    jsonHeaders,
+  );
+  check(message, { "setup: message created": (r) => r.status === 200 || r.status === 201 });
+  const messageId = message.json("id");
+
+  // A safe (no-permission) role, bindable by the owner (who bypasses hierarchy).
+  const role = http.post(
+    `${BASE_URL}/api/guilds/${guildId}/roles`,
+    JSON.stringify({ name: "rr-stress-role", permissions: 0 }),
+    jsonHeaders,
+  );
+  check(role, { "setup: role created": (r) => r.status === 200 || r.status === 201 });
+  const roleId = role.json("id");
+
+  const binding = http.post(
+    `${BASE_URL}/api/guilds/${guildId}/reaction-roles`,
+    JSON.stringify({
+      channel_id: channelId,
+      message_id: messageId,
+      emoji: EMOJI,
+      role_id: roleId,
+      mode: "toggle",
+    }),
+    jsonHeaders,
+  );
+  check(binding, { "setup: binding created": (r) => r.status === 200 || r.status === 201 });
+
+  return { token, guildId, channelId, messageId };
+}
+
+export default function (data) {
+  const h = authHeaders(data.token);
+  const jsonHeaders = { headers: { ...h.headers, "Content-Type": "application/json" } };
+
+  // Read: list bindings for the guild.
+  const list = recordResponse(
+    http.get(`${BASE_URL}/api/guilds/${data.guildId}/reaction-roles`, h),
+  );
+  check(list, { "list: ok or rate-limited": (r) => r.status < 500 });
+
+  // Write: react → grant the role (runs the transactional hook).
+  const react = recordResponse(
+    http.put(
+      `${BASE_URL}/api/channels/${data.channelId}/messages/${data.messageId}/reactions`,
+      JSON.stringify({ emoji: EMOJI }),
+      jsonHeaders,
+    ),
+  );
+  check(react, { "react: ok or rate-limited": (r) => r.status < 500 });
+
+  // Write: un-react → revoke the role.
+  const unreact = recordResponse(
+    http.del(
+      `${BASE_URL}/api/channels/${data.channelId}/messages/${data.messageId}/reactions/${EMOJI}`,
+      null,
+      h,
+    ),
+  );
+  check(unreact, { "unreact: ok or rate-limited": (r) => r.status < 500 });
+
+  sleep(1);
+}
+
+export function teardown(data) {
+  // Guild delete cascades to channel, message, role, and bindings.
+  http.del(`${BASE_URL}/api/guilds/${data.guildId}`, null, authHeaders(data.token));
+}


### PR DESCRIPTION
## Summary
Security follow-up to #637 (reaction roles). The "role is not self-assignable if it carries a privileged permission" guard previously ran **only at binding-creation time**. If an admin later escalated a bound role's permissions (e.g. added `MANAGE_GUILD` to a role that already has a reaction-role binding), members could then self-grant that now-dangerous role just by reacting — defeating the feature's "safe by construction" guarantee.

This adds a **defense-in-depth re-check at grant time**: `apply_on_reaction_add` now reads the role's *current* permissions inside the same transaction and refuses the grant if the role is no longer self-assignable (reusing the same `EVERYONE_FORBIDDEN` deny-list). The binding goes silently inert until the role is made safe again — no error to the reacting member.

Found during the mandated post-merge security review of the reaction-roles code. (The three endpoints were otherwise clean: all scope role/channel/message/binding to `guild_id`, so no cross-guild IDOR; creation enforces hierarchy + the dangerous-perm deny-list; input is validated.)

## Test plan
- [x] New integration test `reaction_does_not_grant_role_escalated_after_binding`: bind a safe role, escalate it to `MANAGE_GUILD`, react → role is **not** granted
- [x] All 8 reaction-role integration tests pass
- [x] `cargo clippy -p vc-server --all-targets` clean; nightly `cargo fmt --check` clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)