### PR TITLE
fix(voice): show own screen-share self-preview

### DIFF
--- a/client/src/stores/voice.ts
+++ b/client/src/stores/voice.ts
@@ -21,6 +21,7 @@ import type {
 import type { VoiceParticipant, WebcamServerInfo } from "@/lib/types";
 import { channelsState } from "@/stores/channels";
 import { appSettings } from "@/stores/settings";
+import { currentUser } from "@/stores/auth";
 import * as tauri from "@/lib/tauri";
 import { showToast, dismissToast } from "@/components/ui/Toast";
 import { PttController, createTauriPttListeners, type PttFullConfig } from "@/lib/pttManager";
@@ -860,6 +861,24 @@ export async function startScreenShare(
     return { ok: false, error: "Failed to notify server" };
   }
 
+  // Register our own capture track for self-preview. The SFU forwards our track
+  // to OTHER subscribers, never back to us, so our own tile would otherwise have
+  // no track and render blank. The browser adapter exposes the local track; the
+  // native adapter returns null (it renders its own preview), so this is a no-op
+  // there.
+  const localTrack = adapter.getScreenShareTrack(streamId);
+  if (localTrack) {
+    const me = currentUser();
+    const { addAvailableTrack } = await import("@/stores/screenShareViewer");
+    addAvailableTrack(
+      streamId,
+      localTrack,
+      me?.id ?? "self",
+      me?.display_name || me?.username || "You",
+      sourceLabel,
+    );
+  }
+
   setVoiceState({ screenSharing: true });
   return { ok: true };
 }
@@ -873,12 +892,17 @@ export async function stopScreenShare(streamId?: string): Promise<void> {
   const channelId = voiceState.channelId;
   const adapter = await createVoiceAdapter();
 
+  // Remove our own self-preview track(s) from the viewer. Stopping a track
+  // programmatically doesn't reliably fire `onended`, so clear it explicitly.
+  const { removeAvailableTrack } = await import("@/stores/screenShareViewer");
+
   if (streamId) {
     // Stop a specific stream
     const result = await adapter.stopScreenShare(streamId);
     if (!result.ok) {
       console.error("Failed to stop screen share:", result.error);
     }
+    removeAvailableTrack(streamId);
 
     // Notify server about this specific stream stop
     if (channelId) {
@@ -907,6 +931,7 @@ export async function stopScreenShare(streamId?: string): Promise<void> {
     if (!result.ok) {
       console.error("Failed to stop all screen shares:", result.error);
     }
+    for (const info of allInfo) removeAvailableTrack(info.streamId);
 
     // Notify server about each stream stop
     if (channelId) {


### PR DESCRIPTION
## Summary
Reported live: starting a screen share shows a **blank self-preview** even though the share publishes fine (server logs confirm the SFU receives the video track and forwards it).

Root cause: the SFU forwards a publisher's track only to **other** subscribers — it never echoes the track back to the sharer. The viewer renders tracks from `availableTracks`, which is populated exclusively by the remote `onScreenShareTrack` callback. So the sharer's own capture track was never registered, and their tile had a null track → blank.

Fix: in `startScreenShare`, after the capture succeeds, register the local track for self-view via the adapter's existing `getScreenShareTrack(streamId)` (browser adapter returns the real `MediaStreamTrack`; the native/Tauri adapter returns null, so it's a no-op there and native keeps its own preview path). `stopScreenShare` now explicitly removes the self-view track(s) too, since stopping a track programmatically doesn't reliably fire `onended`.

Note: the two console errors reported alongside this are unrelated pre-existing noise — the `(index):23` CSP error is a harmless best-effort theme-image preload, and `[WebSocket] No WebSocket instance found` is a transient startup log that self-heals on socket open.

## Test plan
- [x] `bun run build` + lint (0 errors); 620 client tests pass
- [ ] Live: start a screen share solo → own preview now renders; stop → tile clears