### PR TITLE
fix(ws): add per-connection flood ceiling for all message types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Opening a channel with unreads scrolls to your last read position
 
 ### Security
+- WebSocket connections now enforce a per-connection flood ceiling across every message type. Previously only component-interaction clicks were rate-limited; typing, channel subscribe/unsubscribe, presence/status updates, and voice-signaling frames had no per-message limit, so a single misbehaving or malicious client could flood the message dispatcher. The ceiling sits far above any legitimate client's rate (including voice call-setup bursts); excess messages are dropped silently
 - Update `crossbeam-epoch` 0.9.18 → 0.9.20 (RUSTSEC-2026-0204, invalid pointer dereference in a `fmt::Pointer` impl; transitive, lockfile-only), restoring the Security Audit / License Compliance checks to green
 - Hardened login against username enumeration: a login attempt now performs the same Argon2 password verification whether or not the account exists, so response timing no longer reveals valid usernames
 - CORS with `CORS_ALLOWED_ORIGINS=*` no longer sends `Access-Control-Allow-Credentials`; mirroring the Origin with credentials would have let any website make credentialed cross-origin requests. Same-origin app traffic is unaffected; set explicit origins for trusted credentialed cross-origin access

--- a/server/src/guild/core.rs
+++ b/server/src/guild/core.rs
@@ -88,9 +88,7 @@ pub async fn create_guild(
         .tags
         .map(|t| t.into_iter().map(|s| s.to_lowercase()).collect())
         .unwrap_or_default();
-    let banner_url: Option<String> =
-        body.banner_url
-            .and_then(|u| if u.is_empty() { None } else { Some(u) });
+    let banner_url: Option<String> = body.banner_url.filter(|u| !u.is_empty());
 
     // Insert guild with discovery fields
     let guild_id = Uuid::now_v7();

--- a/server/src/ws/events.rs
+++ b/server/src/ws/events.rs
@@ -41,6 +41,56 @@ pub struct CustomStatusState {
     pub(super) last_custom_status: Option<Option<crate::presence::CustomStatus>>,
 }
 
+/// Per-connection flood ceiling applied to **every** inbound message type.
+///
+/// A continuously-refilling token bucket. It is deliberately set far above any
+/// legitimate client's message rate (including voice-signaling bursts at call
+/// setup) and exists purely to bound a single connection that spams the socket.
+/// Most client message types — typing, subscribe/unsubscribe, presence/status
+/// updates, voice signaling — have no other per-message server-side limit, so
+/// without this a compromised or buggy client could flood the dispatcher.
+pub struct FloodBucket {
+    /// Available tokens (fractional; one is consumed per message).
+    tokens: f64,
+    /// Last time tokens were refilled.
+    last_refill: Instant,
+}
+
+impl FloodBucket {
+    /// Burst capacity (messages that can be sent back-to-back).
+    const CAPACITY: f64 = 120.0;
+    /// Sustained refill rate in tokens per second.
+    const REFILL_PER_SEC: f64 = 60.0;
+
+    /// Consume one token. Returns `false` when the bucket is empty, meaning the
+    /// message should be dropped.
+    pub(super) fn allow(&mut self) -> bool {
+        let now = Instant::now();
+        let elapsed = now
+            .saturating_duration_since(self.last_refill)
+            .as_secs_f64();
+        self.last_refill = now;
+        self.tokens = elapsed
+            .mul_add(Self::REFILL_PER_SEC, self.tokens)
+            .min(Self::CAPACITY);
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl Default for FloodBucket {
+    fn default() -> Self {
+        Self {
+            tokens: Self::CAPACITY,
+            last_refill: Instant::now(),
+        }
+    }
+}
+
 /// Bundled per-connection mutable state for client message handling.
 ///
 /// **Internal:** Exposed for integration tests only.
@@ -52,6 +102,8 @@ pub struct ClientMessageState {
     pub custom_status: CustomStatusState,
     /// Per-channel typing throttle (`channel_id` → last typing broadcast time).
     pub last_typing: HashMap<Uuid, Instant>,
+    /// Per-connection flood ceiling across all inbound message types.
+    pub flood: FloodBucket,
 }
 
 /// Default `pc_type` for backward compatibility with old clients.
@@ -1184,4 +1236,38 @@ pub async fn broadcast_member_patch(
         .await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod flood_tests {
+    use std::time::{Duration, Instant};
+
+    use super::FloodBucket;
+
+    #[test]
+    fn allows_a_full_burst_then_blocks() {
+        let mut bucket = FloodBucket::default();
+        // The whole burst capacity is allowed back-to-back...
+        for i in 0..FloodBucket::CAPACITY as usize {
+            assert!(bucket.allow(), "message {i} within burst should be allowed");
+        }
+        // ...and the next message (bucket empty) is dropped.
+        assert!(
+            !bucket.allow(),
+            "message past burst capacity should be blocked"
+        );
+    }
+
+    #[test]
+    fn refills_over_time() {
+        let mut bucket = FloodBucket::default();
+        for _ in 0..FloodBucket::CAPACITY as usize {
+            assert!(bucket.allow());
+        }
+        assert!(!bucket.allow(), "bucket should be empty");
+
+        // Simulate one second elapsing; ~REFILL_PER_SEC tokens return.
+        bucket.last_refill = Instant::now() - Duration::from_secs(1);
+        assert!(bucket.allow(), "bucket should have refilled after a second");
+    }
 }

--- a/server/src/ws/handlers.rs
+++ b/server/src/ws/handlers.rs
@@ -505,6 +505,16 @@ pub async fn handle_client_message(
     let event: ClientEvent = serde_json::from_str(text)?;
     crate::observability::metrics::record_ws_message(event.variant_name());
 
+    // Per-connection flood ceiling across every message type. Most events
+    // (typing, subscribe, presence/status, voice signaling) have no other
+    // per-message limit, so a single spamming connection is bounded here.
+    // Excess messages are dropped silently — replying with an error per dropped
+    // message would turn the flood into an outbound amplifier.
+    if !msg_state.flood.allow() {
+        debug!("Dropping WS message from user={user_id} over per-connection flood limit");
+        return Ok(());
+    }
+
     match event {
         ClientEvent::Ping => {
             tx.send(OutboundMsg::Event(ServerEvent::Pong)).await?;


### PR DESCRIPTION
## Summary

Closes the second finding from the beta red-team pass: **most WebSocket message types had no per-message rate limit**. Only component-interaction clicks went through the Redis `WsMessage` limiter (`ws/handlers.rs`). Everything else dispatched from the same loop — `Typing`, `Subscribe`/`Unsubscribe`, `SetActivity`/`SetStatus`, and voice-signaling frames — was bounded only by the one-time `ws_connect` limit, so a single authenticated connection could flood the dispatcher (a DoS vector).

## Fix

- Add a per-connection token bucket (`FloodBucket`) to `ClientMessageState`, checked at the top of `handle_client_message` before any message is processed.
- **Capacity 120, refill 60/s** — deliberately far above any legitimate client's message rate, including the bursts of ICE candidates at voice call setup. It only trips on an actual flood.
- Excess messages are **dropped silently** (not answered with an error) so the flood cannot be turned into an outbound error-reply amplifier.
- In-memory and per-connection, so it adds **zero** Redis round-trips or latency to the hot path (which matters for the voice-signaling frames that share this handler).

This is defense-in-depth layered under the existing Redis `WsMessage` per-user limit on component interactions, which is unchanged.

## Testing

- `cargo clippy -p vc-server -- -D warnings`, `cargo fmt --check` — clean.
- Unit tests for the bucket: a full burst is allowed then the next message is blocked, and the bucket refills after simulated elapsed time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDEzVG39gGZFozPCndbSid