### PR TITLE
fix(ws): rate-limit component interactions (DoS hardening)

### DIFF
--- a/server/src/ws/handlers.rs
+++ b/server/src/ws/handlers.rs
@@ -820,6 +820,21 @@ async fn handle_component_interaction(
         async move { tx.send(OutboundMsg::Event(ev)).await }
     };
 
+    // Rate-limit clicks per user — each interaction does Redis writes + a
+    // publish + DB reads, so spammed clicks must not flood a bot or Redis.
+    if let Some(rate_limiter) = &state.rate_limiter {
+        let identifier = format!("component_interaction:{user_id}");
+        let allowed = rate_limiter
+            .check(crate::ratelimit::RateLimitCategory::WsMessage, &identifier)
+            .await
+            .map(|r| r.allowed)
+            .unwrap_or(true); // fail-open on limiter error (availability)
+        if !allowed {
+            send_err("rate_limited", "You're interacting too quickly").await?;
+            return Ok(());
+        }
+    }
+
     // The message must exist and the user must be able to view its channel.
     let Some(message) = db::find_message_by_id(&state.db, message_id).await? else {
         send_err("message_not_found", "Message not found").await?;


### PR DESCRIPTION
## Summary
Security follow-up to #640 (interactive components), from the post-merge review. A component-interaction click does two Redis writes + a publish + several DB reads and routes to a bot — so a user spamming clicks could flood the owning bot or fill Redis with interaction keys. The handler had no rate limit.

This applies the existing `RateLimitCategory::WsMessage` limiter, keyed per clicking user (`component_interaction:{user_id}`), at the top of `handle_component_interaction`. On exceed, the user gets a `rate_limited` error and no interaction is minted/published. Fails open if the limiter errors (availability over strictness, matching the bot-gateway pattern).

Found during the mandated security review of feature #2. The rest of the components/embeds surface was clean: bot-only gating runs before validation (human → 403), https-only URLs, render-time sanitization via isolated DOMPurify, and the interaction path already checks channel access + `custom_id_present` + bot authorship + interaction ownership/expiry.

## Test plan
- [x] `cargo check` / `clippy -p vc-server --all-targets` clean; nightly `fmt --check` clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)