### PR TITLE
fix(auth): revoke access tokens on logout and session revoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Opening a channel with unreads scrolls to your last read position
 
 ### Security
+- Logging out (or revoking a session from account settings) now immediately invalidates that session's access token. Previously the stateless access token kept working for up to its 15-minute lifetime after logout, so a captured token stayed usable on a shared or compromised device even after the user signed out. Access tokens now carry the session id and are checked against a short-lived server-side revocation list on every request and WebSocket connection
 - Update `crossbeam-epoch` 0.9.18 → 0.9.20 (RUSTSEC-2026-0204, invalid pointer dereference in a `fmt::Pointer` impl; transitive, lockfile-only), restoring the Security Audit / License Compliance checks to green
 - Hardened login against username enumeration: a login attempt now performs the same Argon2 password verification whether or not the account exists, so response timing no longer reveals valid usernames
 - CORS with `CORS_ALLOWED_ORIGINS=*` no longer sends `Access-Control-Allow-Credentials`; mirroring the Origin with credentials would have let any website make credentialed cross-origin requests. Same-origin app traffic is unaffected; set explicit origins for trusted credentialed cross-origin access

--- a/server/src/auth/jwt.rs
+++ b/server/src/auth/jwt.rs
@@ -28,6 +28,11 @@ pub struct Claims {
     /// JWT ID for refresh token revocation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub jti: Option<String>,
+    /// Session ID (set on access tokens) linking the token to the session it
+    /// was issued with, so logging out or revoking that session can invalidate
+    /// the still-valid stateless access token via a short-lived denylist.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sid: Option<String>,
 }
 
 /// Token type discriminator.
@@ -81,13 +86,16 @@ pub fn generate_token_pair(
     let encoding_key = EncodingKey::from_ed_pem(&key_bytes)
         .map_err(|e| AuthError::Internal(format!("Invalid Ed25519 private key: {e}")))?;
 
-    // Access token
+    // Access token. Carries `sid` = the refresh session's id so the token can
+    // be revoked when that session is logged out or revoked. The matching
+    // session row is stored under the same id (see `create_session`).
     let access_claims = Claims {
         sub: user_id.to_string(),
         exp: (now + Duration::seconds(access_expiry_seconds)).timestamp(),
         iat: now.timestamp(),
         typ: TokenType::Access,
         jti: None,
+        sid: Some(refresh_token_id.to_string()),
     };
 
     let access_token = encode(
@@ -103,6 +111,7 @@ pub fn generate_token_pair(
         iat: now.timestamp(),
         typ: TokenType::Refresh,
         jti: Some(refresh_token_id.to_string()),
+        sid: None,
     };
 
     let refresh_token = encode(
@@ -243,6 +252,25 @@ mod tests {
         let result = validate_refresh_token(&tokens.access_token, TEST_PUBLIC_KEY);
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_access_token_sid_matches_refresh_jti() {
+        // The access token's `sid` must equal the refresh token's `jti` so that
+        // logging out / revoking the session (keyed on that id) invalidates the
+        // paired access token via the denylist.
+        let user_id = Uuid::now_v7();
+
+        let tokens = generate_token_pair(user_id, TEST_PRIVATE_KEY, 900, 604800).unwrap();
+        let access = validate_access_token(&tokens.access_token, TEST_PUBLIC_KEY).unwrap();
+        let refresh = validate_refresh_token(&tokens.refresh_token, TEST_PUBLIC_KEY).unwrap();
+
+        assert_eq!(
+            access.sid.as_deref(),
+            Some(tokens.refresh_token_id.to_string().as_str())
+        );
+        assert_eq!(access.sid, refresh.jti);
+        assert!(access.jti.is_none(), "access token must not carry a jti");
     }
 
     #[test]

--- a/server/src/auth/login.rs
+++ b/server/src/auth/login.rs
@@ -198,6 +198,7 @@ pub async fn login(
 
     create_session(
         &state.db,
+        tokens.refresh_token_id,
         user.id,
         &token_hash,
         expires_at,
@@ -325,6 +326,7 @@ pub async fn refresh_token(
     queries::insert_session_tx(
         &mut tx,
         &InsertSessionParams {
+            id: new_tokens.refresh_token_id,
             user_id,
             token_hash: &new_token_hash,
             expires_at,
@@ -399,6 +401,20 @@ pub async fn logout(
     }
 
     delete_session_by_token_hash(&state.db, &token_hash).await?;
+
+    // Deleting the refresh session kills future refreshes, but the current
+    // stateless access token would otherwise stay valid until it expires.
+    // Add its session id (== the access token's `sid` claim) to the revocation
+    // denylist for the access-token lifetime so it stops working immediately.
+    if let Err(e) = super::revocation::revoke_session(
+        &state.redis,
+        &session.id.to_string(),
+        state.config.jwt_access_expiry,
+    )
+    .await
+    {
+        tracing::warn!(error = %e, user_id = %auth_user.id, "Failed to denylist access token on logout");
+    }
 
     tracing::info!(user_id = %auth_user.id, "User logged out");
 
@@ -864,6 +880,7 @@ pub async fn oidc_callback(
     let expires_at = Utc::now() + Duration::seconds(state.config.jwt_refresh_expiry);
     create_session(
         &state.db,
+        tokens.refresh_token_id,
         user.id,
         &token_hash,
         expires_at,

--- a/server/src/auth/mfa.rs
+++ b/server/src/auth/mfa.rs
@@ -495,6 +495,7 @@ pub async fn qr_redeem(
     let user_agent = extract_user_agent(&headers);
     create_session(
         &state.db,
+        tokens.refresh_token_id,
         user_id,
         &token_hash,
         expires_at,

--- a/server/src/auth/middleware.rs
+++ b/server/src/auth/middleware.rs
@@ -80,6 +80,15 @@ pub async fn require_auth(
     // Validate JWT
     let claims = validate_access_token(token, &state.config.jwt_public_key)?;
 
+    // Reject tokens whose session has been logged out or revoked. Access tokens
+    // are stateless, so without this check a token keeps working until it
+    // expires even after the user logs out.
+    if let Some(sid) = claims.sid.as_deref() {
+        if super::revocation::is_session_revoked(&state.redis, sid).await {
+            return Err(AuthError::InvalidToken);
+        }
+    }
+
     // Parse user ID from claims
     let user_id: Uuid = claims.sub.parse().map_err(|_| AuthError::InvalidToken)?;
 

--- a/server/src/auth/mod.rs
+++ b/server/src/auth/mod.rs
@@ -18,6 +18,7 @@ mod password;
 pub(crate) mod profile;
 mod queries;
 pub(crate) mod register;
+pub(crate) mod revocation;
 pub(crate) mod sessions;
 pub mod types;
 pub mod ua_parser;

--- a/server/src/auth/queries.rs
+++ b/server/src/auth/queries.rs
@@ -116,6 +116,7 @@ pub async fn insert_oidc_user(
 
 /// Parameters for inserting a new session row.
 pub struct InsertSessionParams<'a> {
+    pub id: Uuid,
     pub user_id: Uuid,
     pub token_hash: &'a str,
     pub expires_at: DateTime<Utc>,
@@ -131,9 +132,10 @@ pub async fn insert_session_tx(
     params: &InsertSessionParams<'_>,
 ) -> Result<(), AuthError> {
     sqlx::query(
-        r"INSERT INTO sessions (user_id, token_hash, expires_at, ip_address, user_agent, city, country)
-          VALUES ($1, $2, $3, $4::inet, $5, $6, $7)",
+        r"INSERT INTO sessions (id, user_id, token_hash, expires_at, ip_address, user_agent, city, country)
+          VALUES ($1, $2, $3, $4, $5::inet, $6, $7, $8)",
     )
+    .bind(params.id)
     .bind(params.user_id)
     .bind(params.token_hash)
     .bind(params.expires_at)

--- a/server/src/auth/register.rs
+++ b/server/src/auth/register.rs
@@ -209,6 +209,7 @@ pub async fn register(
     queries::insert_session_tx(
         &mut tx,
         &InsertSessionParams {
+            id: tokens.refresh_token_id,
             user_id: user.id,
             token_hash: &token_hash,
             expires_at,

--- a/server/src/auth/revocation.rs
+++ b/server/src/auth/revocation.rs
@@ -1,0 +1,55 @@
+//! Access-token revocation denylist.
+//!
+//! Access tokens are stateless and short-lived (~15 min), so logging out or
+//! revoking a session does not, by itself, stop an already-issued access token
+//! from being accepted until it expires. To close that window we keep a small
+//! Redis denylist of revoked **session ids** (the `sid` claim carried by every
+//! access token, equal to the session row id). On logout / session revoke we
+//! add the session id with a TTL equal to the access-token lifetime — after
+//! that the token is expired anyway, so the entry can be dropped.
+//!
+//! The check is intentionally **fail-open**: if Redis is unavailable we accept
+//! the token rather than lock everyone out. This is no worse than the previous
+//! behaviour (no revocation at all) and preserves availability.
+
+use fred::prelude::*;
+
+/// Redis key for a revoked session id.
+fn revoked_key(sid: &str) -> String {
+    format!("canis:revoked_sid:{sid}")
+}
+
+/// Add a session id to the revocation denylist for `ttl_secs` seconds.
+///
+/// `ttl_secs` should be the access-token lifetime; once it elapses any access
+/// token bearing this `sid` is already expired.
+pub async fn revoke_session(
+    redis: &Client,
+    sid: &str,
+    ttl_secs: i64,
+) -> Result<(), fred::error::Error> {
+    let ttl = ttl_secs.max(1);
+    redis
+        .set::<(), _, _>(
+            revoked_key(sid),
+            "1",
+            Some(Expiration::EX(ttl)),
+            None,
+            false,
+        )
+        .await
+}
+
+/// Returns `true` if the session id has been revoked.
+///
+/// Fails open (returns `false`) on Redis errors so an outage cannot lock out
+/// legitimate users; a warning is logged so the condition is observable.
+pub async fn is_session_revoked(redis: &Client, sid: &str) -> bool {
+    match redis.exists::<i64, _>(revoked_key(sid)).await {
+        Ok(count) => count > 0,
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to check token revocation denylist; failing open");
+            false
+        }
+    }
+}

--- a/server/src/auth/sessions.rs
+++ b/server/src/auth/sessions.rs
@@ -106,6 +106,19 @@ pub async fn revoke_session(
 
     queries::delete_session_by_id(&state.db, session_id).await?;
 
+    // Revoke the access token issued with this session (its `sid` claim equals
+    // the session id) so it stops working immediately rather than lingering
+    // until expiry.
+    if let Err(e) = super::revocation::revoke_session(
+        &state.redis,
+        &session_id.to_string(),
+        state.config.jwt_access_expiry,
+    )
+    .await
+    {
+        tracing::warn!(error = %e, session_id = %session_id, "Failed to denylist access token on session revoke");
+    }
+
     tracing::info!(user_id = %auth_user.id, session_id = %session_id, "Session revoked");
 
     Ok(StatusCode::NO_CONTENT)

--- a/server/src/db/queries.rs
+++ b/server/src/db/queries.rs
@@ -371,6 +371,7 @@ pub async fn set_mfa_secret(
 #[allow(clippy::too_many_arguments)]
 pub async fn create_session(
     pool: &PgPool,
+    id: Uuid,
     user_id: Uuid,
     token_hash: &str,
     expires_at: DateTime<Utc>,
@@ -381,11 +382,12 @@ pub async fn create_session(
 ) -> sqlx::Result<Session> {
     sqlx::query_as::<_, Session>(
         r"
-        INSERT INTO sessions (user_id, token_hash, expires_at, ip_address, user_agent, city, country)
-        VALUES ($1, $2, $3, $4::inet, $5, $6, $7)
+        INSERT INTO sessions (id, user_id, token_hash, expires_at, ip_address, user_agent, city, country)
+        VALUES ($1, $2, $3, $4, $5::inet, $6, $7, $8)
         RETURNING id, user_id, token_hash, expires_at, host(ip_address) as ip_address, user_agent, city, country, created_at
         ",
     )
+    .bind(id)
     .bind(user_id)
     .bind(token_hash)
     .bind(expires_at)

--- a/server/src/db/tests.rs
+++ b/server/src/db/tests.rs
@@ -166,6 +166,7 @@ mod postgres_tests {
         // Create session
         let session = create_session(
             &pool,
+            uuid::Uuid::now_v7(),
             user.id,
             token_hash,
             expires_at,
@@ -213,15 +214,45 @@ mod postgres_tests {
         let expires_at = Utc::now() + Duration::hours(1);
 
         // Create multiple sessions
-        create_session(&pool, user.id, "token1", expires_at, None, None, None, None)
-            .await
-            .expect("Failed to create session 1");
-        create_session(&pool, user.id, "token2", expires_at, None, None, None, None)
-            .await
-            .expect("Failed to create session 2");
-        create_session(&pool, user.id, "token3", expires_at, None, None, None, None)
-            .await
-            .expect("Failed to create session 3");
+        create_session(
+            &pool,
+            uuid::Uuid::now_v7(),
+            user.id,
+            "token1",
+            expires_at,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("Failed to create session 1");
+        create_session(
+            &pool,
+            uuid::Uuid::now_v7(),
+            user.id,
+            "token2",
+            expires_at,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("Failed to create session 2");
+        create_session(
+            &pool,
+            uuid::Uuid::now_v7(),
+            user.id,
+            "token3",
+            expires_at,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("Failed to create session 3");
 
         // Delete all sessions for user
         let deleted_count = delete_all_user_sessions(&pool, user.id)
@@ -273,6 +304,7 @@ mod postgres_tests {
         let valid_time = Utc::now() + Duration::hours(1);
         create_session(
             &pool,
+            uuid::Uuid::now_v7(),
             user.id,
             "valid_token",
             valid_time,

--- a/server/src/guild/core.rs
+++ b/server/src/guild/core.rs
@@ -88,9 +88,7 @@ pub async fn create_guild(
         .tags
         .map(|t| t.into_iter().map(|s| s.to_lowercase()).collect())
         .unwrap_or_default();
-    let banner_url: Option<String> =
-        body.banner_url
-            .and_then(|u| if u.is_empty() { None } else { Some(u) });
+    let banner_url: Option<String> = body.banner_url.filter(|u| !u.is_empty());
 
     // Insert guild with discovery fields
     let guild_id = Uuid::now_v7();

--- a/server/src/ws/handlers.rs
+++ b/server/src/ws/handlers.rs
@@ -96,6 +96,13 @@ pub async fn handler(
             }
         };
 
+        // Reject access tokens whose session was logged out or revoked.
+        if let Some(sid) = claims.sid.as_deref() {
+            if crate::auth::revocation::is_session_revoked(&state.redis, sid).await {
+                return error_response(401, "Session revoked");
+            }
+        }
+
         let user_id = match Uuid::parse_str(&claims.sub) {
             Ok(id) => id,
             Err(_) => {
@@ -178,6 +185,14 @@ async fn wait_for_auth_frame(
                 Ok(ClientEvent::Authenticate { token }) => {
                     let claims = jwt::validate_access_token(&token, &state.config.jwt_public_key)
                         .map_err(|e| format!("Invalid token: {e}"))?;
+
+                    // Reject access tokens whose session was logged out or revoked.
+                    if let Some(sid) = claims.sid.as_deref() {
+                        if crate::auth::revocation::is_session_revoked(&state.redis, sid).await {
+                            return Err("Session revoked".to_string());
+                        }
+                    }
+
                     let user_id = Uuid::parse_str(&claims.sub)
                         .map_err(|_| "Invalid user ID in token".to_string())?;
 

--- a/server/tests/integration/auth.rs
+++ b/server/tests/integration/auth.rs
@@ -178,8 +178,10 @@ async fn test_session_creation_and_lookup(pool: PgPool) {
     let token_hash = vc_server::auth::hash_token(token);
     let expires_at = chrono::Utc::now() + chrono::Duration::hours(24);
 
+    let session_id = uuid::Uuid::now_v7();
     let session = vc_server::db::create_session(
         &pool,
+        session_id,
         user.id,
         &token_hash,
         expires_at,
@@ -191,6 +193,10 @@ async fn test_session_creation_and_lookup(pool: PgPool) {
     .await
     .expect("Session creation should succeed");
 
+    assert_eq!(
+        session.id, session_id,
+        "session must be stored under the id we supplied"
+    );
     assert_eq!(session.user_id, user.id);
     assert_eq!(session.token_hash, token_hash);
 
@@ -219,6 +225,7 @@ async fn test_session_revocation(pool: PgPool) {
 
     vc_server::db::create_session(
         &pool,
+        uuid::Uuid::now_v7(),
         user.id,
         &token1_hash,
         expires_at,
@@ -232,6 +239,7 @@ async fn test_session_revocation(pool: PgPool) {
 
     vc_server::db::create_session(
         &pool,
+        uuid::Uuid::now_v7(),
         user.id,
         &token2_hash,
         expires_at,


### PR DESCRIPTION
## Summary

Closes a real finding from a red-team pass against the beta: **logging out did not invalidate the access token**. Because access tokens are stateless JWTs (~15 min TTL), a token captured on a shared or compromised device stayed usable for up to 15 minutes *after* the user signed out. Verified live on beta — after `POST /auth/logout` the refresh token was correctly rejected (401) but the same access token still returned `/auth/me` (200).

## Fix

- Access tokens now carry a `sid` claim equal to the id of the session they were issued with. The session row is stored under that same id (`sessions.id = refresh_token_id`), so a session and its access token share one identifier.
- **Logout** (`POST /auth/logout`) and **session revoke** (`DELETE /auth/sessions/{id}`) add that id to a short-lived Redis denylist with `TTL = access-token lifetime` (after which the token is expired anyway).
- `require_auth` middleware and **both** WebSocket auth paths (header subprotocol + post-connect `Authenticate` frame) reject any access token whose `sid` is on the denylist.
- The denylist check **fails open** if Redis is unavailable — no worse than the previous behaviour (no revocation at all), and it avoids locking everyone out during a Redis outage.

Covers both the reported logout case and the sibling `DELETE /sessions/{id}` path (revoking another device from account settings), which had the identical latent issue.

## Compatibility

- Additive JWT claim (`#[serde(skip_serializing_if = "Option::is_none")]`); access tokens issued before deploy simply have no `sid` and are unaffected (they expire within 15 min of rollout).
- `create_session` / `insert_session_tx` gain an explicit `id` argument; all call sites (login, refresh, OIDC login, MFA redeem, register) pass the token pair's `refresh_token_id`. Both are runtime `sqlx::query` calls, so **no `.sqlx` cache regeneration** is required.

## Testing

- `cargo build -p vc-server`, `cargo clippy -p vc-server -- -D warnings`, `cargo fmt --check` — clean.
- New unit test asserts the access token's `sid` equals the refresh token's `jti` (the revocation key).
- Extended `test_session_creation_and_lookup` to assert the session is stored under the supplied id.
- Full DB integration suite (`sqlx::test`) compiles; it could not be run locally (podman networking is broken in this env) and will run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDEzVG39gGZFozPCndbSid